### PR TITLE
Gestionnaire namespace

### DIFF
--- a/app/controllers/new_gestionnaire/avis_controller.rb
+++ b/app/controllers/new_gestionnaire/avis_controller.rb
@@ -76,7 +76,7 @@ module NewGestionnaire
         sign_in(gestionnaire, scope: :gestionnaire)
         Avis.link_avis_to_gestionnaire(gestionnaire)
         avis = Avis.find(params[:id])
-        redirect_to url_for(avis_index_path)
+        redirect_to url_for(gestionnaire_avis_index_path)
       else
         flash[:alert] = gestionnaire.errors.full_messages
         redirect_to url_for(sign_up_gestionnaire_avis_path(params[:id], email))
@@ -96,7 +96,7 @@ module NewGestionnaire
       if current_gestionnaire.present?
         # a gestionnaire is authenticated ... lets see if it can view the dossier
 
-        redirect_to avis_url(avis)
+        redirect_to gestionnaire_avis_url(avis)
       elsif avis.gestionnaire.present? && avis.gestionnaire.email == params[:email]
         # the avis gestionnaire has already signed up and it sould sign in
 

--- a/app/controllers/new_gestionnaire/avis_controller.rb
+++ b/app/controllers/new_gestionnaire/avis_controller.rb
@@ -79,7 +79,7 @@ module NewGestionnaire
         redirect_to url_for(avis_index_path)
       else
         flash[:alert] = gestionnaire.errors.full_messages
-        redirect_to url_for(sign_up_avis_path(params[:id], email))
+        redirect_to url_for(sign_up_gestionnaire_avis_path(params[:id], email))
       end
     end
 

--- a/app/controllers/new_gestionnaire/avis_controller.rb
+++ b/app/controllers/new_gestionnaire/avis_controller.rb
@@ -34,7 +34,7 @@ module NewGestionnaire
     def update
       avis.update_attributes(avis_params)
       flash.notice = 'Votre réponse est enregistrée.'
-      redirect_to instruction_avis_path(avis)
+      redirect_to instruction_gestionnaire_avis_path(avis)
     end
 
     def messagerie
@@ -56,7 +56,7 @@ module NewGestionnaire
     def create_avis
       confidentiel = avis.confidentiel || params[:avis][:confidentiel]
       Avis.create(create_avis_params.merge(claimant: current_gestionnaire, dossier: avis.dossier, confidentiel: confidentiel))
-      redirect_to instruction_avis_path(avis)
+      redirect_to instruction_gestionnaire_avis_path(avis)
     end
 
     def sign_up

--- a/app/controllers/new_gestionnaire/avis_controller.rb
+++ b/app/controllers/new_gestionnaire/avis_controller.rb
@@ -46,7 +46,7 @@ module NewGestionnaire
 
       if @commentaire.save
         flash.notice = "Message envoyé"
-        redirect_to messagerie_avis_path(avis)
+        redirect_to messagerie_gestionnaire_avis_path(avis)
       else
         flash.alert = @commentaire.errors.full_messages
         render :messagerie

--- a/app/controllers/new_gestionnaire/dossiers_controller.rb
+++ b/app/controllers/new_gestionnaire/dossiers_controller.rb
@@ -72,14 +72,14 @@ module NewGestionnaire
       current_gestionnaire.follow(dossier)
       flash.notice = 'Dossier passé en instruction.'
 
-      redirect_to dossier_path(procedure, dossier)
+      redirect_to gestionnaire_dossier_path(procedure, dossier)
     end
 
     def repasser_en_construction
       dossier.en_construction!
       flash.notice = 'Dossier repassé en construction.'
 
-      redirect_to dossier_path(procedure, dossier)
+      redirect_to gestionnaire_dossier_path(procedure, dossier)
     end
 
     def terminer
@@ -118,7 +118,7 @@ module NewGestionnaire
 
       NotificationMailer.send_notification(dossier, template, attestation_pdf).deliver_now!
 
-      redirect_to dossier_path(procedure, dossier)
+      redirect_to gestionnaire_dossier_path(procedure, dossier)
     end
 
     def create_commentaire

--- a/app/controllers/new_gestionnaire/dossiers_controller.rb
+++ b/app/controllers/new_gestionnaire/dossiers_controller.rb
@@ -46,25 +46,25 @@ module NewGestionnaire
     def follow
       current_gestionnaire.follow(dossier)
       flash.notice = 'Dossier suivi'
-      redirect_back(fallback_location: procedures_url)
+      redirect_back(fallback_location: gestionnaire_procedures_url)
     end
 
     def unfollow
       current_gestionnaire.unfollow(dossier)
       flash.notice = "Vous ne suivez plus le dossier nº #{dossier.id}"
 
-      redirect_back(fallback_location: procedures_url)
+      redirect_back(fallback_location: gestionnaire_procedures_url)
     end
 
     def archive
       dossier.update_attributes(archived: true)
       current_gestionnaire.unfollow(dossier)
-      redirect_back(fallback_location: procedures_url)
+      redirect_back(fallback_location: gestionnaire_procedures_url)
     end
 
     def unarchive
       dossier.update_attributes(archived: false)
-      redirect_back(fallback_location: procedures_url)
+      redirect_back(fallback_location: gestionnaire_procedures_url)
     end
 
     def passer_en_instruction

--- a/app/controllers/new_gestionnaire/dossiers_controller.rb
+++ b/app/controllers/new_gestionnaire/dossiers_controller.rb
@@ -40,7 +40,7 @@ module NewGestionnaire
       recipient = Gestionnaire.find(params[:recipient])
       GestionnaireMailer.send_dossier(current_gestionnaire, dossier, recipient).deliver_later
       flash.notice = "Dossier envoyé"
-      redirect_to(personnes_impliquees_dossier_path(procedure, dossier))
+      redirect_to(personnes_impliquees_gestionnaire_dossier_path(procedure, dossier))
     end
 
     def follow

--- a/app/controllers/new_gestionnaire/dossiers_controller.rb
+++ b/app/controllers/new_gestionnaire/dossiers_controller.rb
@@ -160,7 +160,7 @@ module NewGestionnaire
 
     def create_avis
       Avis.create(avis_params.merge(claimant: current_gestionnaire, dossier: dossier))
-      redirect_to avis_dossier_path(procedure, dossier)
+      redirect_to avis_gestionnaire_dossier_path(procedure, dossier)
     end
 
     def update_annotations

--- a/app/controllers/new_gestionnaire/dossiers_controller.rb
+++ b/app/controllers/new_gestionnaire/dossiers_controller.rb
@@ -167,7 +167,7 @@ module NewGestionnaire
       dossier = current_gestionnaire.dossiers.includes(champs_private: :type_de_champ).find(params[:dossier_id])
       # FIXME: add attachements validation, cf. Champ#piece_justificative_file_errors
       dossier.update_attributes(champs_private_params)
-      redirect_to annotations_privees_dossier_path(procedure, dossier)
+      redirect_to annotations_privees_gestionnaire_dossier_path(procedure, dossier)
     end
 
     def print

--- a/app/controllers/new_gestionnaire/dossiers_controller.rb
+++ b/app/controllers/new_gestionnaire/dossiers_controller.rb
@@ -135,7 +135,7 @@ module NewGestionnaire
       if @commentaire.save
         current_gestionnaire.follow(dossier)
         flash.notice = "Message envoyé"
-        redirect_to messagerie_dossier_path(procedure, dossier)
+        redirect_to messagerie_gestionnaire_dossier_path(procedure, dossier)
       else
         flash.alert = @commentaire.errors.full_messages
         render :messagerie

--- a/app/controllers/new_gestionnaire/procedures_controller.rb
+++ b/app/controllers/new_gestionnaire/procedures_controller.rb
@@ -203,7 +203,7 @@ module NewGestionnaire
 
     def redirect_to_avis_if_needed
       if current_gestionnaire.procedures.count == 0 && current_gestionnaire.avis.count > 0
-        redirect_to avis_index_path
+        redirect_to gestionnaire_avis_index_path
       end
     end
 

--- a/app/controllers/new_gestionnaire/procedures_controller.rb
+++ b/app/controllers/new_gestionnaire/procedures_controller.rb
@@ -116,7 +116,7 @@ module NewGestionnaire
         procedure_presentation.update_attributes(sort: Procedure.default_sort)
       end
 
-      redirect_back(fallback_location: procedure_url(procedure))
+      redirect_back(fallback_location: gestionnaire_procedure_url(procedure))
     end
 
     def update_sort
@@ -138,7 +138,7 @@ module NewGestionnaire
 
       procedure_presentation.update_attributes(sort: sort)
 
-      redirect_back(fallback_location: procedure_url(procedure))
+      redirect_back(fallback_location: gestionnaire_procedure_url(procedure))
     end
 
     def add_filter
@@ -157,7 +157,7 @@ module NewGestionnaire
         procedure_presentation.update_attributes(filters: filters.to_json)
       end
 
-      redirect_back(fallback_location: procedure_url(procedure))
+      redirect_back(fallback_location: gestionnaire_procedure_url(procedure))
     end
 
     def remove_filter
@@ -170,7 +170,7 @@ module NewGestionnaire
 
       procedure_presentation.update_attributes(filters: filters.to_json)
 
-      redirect_back(fallback_location: procedure_url(procedure))
+      redirect_back(fallback_location: gestionnaire_procedure_url(procedure))
     end
 
     def download_dossiers

--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -5,7 +5,7 @@ class RootController < ApplicationController
     if administrateur_signed_in?
       return redirect_to admin_procedures_path
     elsif gestionnaire_signed_in?
-      return redirect_to procedures_path
+      return redirect_to gestionnaire_procedures_path
     elsif user_signed_in?
       return redirect_to users_dossiers_path
     elsif administration_signed_in?

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -26,7 +26,7 @@ class Users::SessionsController < Sessions::SessionsController
     if user_signed_in?
       redirect_to after_sign_in_path_for(:user)
     elsif gestionnaire_signed_in?
-      location = stored_location_for(:gestionnaire) || procedures_path
+      location = stored_location_for(:gestionnaire) || gestionnaire_procedures_path
       redirect_to location
     elsif administrateur_signed_in?
       redirect_to admin_path

--- a/app/helpers/dossier_link_helper.rb
+++ b/app/helpers/dossier_link_helper.rb
@@ -1,7 +1,7 @@
 module DossierLinkHelper
   def dossier_linked_path(gestionnaire, dossier)
     if dossier.procedure.gestionnaires.include?(gestionnaire)
-      dossier_path(dossier.procedure, dossier)
+      gestionnaire_dossier_path(dossier.procedure, dossier)
     else
       avis = dossier.avis.find_by(gestionnaire: gestionnaire)
       if avis.present?

--- a/app/helpers/dossier_link_helper.rb
+++ b/app/helpers/dossier_link_helper.rb
@@ -5,7 +5,7 @@ module DossierLinkHelper
     else
       avis = dossier.avis.find_by(gestionnaire: gestionnaire)
       if avis.present?
-        avis_path(avis)
+        gestionnaire_avis_path(avis)
       end
     end
   end

--- a/app/views/avis_mailer/avis_invitation.html.haml
+++ b/app/views/avis_mailer/avis_invitation.html.haml
@@ -12,7 +12,7 @@
 
     - if @avis.gestionnaire.present?
       %p
-        = link_to "Connectez-vous pour donner votre avis", dossier_url(@avis.dossier.procedure, @avis.dossier)
+        = link_to "Connectez-vous pour donner votre avis", gestionnaire_dossier_url(@avis.dossier.procedure, @avis.dossier)
     - else
       %p
         = link_to "Inscrivez-vous pour donner votre avis", sign_up_gestionnaire_avis_url(@avis.id, @avis.email)

--- a/app/views/avis_mailer/avis_invitation.html.haml
+++ b/app/views/avis_mailer/avis_invitation.html.haml
@@ -15,7 +15,7 @@
         = link_to "Connectez-vous pour donner votre avis", dossier_url(@avis.dossier.procedure, @avis.dossier)
     - else
       %p
-        = link_to "Inscrivez-vous pour donner votre avis", sign_up_avis_url(@avis.id, @avis.email)
+        = link_to "Inscrivez-vous pour donner votre avis", sign_up_gestionnaire_avis_url(@avis.id, @avis.email)
 
     Bonne journée,
     %br

--- a/app/views/dossiers/_attestation.html.haml
+++ b/app/views/dossiers/_attestation.html.haml
@@ -14,4 +14,4 @@
         - if user_signed_in? && current_user == dossier.user
           = link_to 'Télécharger', dossier_attestation_path(dossier), target: '_blank', class: 'btn btn-primary'
         - else
-          = link_to 'Télécharger', attestation_dossier_path(dossier.procedure, dossier), target: '_blank', class: 'btn btn-primary'
+          = link_to 'Télécharger', attestation_gestionnaire_dossier_path(dossier.procedure, dossier), target: '_blank', class: 'btn btn-primary'

--- a/app/views/layouts/_new_header.haml
+++ b/app/views/layouts/_new_header.haml
@@ -34,7 +34,7 @@
       - if nav_bar_profile == :gestionnaire && gestionnaire_signed_in?
         %li
           .header-search
-            = form_tag recherche_path, method: :get, class: "form" do
+            = form_tag gestionnaire_recherche_path, method: :get, class: "form" do
               = text_field_tag "q", "#{@search_terms if @search_terms.present?}", placeholder: "Rechercher un dossier"
               %button{ title: "Rechercher" }
                 = image_tag "icons/search-blue.svg"

--- a/app/views/layouts/_new_header.haml
+++ b/app/views/layouts/_new_header.haml
@@ -15,7 +15,7 @@
               = link_to "Procédures", gestionnaire_procedures_path, class: (controller_name != 'avis') ? "tab-link active" : 'tab-link'
           - if current_gestionnaire.avis.count > 0
             %li
-              = link_to avis_index_path, class: (controller_name == 'avis') ? "tab-link active" : 'tab-link' do
+              = link_to gestionnaire_avis_index_path, class: (controller_name == 'avis') ? "tab-link active" : 'tab-link' do
                 Avis
                 - avis_counter = current_gestionnaire.avis.without_answer.count
                 - if avis_counter > 0

--- a/app/views/layouts/_new_header.haml
+++ b/app/views/layouts/_new_header.haml
@@ -12,7 +12,7 @@
         %ul.header-tabs
           - if current_gestionnaire.procedures.count > 0
             %li
-              = link_to "Procédures", procedures_path, class: (controller_name != 'avis') ? "tab-link active" : 'tab-link'
+              = link_to "Procédures", gestionnaire_procedures_path, class: (controller_name != 'avis') ? "tab-link active" : 'tab-link'
           - if current_gestionnaire.avis.count > 0
             %li
               = link_to avis_index_path, class: (controller_name == 'avis') ? "tab-link active" : 'tab-link' do
@@ -60,7 +60,7 @@
                       Passer en usager
                 - if gestionnaire_signed_in? && nav_bar_profile != :gestionnaire
                   %li
-                    = link_to procedures_path, class: "menu-item menu-link" do
+                    = link_to gestionnaire_procedures_path, class: "menu-item menu-link" do
                       = image_tag "icons/switch-profile.svg"
                       Passer en accompagnateur
                 - if administrateur_signed_in? && nav_bar_profile != :administrateur

--- a/app/views/layouts/_switch_devise_profile_module.html.haml
+++ b/app/views/layouts/_switch_devise_profile_module.html.haml
@@ -12,7 +12,7 @@
             Usager
       - if gestionnaire_signed_in?
         %li
-          = link_to(procedures_path) do
+          = link_to(gestionnaire_procedures_path) do
             %i.fa.fa-user
             &nbsp;
             Accompagnateur

--- a/app/views/new_gestionnaire/avis/_header.html.haml
+++ b/app/views/new_gestionnaire/avis/_header.html.haml
@@ -11,5 +11,5 @@
         = link_to 'Avis', instruction_gestionnaire_avis_path(avis)
         - if avis.answer == nil
           %span.notifications{ 'aria-label': 'notifications' }
-      %li{ class: current_page?(messagerie_avis_path(avis)) ? 'active' : nil }
-        = link_to 'Messagerie', messagerie_avis_path(avis)
+      %li{ class: current_page?(messagerie_gestionnaire_avis_path(avis)) ? 'active' : nil }
+        = link_to 'Messagerie', messagerie_gestionnaire_avis_path(avis)

--- a/app/views/new_gestionnaire/avis/_header.html.haml
+++ b/app/views/new_gestionnaire/avis/_header.html.haml
@@ -5,8 +5,8 @@
       %li= "#{dossier.procedure.libelle}, dossier nº #{dossier.id}"
 
     %ul.tabs
-      %li{ class: current_page?(avis_path(avis)) ? 'active' : nil }
-        = link_to 'Demande', avis_path(avis)
+      %li{ class: current_page?(gestionnaire_avis_path(avis)) ? 'active' : nil }
+        = link_to 'Demande', gestionnaire_avis_path(avis)
       %li{ class: current_page?(instruction_gestionnaire_avis_path(avis)) ? 'active' : nil }
         = link_to 'Avis', instruction_gestionnaire_avis_path(avis)
         - if avis.answer == nil

--- a/app/views/new_gestionnaire/avis/_header.html.haml
+++ b/app/views/new_gestionnaire/avis/_header.html.haml
@@ -1,7 +1,7 @@
 .accompagnateur-header
   .container
     %ul.breadcrumbs
-      %li= link_to('Avis', avis_index_path)
+      %li= link_to('Avis', gestionnaire_avis_index_path)
       %li= "#{dossier.procedure.libelle}, dossier nº #{dossier.id}"
 
     %ul.tabs

--- a/app/views/new_gestionnaire/avis/_header.html.haml
+++ b/app/views/new_gestionnaire/avis/_header.html.haml
@@ -7,8 +7,8 @@
     %ul.tabs
       %li{ class: current_page?(avis_path(avis)) ? 'active' : nil }
         = link_to 'Demande', avis_path(avis)
-      %li{ class: current_page?(instruction_avis_path(avis)) ? 'active' : nil }
-        = link_to 'Avis', instruction_avis_path(avis)
+      %li{ class: current_page?(instruction_gestionnaire_avis_path(avis)) ? 'active' : nil }
+        = link_to 'Avis', instruction_gestionnaire_avis_path(avis)
         - if avis.answer == nil
           %span.notifications{ 'aria-label': 'notifications' }
       %li{ class: current_page?(messagerie_avis_path(avis)) ? 'active' : nil }

--- a/app/views/new_gestionnaire/avis/index.html.haml
+++ b/app/views/new_gestionnaire/avis/index.html.haml
@@ -30,11 +30,11 @@
         - @avis.each do |avis|
           %tr
             %td.number-col
-              = link_to(avis_path(avis), class: 'cell-link') do
+              = link_to(gestionnaire_avis_path(avis), class: 'cell-link') do
                 %span.icon.folder
                 #{avis.dossier.id}
-            %td= link_to(avis.dossier.user.email, avis_path(avis), class: 'cell-link')
-            %td= link_to(avis.dossier.procedure.libelle, avis_path(avis), class: 'cell-link')
+            %td= link_to(avis.dossier.user.email, gestionnaire_avis_path(avis), class: 'cell-link')
+            %td= link_to(avis.dossier.procedure.libelle, gestionnaire_avis_path(avis), class: 'cell-link')
     = paginate(@avis)
   - else
     %h2.empty-text Aucun avis

--- a/app/views/new_gestionnaire/avis/index.html.haml
+++ b/app/views/new_gestionnaire/avis/index.html.haml
@@ -7,14 +7,14 @@
       %h1.tab-title Avis
       %ul.tabs
         %li{ class: (@statut == NewGestionnaire::AvisController::A_DONNER_STATUS) ? 'active' : nil }>
-          = link_to(avis_index_path(statut: NewGestionnaire::AvisController::A_DONNER_STATUS)) do
+          = link_to(gestionnaire_avis_index_path(statut: NewGestionnaire::AvisController::A_DONNER_STATUS)) do
             avis à donner
             %span.badge= @avis_a_donner.count
             - if @avis_a_donner.any?
               %span.notifications
 
         %li{ class: (@statut == NewGestionnaire::AvisController::DONNES_STATUS) ? 'active' : nil }>
-          = link_to(avis_index_path(statut: NewGestionnaire::AvisController::DONNES_STATUS)) do
+          = link_to(gestionnaire_avis_index_path(statut: NewGestionnaire::AvisController::DONNES_STATUS)) do
             avis #{'donné'.pluralize(@avis_donnes.count)}
             %span.badge= @avis_donnes.count
 

--- a/app/views/new_gestionnaire/avis/instruction.html.haml
+++ b/app/views/new_gestionnaire/avis/instruction.html.haml
@@ -11,7 +11,7 @@
       %span.date Demande d'avis envoyée le #{I18n.l(@avis.created_at.localtime, format: '%d/%m/%y')}
     %p.introduction= @avis.introduction
 
-    = form_for @avis, url: avis_path(@avis), html: { class: 'form' } do |f|
+    = form_for @avis, url: gestionnaire_avis_path(@avis), html: { class: 'form' } do |f|
       = f.text_area :answer, rows: 3, placeholder: 'Votre avis', required: true
       .flex.justify-between.align-baseline
         %p.confidentiel.flex

--- a/app/views/new_gestionnaire/avis/instruction.html.haml
+++ b/app/views/new_gestionnaire/avis/instruction.html.haml
@@ -21,6 +21,6 @@
         .send-wrapper
           = f.submit 'Envoyer votre avis', class: 'button send'
 
-  = render partial: "new_gestionnaire/shared/avis/form", locals: { url: avis_avis_path(@avis), must_be_confidentiel: @avis.confidentiel? }
+  = render partial: "new_gestionnaire/shared/avis/form", locals: { url: avis_gestionnaire_avis_path(@avis), must_be_confidentiel: @avis.confidentiel? }
 
   = render partial: 'new_gestionnaire/shared/avis/list', locals: { avis: @dossier.avis_for(current_gestionnaire), avis_seen_at: nil }

--- a/app/views/new_gestionnaire/avis/messagerie.html.haml
+++ b/app/views/new_gestionnaire/avis/messagerie.html.haml
@@ -2,4 +2,4 @@
 
 = render partial: 'header', locals: { avis: @avis, dossier: @dossier }
 
-= render partial: "new_gestionnaire/shared/messagerie", locals: { dossier: @dossier, messagerie_seen_at: nil, new_commentaire: @commentaire, form_url: commentaire_avis_path(@avis) }
+= render partial: "new_gestionnaire/shared/messagerie", locals: { dossier: @dossier, messagerie_seen_at: nil, new_commentaire: @commentaire, form_url: commentaire_gestionnaire_avis_path(@avis) }

--- a/app/views/new_gestionnaire/dossiers/_envoyer_dossier_block.html.haml
+++ b/app/views/new_gestionnaire/dossiers/_envoyer_dossier_block.html.haml
@@ -4,7 +4,7 @@
   %p.tab-paragraph
     Vous êtes le seul accompagnateur assigné sur cette procédure
 - else
-  = form_for dossier, url: envoyer_a_accompagnateur_dossier_path(dossier.procedure, dossier), method: :post, html: { class: 'form' } do |f|
+  = form_for dossier, url: envoyer_a_accompagnateur_gestionnaire_dossier_path(dossier.procedure, dossier), method: :post, html: { class: 'form' } do |f|
     .flex.justify-start.align-baseline
       = select_tag(:recipient, options_from_collection_for_select(potential_recipients, :id, :email))
       = f.submit "Envoyer", class: "button large send gap-left"

--- a/app/views/new_gestionnaire/dossiers/_header.html.haml
+++ b/app/views/new_gestionnaire/dossiers/_header.html.haml
@@ -23,10 +23,10 @@
         - if notifications_summary[:demande]
           %span.notifications{ 'aria-label': 'notifications' }
         = link_to "Demande", dossier_path(dossier.procedure, dossier)
-      %li{ class: current_page?(annotations_privees_dossier_path(dossier.procedure, dossier)) ? 'active' : nil }
+      %li{ class: current_page?(annotations_privees_gestionnaire_dossier_path(dossier.procedure, dossier)) ? 'active' : nil }
         - if notifications_summary[:annotations_privees]
           %span.notifications{ 'aria-label': 'notifications' }
-        = link_to "Annotations privées", annotations_privees_dossier_path(dossier.procedure, dossier)
+        = link_to "Annotations privées", annotations_privees_gestionnaire_dossier_path(dossier.procedure, dossier)
       %li{ class: current_page?(avis_dossier_path(dossier.procedure, dossier)) ? 'active' : nil }
         - if notifications_summary[:avis]
           %span.notifications{ 'aria-label': 'notifications' }

--- a/app/views/new_gestionnaire/dossiers/_header.html.haml
+++ b/app/views/new_gestionnaire/dossiers/_header.html.haml
@@ -3,7 +3,7 @@
     .flex.justify-between
       %ul.breadcrumbs
         %li
-          = link_to dossier.procedure.libelle.truncate_words(10), procedure_path(dossier.procedure), title: dossier.procedure.libelle
+          = link_to dossier.procedure.libelle.truncate_words(10), gestionnaire_procedure_path(dossier.procedure), title: dossier.procedure.libelle
         %li
           = "Dossier nº #{dossier.id}"
       .mixed-buttons-bar

--- a/app/views/new_gestionnaire/dossiers/_header.html.haml
+++ b/app/views/new_gestionnaire/dossiers/_header.html.haml
@@ -27,10 +27,10 @@
         - if notifications_summary[:annotations_privees]
           %span.notifications{ 'aria-label': 'notifications' }
         = link_to "Annotations privées", annotations_privees_gestionnaire_dossier_path(dossier.procedure, dossier)
-      %li{ class: current_page?(avis_dossier_path(dossier.procedure, dossier)) ? 'active' : nil }
+      %li{ class: current_page?(avis_gestionnaire_dossier_path(dossier.procedure, dossier)) ? 'active' : nil }
         - if notifications_summary[:avis]
           %span.notifications{ 'aria-label': 'notifications' }
-        = link_to "Avis externes", avis_dossier_path(dossier.procedure, dossier)
+        = link_to "Avis externes", avis_gestionnaire_dossier_path(dossier.procedure, dossier)
       %li{ class: current_page?(messagerie_gestionnaire_dossier_path(dossier.procedure, dossier)) ? 'active' : nil }
         - if notifications_summary[:messagerie]
           %span.notifications{ 'aria-label': 'notifications' }

--- a/app/views/new_gestionnaire/dossiers/_header.html.haml
+++ b/app/views/new_gestionnaire/dossiers/_header.html.haml
@@ -35,8 +35,8 @@
         - if notifications_summary[:messagerie]
           %span.notifications{ 'aria-label': 'notifications' }
         = link_to "Messagerie", messagerie_gestionnaire_dossier_path(dossier.procedure, dossier)
-      %li{ class: current_page?(personnes_impliquees_dossier_path(dossier.procedure, dossier)) ? 'active' : nil }
-        = link_to "Personnes impliquées", personnes_impliquees_dossier_path(dossier.procedure, dossier)
+      %li{ class: current_page?(personnes_impliquees_gestionnaire_dossier_path(dossier.procedure, dossier)) ? 'active' : nil }
+        = link_to "Personnes impliquées", personnes_impliquees_gestionnaire_dossier_path(dossier.procedure, dossier)
 
 .container
   .print-header

--- a/app/views/new_gestionnaire/dossiers/_header.html.haml
+++ b/app/views/new_gestionnaire/dossiers/_header.html.haml
@@ -31,10 +31,10 @@
         - if notifications_summary[:avis]
           %span.notifications{ 'aria-label': 'notifications' }
         = link_to "Avis externes", avis_dossier_path(dossier.procedure, dossier)
-      %li{ class: current_page?(messagerie_dossier_path(dossier.procedure, dossier)) ? 'active' : nil }
+      %li{ class: current_page?(messagerie_gestionnaire_dossier_path(dossier.procedure, dossier)) ? 'active' : nil }
         - if notifications_summary[:messagerie]
           %span.notifications{ 'aria-label': 'notifications' }
-        = link_to "Messagerie", messagerie_dossier_path(dossier.procedure, dossier)
+        = link_to "Messagerie", messagerie_gestionnaire_dossier_path(dossier.procedure, dossier)
       %li{ class: current_page?(personnes_impliquees_dossier_path(dossier.procedure, dossier)) ? 'active' : nil }
         = link_to "Personnes impliquées", personnes_impliquees_dossier_path(dossier.procedure, dossier)
 

--- a/app/views/new_gestionnaire/dossiers/_header.html.haml
+++ b/app/views/new_gestionnaire/dossiers/_header.html.haml
@@ -19,10 +19,10 @@
         = render partial: "state_button", locals: { dossier: dossier }
     %ul.tabs
       - notifications_summary = current_gestionnaire.notifications_for_dossier(dossier)
-      %li{ class: current_page?(dossier_path(dossier.procedure, dossier)) ? 'active' : nil }
+      %li{ class: current_page?(gestionnaire_dossier_path(dossier.procedure, dossier)) ? 'active' : nil }
         - if notifications_summary[:demande]
           %span.notifications{ 'aria-label': 'notifications' }
-        = link_to "Demande", dossier_path(dossier.procedure, dossier)
+        = link_to "Demande", gestionnaire_dossier_path(dossier.procedure, dossier)
       %li{ class: current_page?(annotations_privees_gestionnaire_dossier_path(dossier.procedure, dossier)) ? 'active' : nil }
         - if notifications_summary[:annotations_privees]
           %span.notifications{ 'aria-label': 'notifications' }

--- a/app/views/new_gestionnaire/dossiers/_header.html.haml
+++ b/app/views/new_gestionnaire/dossiers/_header.html.haml
@@ -11,7 +11,7 @@
           %span.icon.printer
           %ul.print-menu
             %li
-              = link_to "Tout le dossier", print_dossier_path(dossier.procedure, dossier), target: "_blank", class: "menu-item menu-link"
+              = link_to "Tout le dossier", print_gestionnaire_dossier_path(dossier.procedure, dossier), target: "_blank", class: "menu-item menu-link"
             %li
               = link_to "Uniquement cet onglet", "#", onclick: "TPS.togglePrintMenu; window.print()", class: "menu-item menu-link"
 

--- a/app/views/new_gestionnaire/dossiers/_map.html.haml
+++ b/app/views/new_gestionnaire/dossiers/_map.html.haml
@@ -14,7 +14,7 @@
       = "Parcelle n° #{p.numero} - Feuille #{p.code_arr} #{p.section} #{p.feuille}"
 
 :javascript
-  var getPositionUrl = "#{position_dossier_path(dossier.procedure, dossier)}";
+  var getPositionUrl = "#{position_gestionnaire_dossier_path(dossier.procedure, dossier)}";
   var dossierJsonLatLngs = #{dossier.json_latlngs};
   var dossierCadastres = #{dossier.cadastres.to_json};
   var dossierQuartiersPrioritaires = #{dossier.quartier_prioritaires.to_json};

--- a/app/views/new_gestionnaire/dossiers/_state_button.html.haml
+++ b/app/views/new_gestionnaire/dossiers/_state_button.html.haml
@@ -10,7 +10,7 @@
               %h4 En construction
               Vous permettez à l'usager de modifier ses réponses au formulaire
           %li
-            = link_to passer_en_instruction_dossier_path(dossier.procedure, dossier), method: :post, data: { confirm: "Confirmer vous le passage en instruction de ce dossier ?" } do
+            = link_to passer_en_instruction_gestionnaire_dossier_path(dossier.procedure, dossier), method: :post, data: { confirm: "Confirmer vous le passage en instruction de ce dossier ?" } do
               %span.icon.in-progress
               .description
                 %h4 Passer en instruction

--- a/app/views/new_gestionnaire/dossiers/_state_button.html.haml
+++ b/app/views/new_gestionnaire/dossiers/_state_button.html.haml
@@ -59,7 +59,7 @@
         - if dossier.attestation.present?
           %h4 Attestation
           %p.attestation L'acceptation du dossier a envoyé automatiquement une attestation au demandeur
-          = link_to "Voir l'attestation", attestation_dossier_path(dossier.procedure, dossier), target: '_blank', class: 'button'
+          = link_to "Voir l'attestation", attestation_gestionnaire_dossier_path(dossier.procedure, dossier), target: '_blank', class: 'button'
   - else
     %span.label{ class: button_or_label_class(dossier) }
       = dossier.statut

--- a/app/views/new_gestionnaire/dossiers/_state_button.html.haml
+++ b/app/views/new_gestionnaire/dossiers/_state_button.html.haml
@@ -18,7 +18,7 @@
 
         - if dossier.en_instruction?
           %li
-            = link_to repasser_en_construction_dossier_path(dossier.procedure, dossier), method: :post, data: { confirm: "Confirmer vous le passage en construction de ce dossier ?" } do
+            = link_to repasser_en_construction_gestionnaire_dossier_path(dossier.procedure, dossier), method: :post, data: { confirm: "Confirmer vous le passage en construction de ce dossier ?" } do
               %span.icon.edit
               .description
                 %h4 Repasser en construction

--- a/app/views/new_gestionnaire/dossiers/_state_button_motivation.html.haml
+++ b/app/views/new_gestionnaire/dossiers/_state_button_motivation.html.haml
@@ -3,7 +3,7 @@
     %span.icon{ class: popup_class }
     #{popup_title}
 
-  = form_tag(terminer_dossier_path(dossier.procedure, dossier), method: :post, class: 'form') do
+  = form_tag(terminer_gestionnaire_dossier_path(dossier.procedure, dossier), method: :post, class: 'form') do
     = text_area :dossier, :motivation, class: 'motivation-text-area', placeholder: 'Rédigez votre motivation ici (facultative)'
     - if title == 'Accepter'
       %p.help

--- a/app/views/new_gestionnaire/dossiers/annotations_privees.html.haml
+++ b/app/views/new_gestionnaire/dossiers/annotations_privees.html.haml
@@ -5,7 +5,7 @@
 #dossier-annotations-privees.container
   - if @dossier.ordered_champs_private.present?
     %section
-      = form_for @dossier, url: annotations_dossier_path(@dossier.procedure, @dossier), html: { class: 'form' } do |f|
+      = form_for @dossier, url: annotations_gestionnaire_dossier_path(@dossier.procedure, @dossier), html: { class: 'form' } do |f|
         = f.fields_for :champs_private, f.object.ordered_champs_private do |champ_form|
           - champ = champ_form.object
           = render partial: "new_gestionnaire/dossiers/editable_champs/editable_champ",

--- a/app/views/new_gestionnaire/dossiers/avis.html.haml
+++ b/app/views/new_gestionnaire/dossiers/avis.html.haml
@@ -3,6 +3,6 @@
 = render partial: "header", locals: { dossier: @dossier }
 
 .container
-  = render partial: "new_gestionnaire/shared/avis/form", locals: { url: avis_dossier_path(@dossier.procedure, @dossier), must_be_confidentiel: false }
+  = render partial: "new_gestionnaire/shared/avis/form", locals: { url: avis_gestionnaire_dossier_path(@dossier.procedure, @dossier), must_be_confidentiel: false }
 
   = render partial: 'new_gestionnaire/shared/avis/list', locals: { avis: @dossier.avis, avis_seen_at: @avis_seen_at }

--- a/app/views/new_gestionnaire/dossiers/messagerie.html.haml
+++ b/app/views/new_gestionnaire/dossiers/messagerie.html.haml
@@ -2,4 +2,4 @@
 
 = render partial: "header", locals: { dossier: @dossier }
 
-= render partial: "new_gestionnaire/shared/messagerie", locals: { dossier: @dossier, messagerie_seen_at: @messagerie_seen_at , new_commentaire: @commentaire, form_url: commentaire_dossier_path(@dossier.procedure, @dossier) }
+= render partial: "new_gestionnaire/shared/messagerie", locals: { dossier: @dossier, messagerie_seen_at: @messagerie_seen_at , new_commentaire: @commentaire, form_url: commentaire_gestionnaire_dossier_path(@dossier.procedure, @dossier) }

--- a/app/views/new_gestionnaire/procedures/_dossier_actions.html.haml
+++ b/app/views/new_gestionnaire/procedures/_dossier_actions.html.haml
@@ -10,10 +10,10 @@
 
 - elsif dossier.termine?
   - if dossier.archived
-    = link_to unarchive_dossier_path(procedure, dossier), method: :patch, class: 'button' do
+    = link_to unarchive_gestionnaire_dossier_path(procedure, dossier), method: :patch, class: 'button' do
       %span.icon.unarchive>
       Désarchiver le dossier
   - else
-    = link_to archive_dossier_path(procedure, dossier), method: :patch, class: 'button' do
+    = link_to archive_gestionnaire_dossier_path(procedure, dossier), method: :patch, class: 'button' do
       %span.icon.archive>
       Archiver le dossier

--- a/app/views/new_gestionnaire/procedures/_dossier_actions.html.haml
+++ b/app/views/new_gestionnaire/procedures/_dossier_actions.html.haml
@@ -1,10 +1,10 @@
 - if dossier.en_construction_ou_instruction?
   - if dossier_is_followed
-    = link_to unfollow_dossier_path(procedure, dossier), method: :patch, class: 'button' do
+    = link_to unfollow_gestionnaire_dossier_path(procedure, dossier), method: :patch, class: 'button' do
       %span.icon.unfollow>
       Ne plus suivre
   - else
-    = link_to follow_dossier_path(procedure, dossier), method: :patch, class: 'button' do
+    = link_to follow_gestionnaire_dossier_path(procedure, dossier), method: :patch, class: 'button' do
       %span.icon.follow>
       Suivre le dossier
 

--- a/app/views/new_gestionnaire/procedures/_download_dossiers.html.haml
+++ b/app/views/new_gestionnaire/procedures/_download_dossiers.html.haml
@@ -4,8 +4,8 @@
     .dropdown-content.fade-in-down
       %ul.dropdown-items
         %li
-          = link_to "Au format .csv", download_dossiers_procedure_path(format: :csv, procedure_id: procedure.id), target: "_blank"
+          = link_to "Au format .csv", download_dossiers_gestionnaire_procedure_path(format: :csv, procedure_id: procedure.id), target: "_blank"
         %li
-          = link_to "Au format .xlsx", download_dossiers_procedure_path(format: :xlsx, procedure_id: procedure.id), target: "_blank"
+          = link_to "Au format .xlsx", download_dossiers_gestionnaire_procedure_path(format: :xlsx, procedure_id: procedure.id), target: "_blank"
         %li
-          = link_to "Au format .ods", download_dossiers_procedure_path(format: :ods, procedure_id: procedure.id), target: "_blank"
+          = link_to "Au format .ods", download_dossiers_gestionnaire_procedure_path(format: :ods, procedure_id: procedure.id), target: "_blank"

--- a/app/views/new_gestionnaire/procedures/_header_field.html.haml
+++ b/app/views/new_gestionnaire/procedures/_header_field.html.haml
@@ -1,5 +1,5 @@
 %th{ class: classname }
-  = link_to update_sort_procedure_path(@procedure, table: field['table'], column: field['column']) do
+  = link_to update_sort_gestionnaire_procedure_path(@procedure, table: field['table'], column: field['column']) do
     = field['label']
     - if @procedure_presentation.sort['table'] == field['table'] && @procedure_presentation.sort['column'] == field['column']
       - if @procedure_presentation.sort['order'] == 'asc'

--- a/app/views/new_gestionnaire/procedures/index.html.haml
+++ b/app/views/new_gestionnaire/procedures/index.html.haml
@@ -6,7 +6,7 @@
   %ul.procedure-list
     - @procedures.each do |p|
       %li.procedure-item.flex.align-start
-        = link_to(procedure_path(p)) do
+        = link_to(gestionnaire_procedure_path(p)) do
           .flex
 
             .procedure-logo{ style: p.logo.present? ? "background-image: url(#{p.logo.url})" : nil }
@@ -18,7 +18,7 @@
               %ul.procedure-stats.flex
                 %li
                   %object
-                    = link_to(procedure_path(p, statut: 'a-suivre')) do
+                    = link_to(gestionnaire_procedure_path(p, statut: 'a-suivre')) do
                       - a_suivre_count = @dossiers_a_suivre_count_per_procedure[p.id] || 0
                       .stats-number
                         = a_suivre_count
@@ -26,7 +26,7 @@
                         à suivre
                 %li
                   %object
-                    = link_to(procedure_path(p, statut: 'suivis')) do
+                    = link_to(gestionnaire_procedure_path(p, statut: 'suivis')) do
                       - if current_gestionnaire.notifications_per_procedure[p.id].present?
                         %span.notifications{ 'aria-label': "notifications" }
                       - followed_count = @followed_dossiers_count_per_procedure[p.id] || 0
@@ -36,7 +36,7 @@
                         = t('pluralize.followed', count: followed_count)
                 %li
                   %object
-                    = link_to(procedure_path(p, statut: 'traites')) do
+                    = link_to(gestionnaire_procedure_path(p, statut: 'traites')) do
                       - if current_gestionnaire.notifications_per_procedure(:termine)[p.id].present?
                         %span.notifications{ 'aria-label': "notifications" }
                       - termines_count = @dossiers_termines_count_per_procedure[p.id] || 0
@@ -46,7 +46,7 @@
                         = t('pluralize.processed', count: termines_count)
                 %li
                   %object
-                    = link_to(procedure_path(p, statut: 'tous')) do
+                    = link_to(gestionnaire_procedure_path(p, statut: 'tous')) do
                       - dossier_count = @dossiers_count_per_procedure[p.id] || 0
                       .stats-number
                         = dossier_count
@@ -54,7 +54,7 @@
                         = t('pluralize.case', count: dossier_count)
                 %li
                   %object
-                    = link_to(procedure_path(p, statut: 'archives')) do
+                    = link_to(gestionnaire_procedure_path(p, statut: 'archives')) do
                       - archived_count = @dossiers_archived_count_per_procedure[p.id] || 0
                       .stats-number
                         = archived_count

--- a/app/views/new_gestionnaire/procedures/show.html.haml
+++ b/app/views/new_gestionnaire/procedures/show.html.haml
@@ -82,7 +82,7 @@
               %span.button.dropdown
                 Personnaliser
                 .dropdown-content.fade-in-down
-                  = form_tag update_displayed_fields_procedure_path(@procedure), method: :patch, class: 'dropdown-form' do
+                  = form_tag update_displayed_fields_gestionnaire_procedure_path(@procedure), method: :patch, class: 'dropdown-form' do
                     = select_tag :values,
                       options_for_select(@procedure.fields_for_select,
                         selected: @displayed_fields_values),

--- a/app/views/new_gestionnaire/procedures/show.html.haml
+++ b/app/views/new_gestionnaire/procedures/show.html.haml
@@ -60,7 +60,7 @@
       - @current_filters.each do |filter|
         %span.filter
           = "#{filter['label']} : #{filter['value']}"
-          = link_to remove_filter_procedure_path(@procedure, statut: @statut, table: filter['table'], column: filter['column']) do
+          = link_to remove_filter_gestionnaire_procedure_path(@procedure, statut: @statut, table: filter['table'], column: filter['column']) do
             %img.close-icon{ src: image_url("close.svg") }
 
       %table.table.dossiers-table.hoverable

--- a/app/views/new_gestionnaire/procedures/show.html.haml
+++ b/app/views/new_gestionnaire/procedures/show.html.haml
@@ -47,7 +47,7 @@
       %span.button.dropdown
         Filtrer
         .dropdown-content.left-aligned.fade-in-down
-          = form_tag add_filter_procedure_path(@procedure), method: :post, class: 'dropdown-form large' do
+          = form_tag add_filter_gestionnaire_procedure_path(@procedure), method: :post, class: 'dropdown-form large' do
             = label_tag :field,  "Colonne"
             = select_tag :field, options_for_select(@available_fields_to_filters)
             %br

--- a/app/views/new_gestionnaire/procedures/show.html.haml
+++ b/app/views/new_gestionnaire/procedures/show.html.haml
@@ -94,22 +94,22 @@
           - @dossiers.each do |dossier|
             %tr
               %td.folder-col
-                = link_to(dossier_path(@procedure, dossier), class: 'cell-link') do
+                = link_to(gestionnaire_dossier_path(@procedure, dossier), class: 'cell-link') do
                   %span.icon.folder
                     - if current_gestionnaire.notifications_for_procedure(@procedure, :not_archived).include?(dossier.id)
                       %span.notifications{ 'aria-label': 'notifications' }
 
               %td.number-col
-                = link_to(dossier_path(@procedure, dossier), class: 'cell-link') do
+                = link_to(gestionnaire_dossier_path(@procedure, dossier), class: 'cell-link') do
                   = dossier.id
 
               - @displayed_fields.each do |field|
                 %td
-                  = link_to(dossier_path(@procedure, dossier), class: 'cell-link') do
+                  = link_to(gestionnaire_dossier_path(@procedure, dossier), class: 'cell-link') do
                     = dossier.get_value(field['table'], field['column'])
 
               %td.status-col
-                = link_to(dossier_path(@procedure, dossier), class: 'cell-link') do
+                = link_to(gestionnaire_dossier_path(@procedure, dossier), class: 'cell-link') do
                   = render partial: 'status', locals: { dossier: dossier }
               %td.follow-col= render partial: 'dossier_actions', locals: { procedure: @procedure, dossier: dossier, dossier_is_followed: @followed_dossiers_id.include?(dossier.id) }
       = paginate @dossiers

--- a/app/views/new_gestionnaire/procedures/show.html.haml
+++ b/app/views/new_gestionnaire/procedures/show.html.haml
@@ -11,31 +11,31 @@
         %h1= @procedure.libelle
         %ul.tabs
           %li{ class: (@statut == 'a-suivre') ? 'active' : nil }>
-            = link_to(procedure_path(@procedure, statut: 'a-suivre')) do
+            = link_to(gestionnaire_procedure_path(@procedure, statut: 'a-suivre')) do
               à suivre
               %span.badge= @a_suivre_dossiers.count
 
           %li{ class: (@statut == 'suivis') ? 'active' : nil }>
             - if current_gestionnaire.notifications_for_procedure(@procedure).present?
               %span.notifications{ 'aria-label': 'notifications' }
-            = link_to(procedure_path(@procedure, statut: 'suivis')) do
+            = link_to(gestionnaire_procedure_path(@procedure, statut: 'suivis')) do
               = t('pluralize.followed', count: @followed_dossiers.count)
               %span.badge= @followed_dossiers.count
 
           %li{ class: (@statut == 'traites') ? 'active' : nil }>
             - if current_gestionnaire.notifications_for_procedure(@procedure, :termine).present?
               %span.notifications{ 'aria-label': 'notifications' }
-            = link_to(procedure_path(@procedure, statut: 'traites')) do
+            = link_to(gestionnaire_procedure_path(@procedure, statut: 'traites')) do
               = t('pluralize.processed', count: @termines_dossiers.count)
               %span.badge= @termines_dossiers.count
 
           %li{ class: (@statut == 'tous') ? 'active' : nil }>
-            = link_to(procedure_path(@procedure, statut: 'tous')) do
+            = link_to(gestionnaire_procedure_path(@procedure, statut: 'tous')) do
               tous les dossiers
               %span.badge= @all_state_dossiers.count
 
           %li{ class: (@statut == 'archives') ? 'active' : nil }>
-            = link_to(procedure_path(@procedure, statut: 'archives')) do
+            = link_to(gestionnaire_procedure_path(@procedure, statut: 'archives')) do
               = t('pluralize.archived', count: @archived_dossiers.count)
               %span.badge= @archived_dossiers.count
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -210,7 +210,7 @@ Rails.application.routes.draw do
     end
   end
 
-  scope module: 'new_gestionnaire' do
+  scope module: 'new_gestionnaire', as: 'gestionnaire' do
     resources :procedures, only: [:index, :show], param: :procedure_id do
       member do
         patch 'update_displayed_fields'

--- a/spec/controllers/new_gestionnaire/avis_controller_spec.rb
+++ b/spec/controllers/new_gestionnaire/avis_controller_spec.rb
@@ -58,7 +58,7 @@ describe NewGestionnaire::AvisController, type: :controller do
         avis_without_answer.reload
       end
 
-      it { expect(response).to redirect_to(instruction_avis_path(avis_without_answer)) }
+      it { expect(response).to redirect_to(instruction_gestionnaire_avis_path(avis_without_answer)) }
       it { expect(avis_without_answer.answer).to eq('answer') }
       it { expect(flash.notice).to eq('Votre réponse est enregistrée.') }
     end
@@ -119,7 +119,7 @@ describe NewGestionnaire::AvisController, type: :controller do
           it { expect(created_avis.introduction).to eq(intro) }
           it { expect(created_avis.dossier).to eq(previous_avis.dossier) }
           it { expect(created_avis.claimant).to eq(gestionnaire) }
-          it { expect(response).to redirect_to(instruction_avis_path(previous_avis)) }
+          it { expect(response).to redirect_to(instruction_gestionnaire_avis_path(previous_avis)) }
         end
 
         context 'when the user asked for a confidentiel avis' do

--- a/spec/controllers/new_gestionnaire/avis_controller_spec.rb
+++ b/spec/controllers/new_gestionnaire/avis_controller_spec.rb
@@ -250,7 +250,7 @@ describe NewGestionnaire::AvisController, type: :controller do
           let(:password) { '' }
 
           it { expect(created_gestionnaire).to be_nil }
-          it { is_expected.to redirect_to sign_up_avis_path(avis_id, invited_email) }
+          it { is_expected.to redirect_to sign_up_gestionnaire_avis_path(avis_id, invited_email) }
           it { expect(flash.alert).to eq(['Password : Le mot de passe est vide']) }
         end
       end

--- a/spec/controllers/new_gestionnaire/avis_controller_spec.rb
+++ b/spec/controllers/new_gestionnaire/avis_controller_spec.rb
@@ -179,7 +179,7 @@ describe NewGestionnaire::AvisController, type: :controller do
             get :sign_up, params: { id: avis.id, email: invited_email }
           end
 
-          it { is_expected.to redirect_to avis_url(avis) }
+          it { is_expected.to redirect_to gestionnaire_avis_url(avis) }
         end
 
         context 'when the gestionnaire is not authenticated' do
@@ -201,7 +201,7 @@ describe NewGestionnaire::AvisController, type: :controller do
         end
 
         # redirected to dossier but then the gestionnaire gonna be banished !
-        it { is_expected.to redirect_to avis_url(avis) }
+        it { is_expected.to redirect_to gestionnaire_avis_url(avis) }
       end
     end
 
@@ -243,7 +243,7 @@ describe NewGestionnaire::AvisController, type: :controller do
           it { expect(Avis).to have_received(:link_avis_to_gestionnaire) }
 
           it { expect(subject.current_gestionnaire).to eq(created_gestionnaire) }
-          it { is_expected.to redirect_to avis_index_path }
+          it { is_expected.to redirect_to gestionnaire_avis_index_path }
         end
 
         context 'when the gestionnaire creation fails' do

--- a/spec/controllers/new_gestionnaire/avis_controller_spec.rb
+++ b/spec/controllers/new_gestionnaire/avis_controller_spec.rb
@@ -76,7 +76,7 @@ describe NewGestionnaire::AvisController, type: :controller do
       it do
         subject
 
-        expect(response).to redirect_to(messagerie_avis_path(avis_without_answer))
+        expect(response).to redirect_to(messagerie_gestionnaire_avis_path(avis_without_answer))
         expect(dossier.commentaires.map(&:body)).to match(['commentaire body'])
       end
 

--- a/spec/controllers/new_gestionnaire/dossiers_controller_spec.rb
+++ b/spec/controllers/new_gestionnaire/dossiers_controller_spec.rb
@@ -307,7 +307,7 @@ describe NewGestionnaire::DossiersController, type: :controller do
       expect(saved_commentaire.body).to eq("<p>avant\n<br />apres</p>")
       expect(saved_commentaire.email).to eq(gestionnaire.email)
       expect(saved_commentaire.dossier).to eq(dossier)
-      expect(response).to redirect_to(messagerie_dossier_path(dossier.procedure, dossier))
+      expect(response).to redirect_to(messagerie_gestionnaire_dossier_path(dossier.procedure, dossier))
       expect(gestionnaire.followed_dossiers).to include(dossier)
       expect(saved_commentaire.file.present?).to eq(false)
     end

--- a/spec/controllers/new_gestionnaire/dossiers_controller_spec.rb
+++ b/spec/controllers/new_gestionnaire/dossiers_controller_spec.rb
@@ -394,6 +394,6 @@ describe NewGestionnaire::DossiersController, type: :controller do
 
     it { expect(champ_multiple_drop_down_list.value).to eq('["un", "deux"]') }
     it { expect(champ_datetime.value).to eq('21/12/2019 13:17') }
-    it { expect(response).to redirect_to(annotations_privees_dossier_path(dossier.procedure, dossier)) }
+    it { expect(response).to redirect_to(annotations_privees_gestionnaire_dossier_path(dossier.procedure, dossier)) }
   end
 end

--- a/spec/controllers/new_gestionnaire/dossiers_controller_spec.rb
+++ b/spec/controllers/new_gestionnaire/dossiers_controller_spec.rb
@@ -54,7 +54,7 @@ describe NewGestionnaire::DossiersController, type: :controller do
       )
     end
 
-    it { expect(response).to redirect_to(personnes_impliquees_dossier_url) }
+    it { expect(response).to redirect_to(personnes_impliquees_gestionnaire_dossier_url) }
   end
 
   describe '#follow' do
@@ -64,7 +64,7 @@ describe NewGestionnaire::DossiersController, type: :controller do
 
     it { expect(gestionnaire.followed_dossiers).to match([dossier]) }
     it { expect(flash.notice).to eq('Dossier suivi') }
-    it { expect(response).to redirect_to(procedures_url) }
+    it { expect(response).to redirect_to(gestionnaire_procedures_url) }
   end
 
   describe '#unfollow' do
@@ -76,7 +76,7 @@ describe NewGestionnaire::DossiersController, type: :controller do
 
     it { expect(gestionnaire.followed_dossiers).to match([]) }
     it { expect(flash.notice).to eq("Vous ne suivez plus le dossier nº #{dossier.id}") }
-    it { expect(response).to redirect_to(procedures_url) }
+    it { expect(response).to redirect_to(gestionnaire_procedures_url) }
   end
 
   describe '#archive' do
@@ -88,7 +88,7 @@ describe NewGestionnaire::DossiersController, type: :controller do
     end
 
     it { expect(dossier.archived).to be true }
-    it { expect(response).to redirect_to(procedures_url) }
+    it { expect(response).to redirect_to(gestionnaire_procedures_url) }
     it { expect(gestionnaire.followed_dossiers).not_to include(dossier) }
   end
 
@@ -100,7 +100,7 @@ describe NewGestionnaire::DossiersController, type: :controller do
     end
 
     it { expect(dossier.archived).to be false }
-    it { expect(response).to redirect_to(procedures_url) }
+    it { expect(response).to redirect_to(gestionnaire_procedures_url) }
   end
 
   describe '#passer_en_instruction' do

--- a/spec/controllers/new_gestionnaire/dossiers_controller_spec.rb
+++ b/spec/controllers/new_gestionnaire/dossiers_controller_spec.rb
@@ -112,7 +112,7 @@ describe NewGestionnaire::DossiersController, type: :controller do
     end
 
     it { expect(dossier.state).to eq('en_instruction') }
-    it { is_expected.to redirect_to dossier_path(procedure, dossier) }
+    it { is_expected.to redirect_to gestionnaire_dossier_path(procedure, dossier) }
     it { expect(gestionnaire.follow?(dossier)).to be true }
   end
 
@@ -131,7 +131,7 @@ describe NewGestionnaire::DossiersController, type: :controller do
       expect(dossier.state).to eq('en_construction')
     end
 
-    it { is_expected.to redirect_to dossier_path(procedure, dossier) }
+    it { is_expected.to redirect_to gestionnaire_dossier_path(procedure, dossier) }
   end
 
   describe '#terminer' do
@@ -158,7 +158,7 @@ describe NewGestionnaire::DossiersController, type: :controller do
         subject
       end
 
-      it { is_expected.to redirect_to redirect_to dossier_path(procedure, dossier) }
+      it { is_expected.to redirect_to redirect_to gestionnaire_dossier_path(procedure, dossier) }
     end
 
     context "with classer_sans_suite" do
@@ -184,7 +184,7 @@ describe NewGestionnaire::DossiersController, type: :controller do
         subject
       end
 
-      it { is_expected.to redirect_to redirect_to dossier_path(procedure, dossier) }
+      it { is_expected.to redirect_to redirect_to gestionnaire_dossier_path(procedure, dossier) }
     end
 
     context "with accepter" do
@@ -233,7 +233,7 @@ describe NewGestionnaire::DossiersController, type: :controller do
           it 'Notification email is sent with the attestation' do
             subject
 
-            is_expected.to redirect_to redirect_to dossier_path(procedure, dossier)
+            is_expected.to redirect_to redirect_to gestionnaire_dossier_path(procedure, dossier)
           end
         end
 
@@ -246,7 +246,7 @@ describe NewGestionnaire::DossiersController, type: :controller do
 
             subject
 
-            is_expected.to redirect_to redirect_to dossier_path(procedure, dossier)
+            is_expected.to redirect_to redirect_to gestionnaire_dossier_path(procedure, dossier)
           end
         end
       end

--- a/spec/controllers/new_gestionnaire/dossiers_controller_spec.rb
+++ b/spec/controllers/new_gestionnaire/dossiers_controller_spec.rb
@@ -350,7 +350,7 @@ describe NewGestionnaire::DossiersController, type: :controller do
     it { expect(saved_avis.confidentiel).to eq(true) }
     it { expect(saved_avis.dossier).to eq(dossier) }
     it { expect(saved_avis.claimant).to eq(gestionnaire) }
-    it { expect(response).to redirect_to(avis_dossier_path(dossier.procedure, dossier)) }
+    it { expect(response).to redirect_to(avis_gestionnaire_dossier_path(dossier.procedure, dossier)) }
   end
 
   describe "#update_annotations" do

--- a/spec/controllers/new_gestionnaire/procedures_controller_spec.rb
+++ b/spec/controllers/new_gestionnaire/procedures_controller_spec.rb
@@ -78,7 +78,7 @@ describe NewGestionnaire::ProceduresController, type: :controller do
       end
 
       it "redirects avis" do
-        expect(@controller).to have_received(:redirect_to).with(avis_index_path)
+        expect(@controller).to have_received(:redirect_to).with(gestionnaire_avis_index_path)
       end
     end
   end

--- a/spec/controllers/root_controller_spec.rb
+++ b/spec/controllers/root_controller_spec.rb
@@ -21,7 +21,7 @@ describe RootController, type: :controller do
       sign_in gestionnaire
     end
 
-    it { expect(subject).to redirect_to(procedures_path) }
+    it { expect(subject).to redirect_to(gestionnaire_procedures_path) }
   end
 
   context 'when Administrateur is connected' do

--- a/spec/features/new_gestionnaire/gestionnaire_spec.rb
+++ b/spec/features/new_gestionnaire/gestionnaire_spec.rb
@@ -80,7 +80,7 @@ feature 'The gestionnaire part' do
     expect(page).to have_text('avis donnés 0')
 
     click_on dossier.user.email
-    expect(page).to have_current_path(avis_path(dossier.avis.first))
+    expect(page).to have_current_path(gestionnaire_avis_path(dossier.avis.first))
 
     within(:css, '.tabs') do
       click_on 'Avis'

--- a/spec/features/new_gestionnaire/gestionnaire_spec.rb
+++ b/spec/features/new_gestionnaire/gestionnaire_spec.rb
@@ -71,7 +71,7 @@ feature 'The gestionnaire part' do
     log_out
 
     avis = dossier.avis.first
-    test_mail(expert_email, sign_up_avis_path(avis, expert_email))
+    test_mail(expert_email, sign_up_gestionnaire_avis_path(avis, expert_email))
 
     avis_sign_up(avis, expert_email, 'a good password')
 
@@ -169,7 +169,7 @@ feature 'The gestionnaire part' do
   end
 
   def avis_sign_up(avis, email, password)
-    visit sign_up_avis_path(avis, email)
+    visit sign_up_gestionnaire_avis_path(avis, email)
     fill_in 'gestionnaire_password', with: 'a good password'
     click_on 'Créer un compte'
     expect(page).to have_current_path(avis_index_path)

--- a/spec/features/new_gestionnaire/gestionnaire_spec.rb
+++ b/spec/features/new_gestionnaire/gestionnaire_spec.rb
@@ -63,7 +63,7 @@ feature 'The gestionnaire part' do
     click_on dossier.user.email
 
     click_on 'Avis externes'
-    expect(page).to have_current_path(avis_dossier_path(procedure, dossier))
+    expect(page).to have_current_path(avis_gestionnaire_dossier_path(procedure, dossier))
 
     expert_email = 'expert@tps.com'
     ask_confidential_avis(expert_email, 'a good introduction')
@@ -115,7 +115,7 @@ feature 'The gestionnaire part' do
     click_on dossier.user.email
 
     click_on 'Avis externes'
-    expect(page).to have_current_path(avis_dossier_path(procedure, dossier))
+    expect(page).to have_current_path(avis_gestionnaire_dossier_path(procedure, dossier))
 
     expert_email = 'expert@tps.com'
     ask_confidential_avis(expert_email, 'a good introduction')

--- a/spec/features/new_gestionnaire/gestionnaire_spec.rb
+++ b/spec/features/new_gestionnaire/gestionnaire_spec.rb
@@ -10,7 +10,7 @@ feature 'The gestionnaire part' do
   scenario 'A gestionnaire can accept a dossier' do
     log_in(gestionnaire.email, password)
 
-    expect(page).to have_current_path(procedures_path)
+    expect(page).to have_current_path(gestionnaire_procedures_path)
 
     click_on procedure.libelle
     expect(page).to have_current_path(gestionnaire_procedure_path(procedure))
@@ -136,7 +136,7 @@ feature 'The gestionnaire part' do
     fill_in 'user_email', with: email
     fill_in 'user_password', with: password
     click_on 'Se connecter'
-    expect(page).to have_current_path(procedures_path)
+    expect(page).to have_current_path(gestionnaire_procedures_path)
   end
 
   def log_out

--- a/spec/features/new_gestionnaire/gestionnaire_spec.rb
+++ b/spec/features/new_gestionnaire/gestionnaire_spec.rb
@@ -16,7 +16,7 @@ feature 'The gestionnaire part' do
     expect(page).to have_current_path(procedure_path(procedure))
 
     click_on dossier.user.email
-    expect(page).to have_current_path(dossier_path(procedure, dossier))
+    expect(page).to have_current_path(gestionnaire_dossier_path(procedure, dossier))
 
     click_on 'Passer en instruction'
     dossier.reload

--- a/spec/features/new_gestionnaire/gestionnaire_spec.rb
+++ b/spec/features/new_gestionnaire/gestionnaire_spec.rb
@@ -85,7 +85,7 @@ feature 'The gestionnaire part' do
     within(:css, '.tabs') do
       click_on 'Avis'
     end
-    expect(page).to have_current_path(instruction_avis_path(dossier.avis.first))
+    expect(page).to have_current_path(instruction_gestionnaire_avis_path(dossier.avis.first))
 
     within(:css, '.give-avis') do
       expect(page).to have_text("Demandeur : #{gestionnaire.email}")

--- a/spec/features/new_gestionnaire/gestionnaire_spec.rb
+++ b/spec/features/new_gestionnaire/gestionnaire_spec.rb
@@ -75,7 +75,7 @@ feature 'The gestionnaire part' do
 
     avis_sign_up(avis, expert_email, 'a good password')
 
-    expect(page).to have_current_path(avis_index_path)
+    expect(page).to have_current_path(gestionnaire_avis_index_path)
     expect(page).to have_text('avis à donner 1')
     expect(page).to have_text('avis donnés 0')
 
@@ -172,7 +172,7 @@ feature 'The gestionnaire part' do
     visit sign_up_gestionnaire_avis_path(avis, email)
     fill_in 'gestionnaire_password', with: 'a good password'
     click_on 'Créer un compte'
-    expect(page).to have_current_path(avis_index_path)
+    expect(page).to have_current_path(gestionnaire_avis_index_path)
   end
 
   def dossier_present?(id, statut)

--- a/spec/features/new_gestionnaire/gestionnaire_spec.rb
+++ b/spec/features/new_gestionnaire/gestionnaire_spec.rb
@@ -13,7 +13,7 @@ feature 'The gestionnaire part' do
     expect(page).to have_current_path(procedures_path)
 
     click_on procedure.libelle
-    expect(page).to have_current_path(procedure_path(procedure))
+    expect(page).to have_current_path(gestionnaire_procedure_path(procedure))
 
     click_on dossier.user.email
     expect(page).to have_current_path(gestionnaire_dossier_path(procedure, dossier))
@@ -40,16 +40,16 @@ feature 'The gestionnaire part' do
     dossier_present?(dossier.id, 'en construction')
 
     click_on 'Suivre le dossier'
-    expect(page).to have_current_path(procedure_path(procedure))
+    expect(page).to have_current_path(gestionnaire_procedure_path(procedure))
     test_statut_bar(suivi: 1, tous_les_dossiers: 1)
     expect(page).to have_text('Aucun dossier')
 
     click_on 'suivi'
-    expect(page).to have_current_path(procedure_path(procedure, statut: 'suivis'))
+    expect(page).to have_current_path(gestionnaire_procedure_path(procedure, statut: 'suivis'))
     dossier_present?(dossier.id, 'en construction')
 
     click_on 'Ne plus suivre'
-    expect(page).to have_current_path(procedure_path(procedure, statut: 'suivis'))
+    expect(page).to have_current_path(gestionnaire_procedure_path(procedure, statut: 'suivis'))
     test_statut_bar(a_suivre: 1, tous_les_dossiers: 1)
     expect(page).to have_text('Aucun dossier')
   end

--- a/spec/features/new_gestionnaire/procedure_filters_spec.rb
+++ b/spec/features/new_gestionnaire/procedure_filters_spec.rb
@@ -11,7 +11,7 @@ feature "procedure filters" do
   before do
     champ.update_attributes(value: "Mon champ rempli")
     login_as gestionnaire, scope: :gestionnaire
-    visit procedure_path(procedure)
+    visit gestionnaire_procedure_path(procedure)
   end
 
   scenario "should display demandeur by default" do

--- a/spec/helpers/dossier_link_helper_spec.rb
+++ b/spec/helpers/dossier_link_helper_spec.rb
@@ -13,7 +13,7 @@ describe DossierLinkHelper do
 
       before { dossier.procedure.gestionnaires << gestionnaire }
 
-      it { expect(helper.dossier_linked_path(gestionnaire, dossier)).to eq(dossier_path(dossier.procedure, dossier)) }
+      it { expect(helper.dossier_linked_path(gestionnaire, dossier)).to eq(gestionnaire_dossier_path(dossier.procedure, dossier)) }
     end
 
     context "when access as expert" do

--- a/spec/helpers/dossier_link_helper_spec.rb
+++ b/spec/helpers/dossier_link_helper_spec.rb
@@ -21,7 +21,7 @@ describe DossierLinkHelper do
       let(:gestionnaire) { create(:gestionnaire) }
       let!(:avis) { create(:avis, dossier: dossier, gestionnaire: gestionnaire) }
 
-      it { expect(helper.dossier_linked_path(gestionnaire, dossier)).to eq(avis_path(avis)) }
+      it { expect(helper.dossier_linked_path(gestionnaire, dossier)).to eq(gestionnaire_avis_path(avis)) }
     end
   end
 end


### PR DESCRIPTION
Cet PR déplace toutes les routes gestionnaires sous le namespace gestionnaire.

Ce changement a été provoqué par le redesign de l'interface usager, en particulier avec les urls  dossiers coté usager qui rentraient en conflit avec les urls dossier du gestionnaire.
