### PR TITLE
[Fix #1454] Send weekly overview emails async, overview param is not …

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -523,7 +523,7 @@ Performance/FlatMap:
   Enabled: true
 
 Performance/HashEachMethods:
-  Enabled: true
+  Enabled: false
 
 Performance/LstripRstrip:
   Enabled: true

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -6,4 +6,8 @@ class ApplicationJob < ActiveJob::Base
   after_perform do |job|
     Rails.logger.info("#{job.class.name} ended at #{Time.now}")
   end
+
+  def error(job, exception)
+    Raven.capture_exception(exception)
+  end
 end

--- a/app/jobs/weekly_overview_job.rb
+++ b/app/jobs/weekly_overview_job.rb
@@ -7,7 +7,7 @@ class WeeklyOverviewJob < ApplicationJob
       Gestionnaire.all
         .map { |gestionnaire| [gestionnaire, gestionnaire.last_week_overview] }
         .reject { |_, overview| overview.nil? }
-        .each { |gestionnaire, overview| GestionnaireMailer.last_week_overview(gestionnaire, overview).deliver_now }
+        .each { |gestionnaire, _| GestionnaireMailer.last_week_overview(gestionnaire).deliver_later }
     end
   end
 end

--- a/app/mailers/gestionnaire_mailer.rb
+++ b/app/mailers/gestionnaire_mailer.rb
@@ -5,8 +5,9 @@ class GestionnaireMailer < ApplicationMailer
     send_mail email, password, "Vous avez été nommé accompagnateur sur la plateforme TPS"
   end
 
-  def last_week_overview(gestionnaire, overview)
+  def last_week_overview(gestionnaire)
     headers['X-mailjet-campaign'] = 'last_week_overview'
+    overview = gestionnaire.last_week_overview
     send_mail gestionnaire.email, overview, 'Vos activités sur TPS'
   end
 

--- a/spec/jobs/weekly_overview_job_spec.rb
+++ b/spec/jobs/weekly_overview_job_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe WeeklyOverviewJob, type: :job do
   describe 'perform' do
     let!(:gestionnaire) { create(:gestionnaire) }
     let(:overview) { double('overview') }
-    let(:mailer_double) { double('mailer', deliver_now: true) }
+    let(:mailer_double) { double('mailer', deliver_later: true) }
 
     context 'if the feature is enabled' do
       before { allow(Features).to receive(:weekly_overview).and_return(true) }
@@ -16,8 +16,8 @@ RSpec.describe WeeklyOverviewJob, type: :job do
           WeeklyOverviewJob.new.perform
         end
 
-        it { expect(GestionnaireMailer).to have_received(:last_week_overview).with(gestionnaire, overview) }
-        it { expect(mailer_double).to have_received(:deliver_now) }
+        it { expect(GestionnaireMailer).to have_received(:last_week_overview).with(gestionnaire) }
+        it { expect(mailer_double).to have_received(:deliver_later) }
       end
 
       context 'with one gestionnaire with no overviews' do


### PR DESCRIPTION
…correctly serialized by activejob so it is computed again when email is sent