### PR TITLE
typo

### DIFF
--- a/app/views/root/landing.html.haml
+++ b/app/views/root/landing.html.haml
@@ -34,7 +34,7 @@
           %p.feature-text
             %em.feature-text-em Intégration
             %br
-            à l'ensemble des services l'État plateforme
+            à l'ensemble des services de l'État plateforme
 
   .landing-panel
     .container


### PR DESCRIPTION
J'aurais aussi trouvé plus naturel 
> Dialogue plus simple entre usagers et services

au lieu de 

> Dialogue entre usagers et services plus simple