### PR TITLE
[Fix #1543] Strip html tags from textarea champs

### DIFF
--- a/lib/tasks/2018_03_06_clean_html_textareas.rake
+++ b/lib/tasks/2018_03_06_clean_html_textareas.rake
@@ -1,0 +1,16 @@
+require Rails.root.join("app", "helpers", "html_to_string_helper")
+
+namespace :'2018_03_06_clean_html_textareas' do
+  task clean: :environment do
+    include ActionView::Helpers::TextHelper
+    include HtmlToStringHelper
+
+    types_de_champ = TypeDeChamp.joins(:champ)
+      .where(type_champ: "textarea")
+      .where("champs.value LIKE '%<%'")
+
+    types_de_champ.find_each do |tdc|
+      tdc.champ.each { |c| c.update_column(:value, html_to_string(c.value)) }
+    end
+  end
+end

--- a/spec/lib/rake/2018_03_06_clean_html_textareas_spec.rb
+++ b/spec/lib/rake/2018_03_06_clean_html_textareas_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+describe '2018_03_06_clean_html_textareas#clean' do
+  let(:procedure) { create(:procedure) }
+  let(:type_champ) { create(:type_de_champ, procedure: procedure, type_champ: :textarea) }
+  let(:champ) { type_champ.champ.create(value: "<p>Gnahar<br>greu bouahaha</p>") }
+  let(:champ_date) { Time.local(1995) }
+  let(:rake_date) { Time.local(2018) }
+  let(:rake_task) { Rake::Task['2018_03_06_clean_html_textareas:clean'] }
+
+  before do
+    Timecop.freeze(champ_date) { champ }
+    TPS::Application.load_tasks
+    Timecop.freeze(rake_date) { rake_task.invoke }
+    champ.reload
+  end
+
+  after { rake_task.reenable }
+
+  it 'cleans up html tags' do
+    expect(champ.value).to eq("Gnahar\ngreu bouahaha\n")
+  end
+
+  it 'does not change the model’s dates' do
+    expect(champ.updated_at).to eq(champ_date)
+  end
+end


### PR DESCRIPTION
Durée indicative du traitement sur ma machine de dev avec un dump de prod : environ 3 minutes wallclock time, dont 1 minute de temps CPU sur le ruby.