### PR TITLE
[Fix #1573] Display multiples spaces from libelle in attestation tags

### DIFF
--- a/app/views/admin/attestation_templates/edit.html.haml
+++ b/app/views/admin/attestation_templates/edit.html.haml
@@ -41,7 +41,8 @@
           - @attestation_template.tags.each do |tag|
             %tr
               %td
-                = "--#{tag[:libelle]}--"
+                %code{ style: "white-space: pre-wrap;" }
+                  = "--#{tag[:libelle]}--"
               %td
                 = tag[:description]
 


### PR DESCRIPTION
exemple avec deux espaces entre **concernées** et **par**

Avant
<img width="319" alt="capture d ecran 2018-03-07 a 16 29 14" src="https://user-images.githubusercontent.com/847942/37101258-666001a2-2225-11e8-9102-86f1c85df0f6.png">

Après
<img width="311" alt="capture d ecran 2018-03-07 a 16 28 47" src="https://user-images.githubusercontent.com/847942/37101284-753235ba-2225-11e8-9115-34b6945831cd.png">

