### PR TITLE
Remove the mandataire_social guess

### DIFF
--- a/app/controllers/users/dossiers_controller.rb
+++ b/app/controllers/users/dossiers_controller.rb
@@ -113,7 +113,6 @@ class Users::DossiersController < UsersController
       etablissement = @facade.dossier.build_etablissement(etablissement_attributes)
       if etablissement.save
         Rails.logger.info("etablissement saved, siret: #{siret}, id: #{etablissement.id}")
-        @facade.dossier.mandataire_social!(current_user.france_connect_information)
       else
         Rails.logger.info("etablissement not saved, siret: #{siret}, errors: #{etablissement.errors.full_messages}")
         return errors_valid_siret

--- a/app/lib/api_entreprise/entreprise_adapter.rb
+++ b/app/lib/api_entreprise/entreprise_adapter.rb
@@ -33,7 +33,6 @@ class ApiEntreprise::EntrepriseAdapter
       :numero_tva_intracommunautaire,
       :forme_juridique,
       :forme_juridique_code,
-      :mandataires_sociaux,
       :nom_commercial,
       :raison_sociale,
       :siret_siege_social,

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -292,12 +292,6 @@ class Dossier < ApplicationRecord
     end
   end
 
-  def mandataire_social!(france_connect_information)
-    if etablissement.mandataire_social?(france_connect_information)
-      update_column(:mandataire_social, true)
-    end
-  end
-
   private
 
   def update_state_dates

--- a/app/models/entreprise.rb
+++ b/app/models/entreprise.rb
@@ -13,6 +13,4 @@ class Entreprise < ApplicationRecord
   def default_values
     self.raison_sociale ||= ''
   end
-
-  attr_writer :mandataires_sociaux
 end

--- a/app/models/etablissement.rb
+++ b/app/models/etablissement.rb
@@ -19,12 +19,4 @@ class Etablissement < ApplicationRecord
   end
 
   attr_accessor :entreprise_mandataires_sociaux
-
-  def mandataire_social?(france_connect_information)
-    if france_connect_information.present?
-      entreprise_mandataires_sociaux&.find do |mandataire|
-        france_connect_information.mandataire_social?(mandataire)
-      end
-    end
-  end
 end

--- a/app/models/etablissement.rb
+++ b/app/models/etablissement.rb
@@ -17,6 +17,4 @@ class Etablissement < ApplicationRecord
     # squeeze needed because of space in excess in the data
     "#{numero_voie} #{type_voie} #{nom_voie}, #{complement_adresse}, #{code_postal} #{localite}".squeeze(' ')
   end
-
-  attr_accessor :entreprise_mandataires_sociaux
 end

--- a/app/models/france_connect_information.rb
+++ b/app/models/france_connect_information.rb
@@ -2,10 +2,4 @@ class FranceConnectInformation < ApplicationRecord
   belongs_to :user
 
   validates :france_connect_particulier_id, presence: true, allow_blank: false, allow_nil: false
-
-  def mandataire_social?(params)
-    params[:nom].casecmp(family_name).zero? &&
-      params[:prenom].casecmp(given_name).zero? &&
-      params[:date_naissance_timestamp] == birthdate.to_time.to_i
-  end
 end

--- a/app/serializers/dossier_serializer.rb
+++ b/app/serializers/dossier_serializer.rb
@@ -4,7 +4,6 @@ class DossierSerializer < ActiveModel::Serializer
     :updated_at,
     :archived,
     :email,
-    :mandataire_social,
     :state,
     :simplified_state,
     :initiated_at,

--- a/app/serializers/dossier_table_export_serializer.rb
+++ b/app/serializers/dossier_table_export_serializer.rb
@@ -4,7 +4,6 @@ class DossierTableExportSerializer < ActiveModel::Serializer
     :updated_at,
     :archived,
     :email,
-    :mandataire_social,
     :state,
     :initiated_at,
     :received_at,

--- a/app/views/dossiers/_infos_dossier.html.haml
+++ b/app/views/dossiers/_infos_dossier.html.haml
@@ -55,13 +55,6 @@
                 - else
                   = sanitize(champ.decorate.value)
 
-    - if @facade.dossier.mandataire_social && gestionnaire_signed_in?
-      .mandataire_social.text-success.center
-        %br
-        Il est probable que le soumissionnaire du dossier soit un des mandataire social de l'entreprise (
-        %b
-          = "#{@facade.dossier.user.given_name} #{@facade.dossier.user.family_name}"
-        )
 .row
   - if @facade.procedure.cerfa_flag? || @facade.dossier.types_de_piece_justificative.count > 0
     .col-xs-12

--- a/doc/apipie_examples.json
+++ b/doc/apipie_examples.json
@@ -45,7 +45,6 @@
           "created_at": "2008-09-01T08:05:00.000Z",
           "updated_at": "2008-09-01T08:05:00.000Z",
           "archived": false,
-          "mandataire_social": false,
           "state": "initiated",
           "simplified_state": "En construction",
           "initiated_at": "2017-04-11T12:00:12.000Z",

--- a/spec/controllers/api/v1/dossiers_controller_spec.rb
+++ b/spec/controllers/api/v1/dossiers_controller_spec.rb
@@ -130,7 +130,7 @@ describe API::V1::DossiersController do
         let!(:dossier) { Timecop.freeze(date_creation) { create(:dossier, :with_entreprise, procedure: procedure, motivation: "Motivation") } }
         let(:dossier_id) { dossier.id }
         let(:body) { JSON.parse(retour.body, symbolize_names: true) }
-        let(:field_list) { [:id, :created_at, :updated_at, :archived, :mandataire_social, :individual, :entreprise, :etablissement, :cerfa, :types_de_piece_justificative, :pieces_justificatives, :champs, :champs_private, :commentaires, :state, :simplified_state, :initiated_at, :processed_at, :received_at, :motivation, :email, :accompagnateurs, :invites] }
+        let(:field_list) { [:id, :created_at, :updated_at, :archived, :individual, :entreprise, :etablissement, :cerfa, :types_de_piece_justificative, :pieces_justificatives, :champs, :champs_private, :commentaires, :state, :simplified_state, :initiated_at, :processed_at, :received_at, :motivation, :email, :accompagnateurs, :invites] }
         subject { body[:dossier] }
 
         it 'return REST code 200', :show_in_doc do
@@ -142,7 +142,6 @@ describe API::V1::DossiersController do
         it { expect(subject[:created_at]).to eq('2008-09-01T10:05:00.000Z') }
         it { expect(subject[:updated_at]).to eq('2008-09-01T10:05:00.000Z') }
         it { expect(subject[:archived]).to eq(dossier.archived) }
-        it { expect(subject[:mandataire_social]).to eq(dossier.mandataire_social) }
 
         it { expect(subject.keys).to match_array(field_list) }
 

--- a/spec/controllers/users/dossiers_controller_spec.rb
+++ b/spec/controllers/users/dossiers_controller_spec.rb
@@ -259,31 +259,6 @@ describe Users::DossiersController, type: :controller do
           expect(Dossier.last.state).to eq('brouillon')
         end
 
-        describe 'Mandataires Sociaux' do
-          let(:france_connect_information) { create(:france_connect_information, given_name: given_name, family_name: family_name, birthdate: birthdate, france_connect_particulier_id: '1234567') }
-          let(:user) { create(:user, france_connect_information: france_connect_information) }
-
-          before do
-            subject
-          end
-
-          context 'when user is present in mandataires sociaux' do
-            let(:given_name) { 'GERARD' }
-            let(:family_name) { 'DEGONSE' }
-            let(:birthdate) { '1947-07-03' }
-
-            it { expect(Dossier.last.mandataire_social).to be_truthy }
-          end
-
-          context 'when user is not present in mandataires sociaux' do
-            let(:given_name) { 'plop' }
-            let(:family_name) { 'plip' }
-            let(:birthdate) { '1965-01-27' }
-
-            it { expect(Dossier.last.mandataire_social).to be_falsey }
-          end
-        end
-
         describe 'get rna informations' do
           context 'when siren have not rna informations' do
             let(:rna_status) { 404 }

--- a/spec/lib/api_entreprise/entreprise_adapter_spec.rb
+++ b/spec/lib/api_entreprise/entreprise_adapter_spec.rb
@@ -63,40 +63,5 @@ describe ApiEntreprise::EntrepriseAdapter do
     it 'L\'entreprise contient bien un prenom' do
       expect(subject[:prenom]).to eq('test_prenom')
     end
-
-    it 'L\'entreprise contient bien les mandataires_sociaux' do
-      expect(subject[:mandataires_sociaux]).to be_an_instance_of(Array)
-    end
-  end
-
-  context 'Mandataire sociaux' do
-    subject { described_class.new(siren, procedure_id).to_params[:mandataires_sociaux] }
-
-    it '#to_params class est une Hash ?' do
-      expect(subject).to be_an_instance_of(Array)
-    end
-
-    it { expect(subject.size).to eq(8) }
-
-    describe 'Attributs' do
-      it 'Un mandataire social possède bien un nom' do
-        expect(subject[0][:nom]).to eq('HISQUIN')
-      end
-      it 'Un mandataire social possède bien un prenom' do
-        expect(subject[0][:prenom]).to eq('FRANCOIS')
-      end
-
-      it 'Un mandataire social possède bien une fonction' do
-        expect(subject[0][:fonction]).to eq('PRESIDENT DU DIRECTOIRE')
-      end
-
-      it 'Un mandataire social possède bien une date de naissance' do
-        expect(subject[0][:date_naissance]).to eq('1965-01-27')
-      end
-
-      it 'Un mandataire social possède bien une date de naissance au format timestamp' do
-        expect(subject[0][:date_naissance_timestamp]).to eq(-155523600)
-      end
-    end
   end
 end

--- a/spec/models/dossier_spec.rb
+++ b/spec/models/dossier_spec.rb
@@ -149,14 +149,12 @@ describe Dossier do
     it { expect(dossier_serialized_attributes[:created_at]).to be_a(Time) }
     it { expect(dossier_serialized_attributes[:updated_at]).to be_a(Time) }
     it { expect(dossier_serialized_attributes[:archived]).to be_in([true, false]) }
-    it { expect(dossier_serialized_attributes[:mandataire_social]).to be_in([true, false]) }
     it { expect(dossier_serialized_attributes[:state]).to be_a(String) }
 
     it { expect(subject[:id]).to be_a(String) }
     it { expect(subject[:created_at]).to be_a(Time) }
     it { expect(subject[:updated_at]).to be_a(Time) }
     it { expect(subject[:archived]).to be_a(String) }
-    it { expect(subject[:mandataire_social]).to be_a(String) }
     it { expect(subject[:state]).to be_a(String) }
   end
 
@@ -227,18 +225,17 @@ describe Dossier do
       it { expect(subject[2]).to be_a_kind_of(Time) }
       it { expect(subject[3]).to be_in([true, false]) }
       it { expect(subject[4]).to eq(dossier.user.email) }
-      it { expect(subject[5]).to be_in([true, false]) }
-      it { expect(subject[6]).to eq("brouillon") }
-      it { expect(subject[7]).to eq(date1) }
-      it { expect(subject[8]).to eq(date2) }
-      it { expect(subject[9]).to eq(date3) }
+      it { expect(subject[5]).to eq("brouillon") }
+      it { expect(subject[6]).to eq(date1) }
+      it { expect(subject[7]).to eq(date2) }
+      it { expect(subject[8]).to eq(date3) }
+      it { expect(subject[9]).to be_a_kind_of(String) }
       it { expect(subject[10]).to be_a_kind_of(String) }
-      it { expect(subject[11]).to be_a_kind_of(String) }
+      it { expect(subject[11]).to be_nil }
       it { expect(subject[12]).to be_nil }
       it { expect(subject[13]).to be_nil }
       it { expect(subject[14]).to be_nil }
       it { expect(subject[15]).to be_nil }
-      it { expect(subject[16]).to be_nil }
       it do
         expect(subject.count).to eq(DossierTableExportSerializer.new(dossier).attributes.count +
           dossier.procedure.types_de_champ.count +
@@ -251,10 +248,10 @@ describe Dossier do
 
         subject { dossier_with_individual.to_sorted_values }
 
-        it { expect(subject[12]).to eq(dossier_with_individual.individual.gender) }
-        it { expect(subject[13]).to eq(dossier_with_individual.individual.prenom) }
-        it { expect(subject[14]).to eq(dossier_with_individual.individual.nom) }
-        it { expect(subject[15]).to eq(dossier_with_individual.individual.birthdate) }
+        it { expect(subject[11]).to eq(dossier_with_individual.individual.gender) }
+        it { expect(subject[12]).to eq(dossier_with_individual.individual.prenom) }
+        it { expect(subject[13]).to eq(dossier_with_individual.individual.nom) }
+        it { expect(subject[14]).to eq(dossier_with_individual.individual.birthdate) }
       end
     end
 
@@ -266,7 +263,6 @@ describe Dossier do
           dossier.updated_at,
           "false",
           dossier.user.email,
-          "false",
           "brouillon",
           dossier.en_construction_at,
           dossier.en_instruction_at,


### PR DESCRIPTION
Rationale:
- is true for only 0.06% of Dossiers
- is not displayed anymore anyways
- will be a rare case for now
  * FC adoption is not insane
  * FC used more for personal than professional
    matters
  * not always the mandataires sociaux that fill
    dossiers for their companies, so not that
    relevant
- we can add it back later