### PR TITLE
API Entreprise hard refactor

### DIFF
--- a/app/lib/api_entreprise/adapter.rb
+++ b/app/lib/api_entreprise/adapter.rb
@@ -9,4 +9,12 @@ class ApiEntreprise::Adapter
   rescue
     @data_source = nil
   end
+
+  def to_params
+    if data_source.present?
+      process_params
+    else
+      {}
+    end
+  end
 end

--- a/app/lib/api_entreprise/adapter.rb
+++ b/app/lib/api_entreprise/adapter.rb
@@ -1,0 +1,6 @@
+class ApiEntreprise::Adapter
+  def initialize(siret_or_siren, procedure_id)
+    @siret_or_siren = siret_or_siren
+    @procedure_id = procedure_id
+  end
+end

--- a/app/lib/api_entreprise/adapter.rb
+++ b/app/lib/api_entreprise/adapter.rb
@@ -3,4 +3,10 @@ class ApiEntreprise::Adapter
     @siret_or_siren = siret_or_siren
     @procedure_id = procedure_id
   end
+
+  def data_source
+    @data_source ||= get_resource
+  rescue
+    @data_source = nil
+  end
 end

--- a/app/lib/api_entreprise/entreprise_adapter.rb
+++ b/app/lib/api_entreprise/entreprise_adapter.rb
@@ -1,18 +1,14 @@
 class ApiEntreprise::EntrepriseAdapter < ApiEntreprise::Adapter
-  def to_params
-    if data_source.present?
-      params = data_source[:entreprise].slice(*attr_to_fetch)
-      params[:date_creation] = Time.at(params[:date_creation]).to_datetime
-      params
-    else
-      {}
-    end
-  end
-
   private
 
   def get_resource
     ApiEntreprise::API.entreprise(@siret_or_siren, @procedure_id)
+  end
+
+  def process_params
+    params = data_source[:entreprise].slice(*attr_to_fetch)
+    params[:date_creation] = Time.at(params[:date_creation]).to_datetime
+    params
   end
 
   def attr_to_fetch

--- a/app/lib/api_entreprise/entreprise_adapter.rb
+++ b/app/lib/api_entreprise/entreprise_adapter.rb
@@ -11,10 +11,8 @@ class ApiEntreprise::EntrepriseAdapter < ApiEntreprise::Adapter
 
   private
 
-  def data_source
-    @data_source ||= ApiEntreprise::API.entreprise(@siret_or_siren, @procedure_id)
-  rescue
-    @data_source = nil
+  def get_resource
+    ApiEntreprise::API.entreprise(@siret_or_siren, @procedure_id)
   end
 
   def attr_to_fetch

--- a/app/lib/api_entreprise/entreprise_adapter.rb
+++ b/app/lib/api_entreprise/entreprise_adapter.rb
@@ -1,9 +1,4 @@
-class ApiEntreprise::EntrepriseAdapter
-  def initialize(siren, procedure_id)
-    @siren = siren
-    @procedure_id = procedure_id
-  end
-
+class ApiEntreprise::EntrepriseAdapter < ApiEntreprise::Adapter
   def to_params
     if data_source.present?
       params = data_source[:entreprise].slice(*attr_to_fetch)
@@ -17,7 +12,7 @@ class ApiEntreprise::EntrepriseAdapter
   private
 
   def data_source
-    @data_source ||= ApiEntreprise::API.entreprise(@siren, @procedure_id)
+    @data_source ||= ApiEntreprise::API.entreprise(@siret_or_siren, @procedure_id)
   rescue
     @data_source = nil
   end

--- a/app/lib/api_entreprise/etablissement_adapter.rb
+++ b/app/lib/api_entreprise/etablissement_adapter.rb
@@ -1,20 +1,16 @@
 class ApiEntreprise::EtablissementAdapter < ApiEntreprise::Adapter
-  def to_params
-    if data_source.present?
-      params = data_source[:etablissement].slice(*attr_to_fetch)
-      adresse_line = params[:adresse].slice(*address_lines_to_fetch).values.compact.join("\r\n")
-      params.merge!(params[:adresse].slice(*address_attr_to_fetch))
-      params[:adresse] = adresse_line
-      params
-    else
-      {}
-    end
-  end
-
   private
 
   def get_resource
     ApiEntreprise::API.etablissement(@siret_or_siren, @procedure_id)
+  end
+
+  def process_params
+    params = data_source[:etablissement].slice(*attr_to_fetch)
+    adresse_line = params[:adresse].slice(*address_lines_to_fetch).values.compact.join("\r\n")
+    params.merge!(params[:adresse].slice(*address_attr_to_fetch))
+    params[:adresse] = adresse_line
+    params
   end
 
   def attr_to_fetch

--- a/app/lib/api_entreprise/etablissement_adapter.rb
+++ b/app/lib/api_entreprise/etablissement_adapter.rb
@@ -1,9 +1,4 @@
-class ApiEntreprise::EtablissementAdapter
-  def initialize(siret, procedure_id)
-    @siret = siret
-    @procedure_id = procedure_id
-  end
-
+class ApiEntreprise::EtablissementAdapter < ApiEntreprise::Adapter
   def to_params
     if data_source.present?
       params = data_source[:etablissement].slice(*attr_to_fetch)
@@ -19,7 +14,7 @@ class ApiEntreprise::EtablissementAdapter
   private
 
   def data_source
-    @data_source ||= ApiEntreprise::API.etablissement(@siret, @procedure_id)
+    @data_source ||= ApiEntreprise::API.etablissement(@siret_or_siren, @procedure_id)
   rescue
     @data_source = nil
   end

--- a/app/lib/api_entreprise/etablissement_adapter.rb
+++ b/app/lib/api_entreprise/etablissement_adapter.rb
@@ -13,10 +13,8 @@ class ApiEntreprise::EtablissementAdapter < ApiEntreprise::Adapter
 
   private
 
-  def data_source
-    @data_source ||= ApiEntreprise::API.etablissement(@siret_or_siren, @procedure_id)
-  rescue
-    @data_source = nil
+  def get_resource
+    ApiEntreprise::API.etablissement(@siret_or_siren, @procedure_id)
   end
 
   def attr_to_fetch

--- a/app/lib/api_entreprise/exercices_adapter.rb
+++ b/app/lib/api_entreprise/exercices_adapter.rb
@@ -1,9 +1,4 @@
-class ApiEntreprise::ExercicesAdapter
-  def initialize(siret, procedure_id)
-    @siret = siret
-    @procedure_id = procedure_id
-  end
-
+class ApiEntreprise::ExercicesAdapter < ApiEntreprise::Adapter
   def to_array
     if data_source.present?
       data_source[:exercices].map do |exercice|
@@ -17,7 +12,7 @@ class ApiEntreprise::ExercicesAdapter
   private
 
   def data_source
-    @data_source ||= ApiEntreprise::API.exercices(@siret, @procedure_id)
+    @data_source ||= ApiEntreprise::API.exercices(@siret_or_siren, @procedure_id)
   rescue
     @data_source = nil
   end

--- a/app/lib/api_entreprise/exercices_adapter.rb
+++ b/app/lib/api_entreprise/exercices_adapter.rb
@@ -11,10 +11,8 @@ class ApiEntreprise::ExercicesAdapter < ApiEntreprise::Adapter
 
   private
 
-  def data_source
-    @data_source ||= ApiEntreprise::API.exercices(@siret_or_siren, @procedure_id)
-  rescue
-    @data_source = nil
+  def get_resource
+    ApiEntreprise::API.exercices(@siret_or_siren, @procedure_id)
   end
 
   def attr_to_fetch

--- a/app/lib/api_entreprise/exercices_adapter.rb
+++ b/app/lib/api_entreprise/exercices_adapter.rb
@@ -1,11 +1,13 @@
 class ApiEntreprise::ExercicesAdapter < ApiEntreprise::Adapter
-  def to_array
+  def to_params
     if data_source.present?
-      data_source[:exercices].map do |exercice|
+      exercices_array = data_source[:exercices].map do |exercice|
         exercice.slice(*attr_to_fetch)
       end
+
+      { exercices_attributes: exercices_array }
     else
-      []
+      {}
     end
   end
 

--- a/app/lib/api_entreprise/exercices_adapter.rb
+++ b/app/lib/api_entreprise/exercices_adapter.rb
@@ -1,20 +1,16 @@
 class ApiEntreprise::ExercicesAdapter < ApiEntreprise::Adapter
-  def to_params
-    if data_source.present?
-      exercices_array = data_source[:exercices].map do |exercice|
-        exercice.slice(*attr_to_fetch)
-      end
-
-      { exercices_attributes: exercices_array }
-    else
-      {}
-    end
-  end
-
   private
 
   def get_resource
     ApiEntreprise::API.exercices(@siret_or_siren, @procedure_id)
+  end
+
+  def process_params
+    exercices_array = data_source[:exercices].map do |exercice|
+      exercice.slice(*attr_to_fetch)
+    end
+
+    { exercices_attributes: exercices_array }
   end
 
   def attr_to_fetch

--- a/app/lib/api_entreprise/rna_adapter.rb
+++ b/app/lib/api_entreprise/rna_adapter.rb
@@ -1,18 +1,18 @@
 class ApiEntreprise::RNAAdapter < ApiEntreprise::Adapter
-  def to_params
-    if data_source.present? && data_source[:association][:id].present?
+  private
+
+  def get_resource
+    ApiEntreprise::API.rna(@siret_or_siren, @procedure_id)
+  end
+
+  def process_params
+    if data_source[:association][:id].present?
       params = data_source[:association].slice(*attr_to_fetch)
       params[:rna] = data_source[:association][:id]
       params
     else
       {}
     end
-  end
-
-  private
-
-  def get_resource
-    ApiEntreprise::API.rna(@siret_or_siren, @procedure_id)
   end
 
   def attr_to_fetch

--- a/app/lib/api_entreprise/rna_adapter.rb
+++ b/app/lib/api_entreprise/rna_adapter.rb
@@ -11,10 +11,8 @@ class ApiEntreprise::RNAAdapter < ApiEntreprise::Adapter
 
   private
 
-  def data_source
-    @data_source ||= ApiEntreprise::API.rna(@siret_or_siren, @procedure_id)
-  rescue
-    @data_source = nil
+  def get_resource
+    ApiEntreprise::API.rna(@siret_or_siren, @procedure_id)
   end
 
   def attr_to_fetch

--- a/app/lib/api_entreprise/rna_adapter.rb
+++ b/app/lib/api_entreprise/rna_adapter.rb
@@ -1,9 +1,4 @@
-class ApiEntreprise::RNAAdapter
-  def initialize(siret, procedure_id)
-    @siret = siret
-    @procedure_id = procedure_id
-  end
-
+class ApiEntreprise::RNAAdapter < ApiEntreprise::Adapter
   def to_params
     if data_source.present? && data_source[:association][:id].present?
       params = data_source[:association].slice(*attr_to_fetch)
@@ -17,7 +12,7 @@ class ApiEntreprise::RNAAdapter
   private
 
   def data_source
-    @data_source ||= ApiEntreprise::API.rna(@siret, @procedure_id)
+    @data_source ||= ApiEntreprise::API.rna(@siret_or_siren, @procedure_id)
   rescue
     @data_source = nil
   end

--- a/app/services/siret_service.rb
+++ b/app/services/siret_service.rb
@@ -7,12 +7,12 @@ class SIRETService
 
     if etablissement_params.present? && entreprise_params.present?
       association_params = ApiEntreprise::RNAAdapter.new(siret, procedure_id).to_params
-      exercices_array = ApiEntreprise::ExercicesAdapter.new(siret, procedure_id).to_array
+      exercices_params = ApiEntreprise::ExercicesAdapter.new(siret, procedure_id).to_params
 
       params = etablissement_params
         .merge(entreprise_params.transform_keys { |k| "entreprise_#{k}" })
         .merge(association_params.transform_keys { |k| "association_#{k}" })
-        .merge(exercices_attributes: exercices_array)
+        .merge(exercices_params)
 
       # This is to fill legacy models and relationships
       if dossier.present?

--- a/app/services/siret_service.rb
+++ b/app/services/siret_service.rb
@@ -16,12 +16,7 @@ class SIRETService
 
       # This is to fill legacy models and relationships
       if dossier.present?
-        params[:entreprise_attributes] = entreprise_params.merge(
-          {
-            dossier: dossier,
-            rna_information_attributes: association_params.presence
-          }.compact
-        )
+        handle_legacy_models!(params, entreprise_params, dossier, association_params)
       end
 
       params
@@ -30,5 +25,14 @@ class SIRETService
 
   def self.siren(siret)
     siret[0..8]
+  end
+
+  def self.handle_legacy_models!(params, entreprise_params, dossier, association_params)
+    params[:entreprise_attributes] = entreprise_params.merge(
+      {
+        dossier: dossier,
+        rna_information_attributes: association_params.presence
+      }.compact
+    )
   end
 end

--- a/spec/lib/api_entreprise/exercices_adapter_spec.rb
+++ b/spec/lib/api_entreprise/exercices_adapter_spec.rb
@@ -3,32 +3,32 @@ require 'spec_helper'
 describe ApiEntreprise::ExercicesAdapter do
   let(:siret) { '41816609600051' }
   let(:procedure_id) { 11 }
-  subject { described_class.new(siret, procedure_id).to_array }
+  subject { described_class.new(siret, procedure_id).to_params }
 
   before do
     stub_request(:get, /https:\/\/staging.entreprise.api.gouv.fr\/v2\/exercices\/.*token=/)
       .to_return(body: File.read('spec/support/files/exercices.json', status: 200))
   end
 
-  it '#to_array class est un Array ?' do
-    expect(subject).to be_an_instance_of(Array)
+  it '#to_params class est un Hash ?' do
+    expect(subject).to be_an_instance_of(Hash)
   end
 
   it 'have 3 exercices' do
-    expect(subject.size).to eq(3)
+    expect(subject[:exercices_attributes].size).to eq(3)
   end
 
   context 'Attributs Exercices' do
     it 'L\'exercice contient bien un ca' do
-      expect(subject[0][:ca]).to eq('21009417')
+      expect(subject[:exercices_attributes][0][:ca]).to eq('21009417')
     end
 
     it 'L\'exercice contient bien une date de fin d\'exercice' do
-      expect(subject[0][:date_fin_exercice]).to eq("2013-12-31T00:00:00+01:00")
+      expect(subject[:exercices_attributes][0][:date_fin_exercice]).to eq("2013-12-31T00:00:00+01:00")
     end
 
     it 'L\'exercice contient bien une date_fin_exercice_timestamp' do
-      expect(subject[0][:date_fin_exercice_timestamp]).to eq(1388444400)
+      expect(subject[:exercices_attributes][0][:date_fin_exercice_timestamp]).to eq(1388444400)
     end
   end
 end


### PR DESCRIPTION
Pas certain de mon coup pour le commit `Mutualize the adapters’ #data_source methods
` car on perd l’info “cette méthode prend un SIRET” / “cette méthode prend un SIREN”, c’est indifférencié désormais.