### PR TITLE
Fix #1690 – migrate procedure descriptions to plain text

### DIFF
--- a/lib/tasks/2018_03_29_procedure_description_markup.rake
+++ b/lib/tasks/2018_03_29_procedure_description_markup.rake
@@ -1,0 +1,17 @@
+require Rails.root.join("app", "helpers", "html_to_string_helper")
+
+namespace :'2018_03_29_procedure_description_markup' do
+  task strip: :environment do
+    include ActionView::Helpers::TextHelper
+    include HtmlToStringHelper
+
+    total = Procedure.count
+
+    Procedure.find_each(batch_size: 100).with_index do |p, i|
+      if (i % 100) == 0
+        print "Procedure #{i}/#{total}\n"
+      end
+      p.update_column(:description, html_to_string(p.description))
+    end
+  end
+end


### PR DESCRIPTION
Moulinette à faire tourner. Fixes #1690 

à mettre en prod en même temps que #1752 #1753 et #1754 