### PR TITLE
Simplify error trads

### DIFF
--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -86,6 +86,8 @@ fr:
         delimiter: ''
   activerecord:
     errors:
+      messages:
+        blank: "doit être rempli"
       models:
         attestation_template:
           attributes:

--- a/config/locales/models/administrateur/fr.yml
+++ b/config/locales/models/administrateur/fr.yml
@@ -1,8 +1,0 @@
-fr:
-  activerecord:
-    errors:
-      models:
-        administrateur:
-          attributes:
-            email:
-              blank: 'doit être rempli'

--- a/config/locales/models/dossier/fr.yml
+++ b/config/locales/models/dossier/fr.yml
@@ -15,17 +15,3 @@ fr:
           refuse: "Refusé"
           sans_suite: "Sans suite"
         autorisation_donnees: Acceptation des CGU
-
-    errors:
-      models:
-        dossier:
-          attributes:
-            mail_contact:
-              blank: 'doit être rempli'
-              invalid: 'est incorrect'
-            montant_projet:
-              blank: 'doit être rempli'
-            montant_aide_demande:
-              blank: 'doit être rempli'
-            date_previsionnelle:
-              blank: 'doit être remplie'

--- a/config/locales/models/individual/fr.yml
+++ b/config/locales/models/individual/fr.yml
@@ -6,15 +6,3 @@ fr:
         nom: Nom
         prenom: Prénom
         birthdate: Date de naissance
-    errors:
-      models:
-        individual:
-          attributes:
-            gender:
-              blank: 'doit être rempli'
-            nom:
-              blank: 'doit être rempli'
-            prenom:
-              blank: 'doit être rempli'
-            birthdate:
-              blank: 'doit être rempli'

--- a/config/locales/models/procedure/fr.yml
+++ b/config/locales/models/procedure/fr.yml
@@ -3,15 +3,3 @@ fr:
     attributes:
       procedure:
         organisation: Organisme
-    errors:
-      models:
-        procedure:
-          attributes:
-            libelle:
-              blank: Attribut manquant
-            description:
-              blank: Attribut manquant
-            lien_demarche:
-              blank: Attribut manquant
-            organisation:
-              blank: Attribut manquant


### PR DESCRIPTION
En rajoutant les champs pour le délai de conservation des données, j’en ai eu marre de saisir une nième fois la traduction pour `blank`, d’où cette petite factorisation