### PR TITLE
Remove duplicate translations

### DIFF
--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -108,25 +108,20 @@ fr:
             email:
               invalid: invalide
               taken: déjà utilisé
-              blank: est vide
             password:
               too_short: ': Le mot de passe est trop court'
-              blank: ': Le mot de passe est vide'
             password_confirmation:
               confirmation: ': Les deux mots de passe ne correspondent pas'
         invite:
           attributes:
             email:
-              blank: est vide
               taken: ': Invitation déjà envoyée'
         gestionnaire:
           attributes:
             email:
               invalid: invalide
               taken: déjà utilisé
-              blank: est vide
             password:
-              blank: ': Le mot de passe est vide'
               too_short: ': Le mot de passe est trop court'
 
   devise:

--- a/config/locales/models/procedure/fr.yml
+++ b/config/locales/models/procedure/fr.yml
@@ -3,17 +3,3 @@ fr:
     attributes:
       procedure:
         organisation: Organisme
-    errors:
-      models:
-        procedure:
-          attributes:
-            libelle:
-              blank: Attribut manquant
-            description:
-              blank: Attribut manquant
-            lien_demarche:
-              blank: Attribut manquant
-            organisation:
-              blank: Attribut manquant
-            'cadre_juridique':
-              blank: Attribut manquant

--- a/spec/controllers/new_gestionnaire/avis_controller_spec.rb
+++ b/spec/controllers/new_gestionnaire/avis_controller_spec.rb
@@ -276,7 +276,7 @@ describe NewGestionnaire::AvisController, type: :controller do
 
           it { expect(created_gestionnaire).to be_nil }
           it { is_expected.to redirect_to sign_up_gestionnaire_avis_path(avis_id, invited_email) }
-          it { expect(flash.alert).to eq(['Password : Le mot de passe est vide']) }
+          it { expect(flash.alert).to eq(['Password doit être rempli']) }
         end
       end
     end

--- a/spec/models/invite_spec.rb
+++ b/spec/models/invite_spec.rb
@@ -41,7 +41,7 @@ describe Invite do
 
           it do
             expect(invite.save).to be false
-            expect(invite.errors.full_messages).to eq(["Email est vide"])
+            expect(invite.errors.full_messages).to eq(["Email doit être rempli"])
           end
         end
       end


### PR DESCRIPTION
There is a default translation for `blank` already