### PR TITLE
Fix double confirmation

### DIFF
--- a/app/controllers/admin/gestionnaires_controller.rb
+++ b/app/controllers/admin/gestionnaires_controller.rb
@@ -52,7 +52,7 @@ class Admin::GestionnairesController < AdminController
       if User.exists?(email: @gestionnaire.email)
         GestionnaireMailer.user_to_gestionnaire(@gestionnaire.email).deliver_later
       else
-        User.create(email: email, password: password)
+        User.create(email: email, password: password, confirmed_at: DateTime.now)
       end
       flash.notice = 'Accompagnateur ajouté'
     else

--- a/app/models/administration.rb
+++ b/app/models/administration.rb
@@ -21,7 +21,8 @@ class Administration < ApplicationRecord
       administrateur.invite!(id)
       User.create({
         email: email,
-        password: password
+        password: password,
+        confirmed_at: DateTime.now
       })
     end
 


### PR DESCRIPTION
Un quick-fix pour #2042 et #2043 

Ça évite la double confirmation dans les cas d‘utilisation ordinaires. Par contre, c’est pas super joli : 

- les comptes user créés pour les admins et les gestionnaires sont immédiatement accessibles, sans avoir à attendre la confirmation du mail
- on peut encore imaginer des cas tordus où la double activation est nécessaire, par exemple : 
  1. je crée un compte User sans l’activer
  2. on me valide la création d’un compte admin
  3. j’active mon compte admin depuis le lien
  4. il faut alors manuellement activer le compte user avec le mail de confirmation reçu à l’étape 1