### PR TITLE
[Fix #2068] Use mail templates from application rather than devise

### DIFF
--- a/app/mailers/devise_user_mailer.rb
+++ b/app/mailers/devise_user_mailer.rb
@@ -1,6 +1,9 @@
 class DeviseUserMailer < Devise::Mailer
   helper :application # gives access to all helpers defined within `application_helper`.
   include Devise::Controllers::UrlHelpers # Optional. eg. `confirmation_url`
-  default template_path: 'devise_mailer' # to make sure that your mailer uses the devise views
   layout 'mailers/layout'
+
+  def template_paths
+    ['devise_mailer']
+  end
 end

--- a/app/views/devise_mailer/email_changed.html.haml
+++ b/app/views/devise_mailer/email_changed.html.haml
@@ -1,0 +1,23 @@
+- content_for(:title, 'Votre nouvelle adresse électronique')
+
+%p
+  Bonjour,
+
+- unconfirmed_email = @resource.try(:unconfirmed_email?)
+- if unconfirmed_email.present?
+  %p
+    Nous avons reçu une demande de changement d’adresse électronique pour votre
+    compte #{@email} sur demarches-simplifiees.fr.
+    Une fois la demande prise en compte, la nouvelle adresse électronique de
+    votre compte sera #{unconfirmed_email}.
+- else
+  %p
+    Le changement d’adresse électronique de votre compte #{@email} sur
+    demarches-simplifiees.fr a bien été pris en compte.
+    Vous pouvez désormais vous connecter avec l’adresse #{@resource.email}.
+
+%p
+  Bonne journée,
+
+%p
+  L'équipe demarches-simplifiees.fr

--- a/app/views/devise_mailer/password_change.html.haml
+++ b/app/views/devise_mailer/password_change.html.haml
@@ -1,0 +1,14 @@
+- content_for(:title, 'Votre nouveau mot de passe')
+
+%p
+  Bonjour,
+
+%p
+  La demande de changement de mot de passe pour votre compte #{@resource.email} sur
+  demarches-simplifiees.fr a bien été prise en compte.
+
+%p
+  Bonne journée,
+
+%p
+  L'équipe demarches-simplifiees.fr

--- a/app/views/devise_mailer/reset_password_instructions.html.haml
+++ b/app/views/devise_mailer/reset_password_instructions.html.haml
@@ -7,7 +7,7 @@
   = link_to edit_password_url(@resource, reset_password_token: @token), edit_password_url(@resource, reset_password_token: @token)
 
 %p
-  Si vous n'avez pas effectué une telle demande, merci d'ignorer ce mail. Votre mot de passe ne sera pas changé.
+  Si vous n'avez pas effectué une telle demande, merci d'ignorer ce courriel. Votre mot de passe ne sera pas changé.
 
 %p
   Bonne journée,

--- a/app/views/devise_mailer/unlock_instructions.html.haml
+++ b/app/views/devise_mailer/unlock_instructions.html.haml
@@ -1,0 +1,20 @@
+- content_for(:title, 'Réactivez votre compte')
+
+%p
+  Bonjour,
+
+%p
+  Quelqu’un a tenté de se connecter un grand nombre de fois sans succès à votre
+  compte #{@resource.email} sur demarches-simplifiees.fr. Par mesure de précaution,
+  nous avons temporairement désactivé l’accès à votre compte.
+
+%p
+  Pour rétablir l’accès à votre compte, veuillez utiliser le lien ci-dessous.
+
+%p= link_to 'Déverrouiller mon compte', unlock_url(@resource, unlock_token: @token)
+
+%p
+  Bonne journée,
+
+%p
+  L'équipe demarches-simplifiees.fr

--- a/config/locales/devise.fr.yml
+++ b/config/locales/devise.fr.yml
@@ -23,6 +23,8 @@ fr:
         subject: "Instructions pour changer le mot de passe"
       unlock_instructions:
         subject: "Instructions pour déverrouiller le compte"
+      email_changed:
+        subject: "Changement d’adresse mail"
       password_change:
         subject: "Votre mot de passe a été modifié avec succés."
     omniauth_callbacks:

--- a/config/locales/devise.fr.yml
+++ b/config/locales/devise.fr.yml
@@ -4,7 +4,7 @@ fr:
   devise:
     confirmations:
       confirmed: "Votre compte a été validé."
-      send_instructions: "Vous allez recevoir les instructions nécessaires à la confirmation de votre compte dans quelques minutes."
+      send_instructions: 'Vous allez recevoir un e-mail avec les instructions nécessaires à la confirmation de votre compte dans quelques minutes.'
       send_paranoid_instructions: "Si votre e-mail existe dans notre base de données, vous allez bientôt recevoir un e-mail contenant les instructions de confirmation de votre compte."
     failure:
       already_authenticated: "Vous êtes déjà connecté"

--- a/config/locales/devise.fr.yml
+++ b/config/locales/devise.fr.yml
@@ -4,15 +4,15 @@ fr:
   devise:
     confirmations:
       confirmed: "Votre compte a été validé."
-      send_instructions: 'Vous allez recevoir un e-mail avec les instructions nécessaires à la confirmation de votre compte dans quelques minutes.'
-      send_paranoid_instructions: "Si votre e-mail existe dans notre base de données, vous allez bientôt recevoir un e-mail contenant les instructions de confirmation de votre compte."
+      send_instructions: 'Vous allez recevoir un courriel avec les instructions nécessaires à la confirmation de votre compte dans quelques minutes.'
+      send_paranoid_instructions: "Si votre adresse électronique existe dans notre base de données, vous allez bientôt recevoir un courriel contenant les instructions de confirmation de votre compte."
     failure:
       already_authenticated: "Vous êtes déjà connecté"
       inactive: "Votre compte n'est pas encore activé."
-      invalid: "Email ou mot de passe incorrect."
+      invalid: "Adresse électronique ou mot de passe incorrect."
       last_attempt: "Vous avez droit à une tentative avant que votre compte ne soit verrouillé."
       locked: "Votre compte est verrouillé."
-      not_found_in_database: "Email ou mot de passe invalide."
+      not_found_in_database: "Adresse électronique ou mot de passe invalide."
       timeout: "Votre session est expirée. Veuillez vous reconnecter pour continuer."
       unauthenticated: "Vous devez vous connecter ou vous inscrire pour continuer."
       unconfirmed: "Vous devez valider votre compte pour continuer."
@@ -24,16 +24,16 @@ fr:
       unlock_instructions:
         subject: "Instructions pour déverrouiller le compte"
       email_changed:
-        subject: "Changement d’adresse mail"
+        subject: "Changement d’adresse électronique"
       password_change:
         subject: "Votre mot de passe a été modifié avec succés."
     omniauth_callbacks:
       failure: "Nous n'avons pas pu vous authentifier via %{kind} : '%{reason}'."
       success: "Authentifié avec succès via %{kind}."
     passwords:
-      no_token: "Vous ne pouvez accéder à cette page sans passer par un e-mail de réinitialisation de mot de passe. Si vous êtes passé par un e-mail de ce type, assurez-vous d'utiliser l'URL complète."
+      no_token: "Vous ne pouvez accéder à cette page sans passer par un courriel de réinitialisation de mot de passe. Si vous êtes passé par un courriel de ce type, assurez-vous d'utiliser l'URL complète."
       send_instructions: "Vous allez recevoir les instructions de réinitialisation du mot de passe dans quelques instants"
-      send_paranoid_instructions: "Si votre e-mail existe dans notre base de données, vous allez recevoir un lien de réinitialisation par e-mail"
+      send_paranoid_instructions: "Si votre adresse électronique existe dans notre base de données, vous allez recevoir un lien de réinitialisation par courriel"
       updated: "Votre mot de passe a été édité avec succès, vous êtes maintenant connecté"
       updated_not_active: "Votre mot de passe a été changé avec succès."
     registrations:
@@ -41,8 +41,8 @@ fr:
       signed_up: "Bienvenue, vous êtes connecté."
       signed_up_but_inactive: "Vous êtes bien enregistré. Vous ne pouvez cependant pas vous connecter car votre compte n'est pas encore activé."
       signed_up_but_locked: "Vous êtes bien enregistré. Vous ne pouvez cependant pas vous connecter car votre compte est verrouillé."
-      signed_up_but_unconfirmed: "Un message contenant un lien de confirmation a été envoyé à votre adresse email. Ouvrez ce lien pour activer votre compte."
-      update_needs_confirmation: "Votre compte a bien été mis à jour mais nous devons vérifier votre nouvelle adresse email. Merci de vérifier vos emails et de cliquer sur le lien de confirmation pour finaliser la validation de votre nouvelle adresse."
+      signed_up_but_unconfirmed: "Un message contenant un lien de confirmation a été envoyé à votre adresse électronique. Ouvrez ce lien pour activer votre compte."
+      update_needs_confirmation: "Votre compte a bien été mis à jour mais nous devons vérifier votre nouvelle adresse électronique. Merci de vérifier vos courriels et de cliquer sur le lien de confirmation pour finaliser la validation de votre nouvelle adresse."
       updated: "Votre compte a été modifié avec succès."
     sessions:
       signed_in: "Connecté."
@@ -50,7 +50,7 @@ fr:
       already_signed_out: "Déconnecté."
     unlocks:
       send_instructions: "Vous allez recevoir les instructions nécessaires au déverrouillage de votre compte dans quelques instants"
-      send_paranoid_instructions: "Si votre compte existe, vous allez bientôt recevoir un email contenant les instructions pour le déverrouiller."
+      send_paranoid_instructions: "Si votre compte existe, vous allez bientôt recevoir un courriel contenant les instructions pour le déverrouiller."
       unlocked: "Votre compte a été déverrouillé avec succès, vous êtes maintenant connecté."
   errors:
     messages:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -129,54 +129,6 @@ fr:
             password:
               too_short: ': Le mot de passe est trop court'
 
-  devise:
-    confirmations:
-      confirmed: 'Votre compte a été confirmé avec succès.'
-      send_instructions: 'Vous allez recevoir un e-mail avec les instructions nécessaires à la confirmation de votre compte dans quelques minutes.'
-      send_paranoid_instructions: 'Si votre e-mail existe dans notre base de données, vous allez bientôt recevoir un e-mail contenant les instructions de confirmation de votre compte.'
-    failure:
-      already_authenticated: "Vous êtes déjà connecté"
-      inactive: "Votre compte n'est pas encore activé."
-      invalid: "%{authentication_keys} ou mot de passe incorrect."
-      locked: "Votre compte est verrouillé."
-      last_attempt: "Vous avez droit à une tentative avant que votre compte ne soit verrouillé."
-      locked: "Votre compte est verrouillé."
-      not_found_in_database: "%{authentication_keys} ou mot de passe incorrect."
-      timeout: "Votre session est expirée. Veuillez vous reconnecter pour continuer."
-      unauthenticated: "Vous devez vous connecter ou vous inscrire pour continuer."
-      unconfirmed: "Vous devez confirmer votre compte pour continuer."
-    mailer:
-      confirmation_instructions:
-        subject: "Instructions de confirmation"
-      reset_password_instructions:
-        subject: "Instructions pour changer le mot de passe"
-      unlock_instructions:
-        subject: "Instructions pour déverrouiller le compte"
-    omniauth_callbacks:
-      failure: "Nous n'avons pas pu vous authentifier via %{kind} : '%{reason}'."
-      success: 'Authentifié avec succès via %{kind}.'
-    passwords:
-      no_token: "Vous ne pouvez accéder à cette page sans passer par un e-mail de réinitialisation de mot de passe. Si vous êtes passé par un e-mail de ce type, assurez-vous d'utiliser l'URL complète."
-      send_instructions: 'Vous allez recevoir les instructions de réinitialisation du mot de passe dans quelques instants'
-      send_paranoid_instructions: "Si votre e-mail existe dans notre base de données, vous allez recevoir un lien de réinitialisation par e-mail"
-      updated: 'Votre mot de passe a été édité avec succès, vous êtes maintenant connecté'
-      updated_not_active: 'Votre mot de passe a été changé avec succès.'
-    registrations:
-      destroyed: 'Votre compte a été supprimé avec succès. Nous espérons vous revoir bientôt.'
-      signed_up: 'Bienvenue, vous êtes connecté.'
-      signed_up_but_inactive: "Vous êtes bien enregistré. Vous ne pouvez cependant pas vous connecter car votre compte n'est pas encore activé."
-      signed_up_but_locked: "Vous êtes bien enregistré. Vous ne pouvez cependant pas vous connecter car votre compte est verrouillé."
-      signed_up_but_unconfirmed: 'Un message contenant un lien de confirmation a été envoyé à votre adresse email. Ouvrez ce lien pour confirmer votre compte.'
-      update_needs_confirmation: "Votre compte a bien été mis à jour mais nous devons vérifier votre nouvelle adresse email. Merci de vérifier vos emails et de cliquer sur le lien de confirmation pour finaliser la validation de votre nouvelle adresse."
-      updated: 'Votre compte a été modifié avec succès.'
-    sessions:
-      signed_in: "Connecté avec succès."
-      signed_out: "Déconnecté avec succès."
-      already_signed_out: "Déconnecté avec succès."
-    unlocks:
-      send_instructions: 'Vous allez recevoir les instructions nécessaires au déverrouillage de votre compte dans quelques instants'
-      send_paranoid_instructions: 'Si votre compte existe, vous allez bientôt recevoir un email contenant les instructions pour le déverrouiller.'
-      unlocked: 'Votre compte a été déverrouillé avec succès, veuillez vous connecter pour continuer.'
   errors:
     messages:
       already_confirmed: "a déjà été validé(e), veuillez essayer de vous connecter"


### PR DESCRIPTION
`default template_path:` was the documented way, but wasn’t working
(and there was no hint in the source code of Devise that it could
work)

Therefore, let’s override `template_paths` instead and stop worrying