### PR TITLE
README: petites améliorations

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,8 @@ Afin de générer la BDD de l'application, il est nécessaire d'exécuter les co
     # Create and load the schema for both databases
     bin/rails db:create db:schema:load
 
-    # Migrate the development database and then the test database
-    bin/rails db:migrate
-    bin/rails db:migrate RAILS_ENV=test
+    # Migrate the development database and the test database
+    rails db:migrate
 
 ## Bouchonnage de l’authentification
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ demarches-simplifiees.fr est un site web conçu afin de répondre au besoin urge
 
 ## Initialisation de l'environnement de développement
 
-Afin d'initialiser l'environnement de développement, éxécutez la commande suivante :
+Afin d'initialiser l'environnement de développement, exécutez la commande suivante :
 
     bundle install
 
@@ -43,7 +43,7 @@ Les informations nécessaire à l'initialisation de la base doivent être pré-c
     > create user tps_test with password 'tps_test' superuser;
     > \q
 
-Afin de générer la BDD de l'application, il est nécessaire d'éxécuter les commandes suivantes :
+Afin de générer la BDD de l'application, il est nécessaire d'exécuter les commandes suivantes :
 
     # Create and load the schema for both databases
     rake db:create db:schema:load

--- a/README.md
+++ b/README.md
@@ -46,11 +46,11 @@ Les informations nécessaire à l'initialisation de la base doivent être pré-c
 Afin de générer la BDD de l'application, il est nécessaire d'exécuter les commandes suivantes :
 
     # Create and load the schema for both databases
-    rake db:create db:schema:load
+    bin/rails db:create db:schema:load
 
     # Migrate the development database and then the test database
-    rake db:migrate
-    rake db:migrate RAILS_ENV=test
+    bin/rails db:migrate
+    bin/rails db:migrate RAILS_ENV=test
 
 ## Bouchonnage de l’authentification
 


### PR DESCRIPTION
- Correction d'une coquille
- Suppression de la migration explicite de la base de test :
  - Depuis Rails 4.1 la migration de la base de test est gérée par `maintain_test_schema`.
- Utilisation de `bin/rails` plutôt que de `rake` :
  - Depuis Rails 5.0 les tâches standards sont exposées dans `rails` ;
  - `rails` tape dans la gem globale du système, alors que `bin/rails` utilise un binstub avec la version qui correspond bien au Gemfile du projet.
