### PR TITLE
Ajoute les fichiers de configuration par défaut à `/config`

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,25 +53,10 @@ Afin de générer la BDD de l'application, il est nécessaire d'exécuter les co
 
 ## Bouchonnage de l’authentification
 
-Créer le fichier `config/france_connect.yml` avec le contenu
+Créer les fichiers de configuration avec les valeurs par défaut :
 
-```yaml
-particulier_identifier: ''
-particulier_secret: ''
-
-particulier_redirect_uri: ''
-particulier_authorization_endpoint: ''
-particulier_token_endpoint: ''
-particulier_userinfo_endpoint: ''
-particulier_logout_endpoint: ''
-```
-
-Créer le fichier `config/github_secrets.yml` avec le contenu
-
-```yaml
-client_id: ''
-client_secret: ''
-```
+    cp config/france_connect.example.yml config/france_connect.yml
+    cp config/github_secrets.example.yml config/github_secrets.yml
 
 ## Connexion a Pipedrive
 

--- a/config/france_connect.example.yml
+++ b/config/france_connect.example.yml
@@ -1,0 +1,8 @@
+particulier_identifier: ''
+particulier_secret: ''
+
+particulier_redirect_uri: ''
+particulier_authorization_endpoint: ''
+particulier_token_endpoint: ''
+particulier_userinfo_endpoint: ''
+particulier_logout_endpoint: ''

--- a/config/github_secrets.example.yml
+++ b/config/github_secrets.example.yml
@@ -1,0 +1,2 @@
+client_id: ''
+client_secret: ''


### PR DESCRIPTION
En ce moment les valeurs par défaut des fichiers de config sont définies dans le README, et doivent être copiées à la main dans deux nouveaux fichiers.

Cette PR déplace les valeurs par défaut dans des fichiers `config/*.example.yml`. Ça permet de simplifier le README, et de créer les fichiers de configuration par défaut avec juste un coup de `cp`.