### PR TITLE
Crée l'utilisateur initial dans les seeds

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ Les informations nécessaire à l'initialisation de la base doivent être pré-c
 
 Afin de générer la BDD de l'application, il est nécessaire d'exécuter les commandes suivantes :
 
-    # Create and load the schema for both databases
-    bin/rails db:create db:schema:load
+    # Create and initialize the database
+    bin/rails db:create db:schema:load db:seed
 
     # Migrate the development database and the test database
     bin/rails db:migrate
@@ -81,13 +81,11 @@ Dans le fichier `config/intializers/token.rb`, ajouter
 
 *Note : les valeurs pour ces paramètres sont renseignées dans le Keepass*
 
-## Création d'un compte de test initial en local
-
-    bin/rake create_test_account -- --email=EMAIL --password=PASSWORD
-
 ## Lancement de l'application
 
     overmind s
+
+Un utilisateur de test est disponible, avec les identifiants `test@exemple.fr`/`testpassword`.
 
 ## Programmation des jobs
 

--- a/README.md
+++ b/README.md
@@ -81,16 +81,9 @@ Dans le fichier `config/intializers/token.rb`, ajouter
 
 *Note : les valeurs pour ces paramètres sont renseignées dans le Keepass*
 
-## Création des comptes initiaux
+## Création d'un compte de test initial en local
 
-    bin/rails console
-    > email = "<votre email>"
-    > password = "<votre mot de passe>"
-    > Administration.create(email: email, password: password)
-    > Administrateur.create(email: email, password: password)
-    > Gestionnaire.create(email: email, password: password)
-    > User.create(email: email, password: password)
-
+    bin/rake create_test_account -- --email=EMAIL --password=PASSWORD
 
 ## Lancement de l'application
 

--- a/Rakefile
+++ b/Rakefile
@@ -5,27 +5,6 @@ require File.expand_path('config/application', __dir__)
 
 Rails.application.load_tasks
 
-desc "Create a test account that includes all roles"
-task :create_test_account => :environment do
-  email, password = nil
-  optparse = OptionParser.new do |opts|
-    opts.banner = "Usage: rake create_test_account -- --email=EMAIL --password=PASSWORD"
-    opts.on("--email ARG",    String) { |e| email = e }
-    opts.on("--password ARG", String) { |p| password = p }
-  end
-  args = optparse.order!(ARGV) {}
-  optparse.parse!(args)
-
-  raise optparse.banner if email.nil? || password.nil?
-  raise "Password must be at least 8 characters." if password.length < 8
-
-  Administration.create!(email: email, password: password)
-  Administrateur.create!(email: email, password: password)
-  Gestionnaire.create!(email: email, password: password)
-  User.create!(email: email, password: password, confirmed_at: DateTime.now)
-  puts "Test account #{email} created"
-end
-
 task :deploy do
   domains = %w(37.187.249.111 149.202.72.152 149.202.198.6)
   domains.each do |domain|

--- a/Rakefile
+++ b/Rakefile
@@ -5,6 +5,27 @@ require File.expand_path('config/application', __dir__)
 
 Rails.application.load_tasks
 
+desc "Create a test account that includes all roles"
+task :create_test_account => :environment do
+  email, password = nil
+  optparse = OptionParser.new do |opts|
+    opts.banner = "Usage: rake create_test_account -- --email=EMAIL --password=PASSWORD"
+    opts.on("--email ARG",    String) { |e| email = e }
+    opts.on("--password ARG", String) { |p| password = p }
+  end
+  args = optparse.order!(ARGV) {}
+  optparse.parse!(args)
+
+  raise optparse.banner if email.nil? || password.nil?
+  raise "Password must be at least 8 characters." if password.length < 8
+
+  Administration.create!(email: email, password: password)
+  Administrateur.create!(email: email, password: password)
+  Gestionnaire.create!(email: email, password: password)
+  User.create!(email: email, password: password, confirmed_at: DateTime.now)
+  puts "Test account #{email} created"
+end
+
 task :deploy do
   domains = %w(37.187.249.111 149.202.72.152 149.202.198.6)
   domains.each do |domain|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,15 @@
 # This file should contain all the record creation needed to seed the database with its default values.
 # The data can then be loaded with the rake db:seed (or created alongside the db with db:setup).
+
 #
-# Examples:
+# Create an initial user who can use all roles
 #
-#   cities = City.create([{ name: 'Chicago' }, { name: 'Copenhagen' }])
-#   Mayor.create(name: 'Emanuel', city: cities.first)
+
+default_user = "test@exemple.fr"
+default_password = "testpassword"
+
+puts "Create test user '#{default_user}'"
+Administration.create!(email: default_user, password: default_password)
+Administrateur.create!(email: default_user, password: default_password)
+Gestionnaire.create!(email: default_user, password: default_password)
+User.create!(email: default_user, password: default_password, confirmed_at: DateTime.now)


### PR DESCRIPTION
Pour l'instant la création d'un utilisateur de test à l'installation du projet est définie dans le README.

Cela dit la commande ne fonctionne pas complètement (il manque un `:confirmed_at`). Et aussi Simon me dit qu'elle ne sert habituellement qu'au setup initial du projet, mais plus jamais après.

Cette PR déplace donc la création d'un utilisateur de test dans les seeds. L'utilisateur est créé quand on initialise le projet en local, le `confirmed_at` est corrigé, ça réduit la quantité de code dans le README, et au besoin on peut toujours créer de nouveaux utilisateurs dans la console.