### PR TITLE
README: always use binstubs

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Afin de générer la BDD de l'application, il est nécessaire d'exécuter les co
     bin/rails db:create db:schema:load
 
     # Migrate the development database and the test database
-    rails db:migrate
+    bin/rails db:migrate
 
 ## Bouchonnage de l’authentification
 
@@ -83,7 +83,7 @@ Dans le fichier `config/intializers/token.rb`, ajouter
 
 ## Création des comptes initiaux
 
-    rails c
+    bin/rails console
     > email = "<votre email>"
     > password = "<votre mot de passe>"
     > Administration.create(email: email, password: password)
@@ -110,18 +110,18 @@ Pour exécuter les tests de l'application, plusieurs possibilités :
 
 - Lancer tous les tests
 
-        rake spec
-        rspec
+        bin/rake spec
+        bin/rspec
 
 - Lancer un test en particulier
 
-        rake spec SPEC=file_path/file_name_spec.rb:line_number
-        rspec file_path/file_name_spec.rb:line_number
+        bin/rake spec SPEC=file_path/file_name_spec.rb:line_number
+        bin/rspec file_path/file_name_spec.rb:line_number
 
 - Lancer tous les tests d'un fichier
 
-        rake spec SPEC=file_path/file_name_spec.rb
-        rspec file_path/file_name_spec.rb
+        bin/rake spec SPEC=file_path/file_name_spec.rb
+        bin/rspec file_path/file_name_spec.rb
 
 ## Debug
 
@@ -145,18 +145,18 @@ Une fois `overmind` lancé, et un breakpoint `byebug` inséré dans le code, il 
 ## Régénérer les binstubs
 
     bundle binstub railties --force
-    rake rails:update:bin
+    bin/rake rails:update:bin
 
 ## Tâches Super Admin
 
 - ajouter un compte super admin :
-  `bundle exec rake admin:create_admin[email-du-compte-github@exemple.com]`
+  `bin/rake admin:create_admin[email-du-compte-github@exemple.com]`
 
 - lister les comptes super admin :
-  `bundle exec rake admin:list`
+  `bin/rake admin:list`
 
 - supprimer un compte super admin :
-  `bundle exec rake admin:delete_admin[email-du-compte-github@exemple.com]`
+  `bin/rake admin:delete_admin[email-du-compte-github@exemple.com]`
 
 ## Compatibilité navigateurs
 


### PR DESCRIPTION
Otherwise we use the gem installed globally, which may not be the same version as the gem defined in the project Gemfile.

Also, in newly generated Rails 5.0 projects, `bin/rails` seems to be preferred to `bundle exec rails`.