### PR TITLE
tasks: silence output of tasks during tests

### DIFF
--- a/lib/tasks/2017_07_26_clean_birthdate_on_individual.rake
+++ b/lib/tasks/2017_07_26_clean_birthdate_on_individual.rake
@@ -1,3 +1,5 @@
+require Rails.root.join("lib", "tasks", "task_helper")
+
 namespace :'2017_07_26_clean_birthdate_on_individual' do
   task clean: :environment do
     # remove duplicates
@@ -10,13 +12,13 @@ namespace :'2017_07_26_clean_birthdate_on_individual' do
     individuals_with_date = Individual.where.not(birthdate: nil)
     # Match 31/12/2017 => 2017-12-31
     individuals_with_date.select { |i| /^\d{2}\/\d{2}\/\d{4}$/.match(i.birthdate) }.each do |i|
-      puts "cleaning #{i.birthdate}"
+      rake_puts "cleaning #{i.birthdate}"
       i.update(birthdate: Date.parse(i.birthdate).iso8601) rescue nil
     end
 
     # Match 31/12/17 => 2017-12-31
     individuals_with_date.select { |i| /^\d{2}\/\d{2}\/\d{2}$/.match(i.birthdate) }.each do |i|
-      puts "cleaning #{i.birthdate}"
+      rake_puts "cleaning #{i.birthdate}"
       new_date = Date.strptime(i.birthdate, "%d/%m/%y")
       if new_date.year > 2017
         new_date = new_date - 100.years

--- a/lib/tasks/2017_10_18_regenerate_attestation.rake
+++ b/lib/tasks/2017_10_18_regenerate_attestation.rake
@@ -1,3 +1,5 @@
+require Rails.root.join("lib", "tasks", "task_helper")
+
 namespace :'2017_10_18_regenerate_attestation' do
   task set: :environment do
     include ActiveSupport::Testing::TimeHelpers
@@ -15,7 +17,7 @@ namespace :'2017_10_18_regenerate_attestation' do
         dossier = attestation.dossier
         procedure = dossier.procedure
 
-        puts "processing dossier #{dossier.id}"
+        rake_puts "processing dossier #{dossier.id}"
 
         travel_to(dossier.processed_at) do
           new_attestation = procedure.attestation_template.attestation_for(dossier)

--- a/lib/tasks/2017_10_30_copy_commentaire_piece_justificative_to_file.rake
+++ b/lib/tasks/2017_10_30_copy_commentaire_piece_justificative_to_file.rake
@@ -1,8 +1,10 @@
+require Rails.root.join("lib", "tasks", "task_helper")
+
 namespace :'2017_10_30_copy_commentaire_piece_justificative_to_file' do
   task set: :environment do
     commentaires_to_process = Commentaire.where(file: nil).where.not(piece_justificative_id: nil).reorder(id: :desc)
 
-    puts "#{commentaires_to_process.count} commentaires to process..."
+    rake_puts "#{commentaires_to_process.count} commentaires to process..."
 
     commentaires_to_process.each do |c|
       process_commentaire(c)
@@ -12,7 +14,7 @@ namespace :'2017_10_30_copy_commentaire_piece_justificative_to_file' do
   task fix: :environment do
     commentaires_to_fix = Commentaire.where.not(file: nil).where.not(piece_justificative_id: nil).reorder(id: :desc)
 
-    puts "#{commentaires_to_fix.count} commentaires to fix..."
+    rake_puts "#{commentaires_to_fix.count} commentaires to fix..."
 
     commentaires_to_fix.each do |c|
       process_commentaire(c)
@@ -27,7 +29,7 @@ namespace :'2017_10_30_copy_commentaire_piece_justificative_to_file' do
   end
 
   def process_commentaire(commentaire)
-    puts "Processing commentaire #{commentaire.id}"
+    rake_puts "Processing commentaire #{commentaire.id}"
     if commentaire.piece_justificative.present?
       # https://github.com/carrierwaveuploader/carrierwave#uploading-files-from-a-remote-location
       commentaire.remote_file_url = commentaire.piece_justificative.content_url
@@ -42,7 +44,7 @@ namespace :'2017_10_30_copy_commentaire_piece_justificative_to_file' do
 
       commentaire.save
       if commentaire.file.blank?
-        puts "Failed to save file for commentaire #{commentaire.id}"
+        rake_puts "Failed to save file for commentaire #{commentaire.id}"
       end
     end
   end

--- a/lib/tasks/2017_12_05_initialize_timestamps_for_entreprises.rake
+++ b/lib/tasks/2017_12_05_initialize_timestamps_for_entreprises.rake
@@ -1,18 +1,20 @@
+require Rails.root.join("lib", "tasks", "task_helper")
+
 namespace :'2017_12_05_initialize_timestamps_for_entreprises' do
   task set: :environment do
     entreprises = Entreprise.where(created_at: nil).includes(:dossier)
 
-    puts "#{entreprises.count} to initialize..."
+    rake_puts "#{entreprises.count} to initialize..."
 
     entreprises.each { |e| initialize_entreprise(e) }
   end
 
   def initialize_entreprise(entreprise)
-    puts "initializing entreprise #{entreprise.id}"
+    rake_puts "initializing entreprise #{entreprise.id}"
     if entreprise.dossier.present?
       entreprise.update_columns(created_at: entreprise.dossier.created_at, updated_at: entreprise.dossier.created_at)
     else
-      puts "dossier #{entreprise.dossier_id} is missing for entreprise #{entreprise.id}"
+      rake_puts "dossier #{entreprise.dossier_id} is missing for entreprise #{entreprise.id}"
       entreprise.update_columns(created_at: DateTime.now, updated_at: DateTime.now)
     end
   end

--- a/lib/tasks/2017_12_20_delete_old_administration.rake
+++ b/lib/tasks/2017_12_20_delete_old_administration.rake
@@ -1,7 +1,9 @@
+require Rails.root.join("lib", "tasks", "task_helper")
+
 namespace :'2017_12_20_delete_old_administration' do
   task set: :environment do
     Administration.all.each do |a|
-      puts "Deleting #{a.email}"
+      rake_puts "Deleting #{a.email}"
       a.destroy
     end
   end

--- a/lib/tasks/2018_01_18_clean_datetime_in_champs.rake
+++ b/lib/tasks/2018_01_18_clean_datetime_in_champs.rake
@@ -1,17 +1,19 @@
+require Rails.root.join("lib", "tasks", "task_helper")
+
 namespace :'2018_01_18_clean_datetime_in_champs' do
   task clean: :environment do
     datetime_champs = TypeDeChamp.where(type_champ: "datetime").flat_map{ |t| t.champ }
 
     # Match " HH:MM" => nil a datetime is not valid if not composed by date AND time
     datetime_champs.select { |c| /^\s\d{2}:\d{2}$/.match(c.value) }.each do |c|
-      puts "cleaning #{c.value} => nil"
+      rake_puts "cleaning #{c.value} => nil"
       c.update_columns(value: nil)
     end
 
     # Match "dd/mm/YYYY HH:MM" => "YYYY-mm-dd HH:MM"
     datetime_champs.select { |c| /^\d{2}\/\d{2}\/\d{4}\s\d{2}:\d{2}$/ =~ c.value }.each do |c|
       formated_date = DateTime.parse(c.value, "%d/%m/%Y %H:%M").strftime("%Y-%m-%d %H:%M")
-      puts "cleaning #{c.value} => #{formated_date}"
+      rake_puts "cleaning #{c.value} => #{formated_date}"
       c.update_columns(value: formated_date)
     end
 
@@ -23,7 +25,7 @@ namespace :'2018_01_18_clean_datetime_in_champs' do
       hours = c.value[9,2]
       minutes = c.value[12,2]
       formated_date = "#{year}-#{month}-#{day} #{hours}:#{minutes}"
-      puts "cleaning #{c.value} => #{formated_date}"
+      rake_puts "cleaning #{c.value} => #{formated_date}"
       c.update_columns(value: formated_date)
     end
   end

--- a/lib/tasks/2018_03_06_clean_html_textareas.rake
+++ b/lib/tasks/2018_03_06_clean_html_textareas.rake
@@ -1,9 +1,12 @@
+require Rails.root.join("lib", "tasks", "task_helper")
 require Rails.root.join("app", "helpers", "html_to_string_helper")
 
 namespace :'2018_03_06_clean_html_textareas' do
   task clean: :environment do
     include ActionView::Helpers::TextHelper
     include HtmlToStringHelper
+
+    rake_puts "PUTS Will migrate champs"
 
     champs = Champ.joins(:type_de_champ)
       .where(types_de_champ: { type_champ: "textarea" })
@@ -13,7 +16,7 @@ namespace :'2018_03_06_clean_html_textareas' do
 
     champs.find_each(batch_size: 100).with_index do |c, i|
       if (i % 100) == 0
-        print "Champ #{i}/#{total}\n"
+        rake_puts "Champ #{i}/#{total}\n"
       end
       c.update_column(:value, html_to_string(c.value))
     end

--- a/lib/tasks/2018_03_29_remove_code_tags_from_mail_templates.rake
+++ b/lib/tasks/2018_03_29_remove_code_tags_from_mail_templates.rake
@@ -1,3 +1,5 @@
+require Rails.root.join("lib", "tasks", "task_helper")
+
 namespace :'2018_03_29_remove_code_tags_from_mail_templates' do
   task clean: :environment do
     remove_code_tag_from_body(Mails::ClosedMail)
@@ -9,9 +11,9 @@ namespace :'2018_03_29_remove_code_tags_from_mail_templates' do
 
   def remove_code_tag_from_body(model_class)
     mails = model_class.where("body LIKE ?", "%<code>%")
-    puts "#{mails.count} #{model_class.name} to clean"
+    rake_puts "#{mails.count} #{model_class.name} to clean"
     mails.each do |m|
-      puts "cleaning #{model_class.name} ##{m.id}"
+      rake_puts "cleaning #{model_class.name} ##{m.id}"
       m.update(body: m.body.gsub("<code>", "").gsub("</code>", ""))
     end
   end

--- a/lib/tasks/2018_04_04_fetch_etablissement_with_no_entreprise.rake
+++ b/lib/tasks/2018_04_04_fetch_etablissement_with_no_entreprise.rake
@@ -1,3 +1,5 @@
+require Rails.root.join("lib", "tasks", "task_helper")
+
 namespace :'2018_04_04_fetch_etablissement_with_no_entreprise' do
   task fetch: :environment do
     dossiers = Entreprise.joins('LEFT JOIN etablissements et ON entreprises.id = et.entreprise_id')
@@ -7,7 +9,7 @@ namespace :'2018_04_04_fetch_etablissement_with_no_entreprise' do
     dossiers.each do |dossier|
       siret = dossier.entreprise.siret_siege_social
 
-      puts "Fetch siret: #{siret} for dossier: #{dossier.id}"
+      rake_puts "Fetch siret: #{siret} for dossier: #{dossier.id}"
 
       if siret
         EtablissementUpdateJob.perform_later(dossier, siret)

--- a/lib/tasks/2018_06_05_resend_attestations.rake
+++ b/lib/tasks/2018_06_05_resend_attestations.rake
@@ -1,3 +1,5 @@
+require Rails.root.join("lib", "tasks", "task_helper")
+
 namespace :'2018_06_05_resend_attestations' do
   task set: :environment do
     procedure = Procedure.find(4247)
@@ -12,7 +14,7 @@ namespace :'2018_06_05_resend_attestations' do
       dossier.attestation = dossier.build_attestation
 
       ResendAttestationMailer.resend_attestation(dossier).deliver_later
-      puts "Email envoyé à #{dossier.user.email} pour le dossier #{dossier.id}"
+      rake_puts "Email envoyé à #{dossier.user.email} pour le dossier #{dossier.id}"
     end
   end
 end

--- a/lib/tasks/2018_06_05_send_new_attestations.rake
+++ b/lib/tasks/2018_06_05_send_new_attestations.rake
@@ -1,3 +1,5 @@
+require Rails.root.join("lib", "tasks", "task_helper")
+
 namespace :'2018_06_05_send_new_attestation' do
   task set: :environment do
     ids = [
@@ -37,14 +39,14 @@ namespace :'2018_06_05_send_new_attestation' do
       if attestation
         id = attestation.id
         attestation.destroy
-        puts "Attestation #{id} détruite"
+        rake_puts "Attestation #{id} détruite"
       end
 
       dossier.attestation = dossier.build_attestation
 
       NewAttestationMailer.new_attestation(dossier).deliver_later
-      puts "Email envoyé à #{dossier.user.email} pour le dossier #{dossier.id}"
-      puts
+      rake_puts "Email envoyé à #{dossier.user.email} pour le dossier #{dossier.id}"
+      rake_puts
     end
   end
 end

--- a/lib/tasks/2018_06_06_users_for_admins_and_gestionnaires.rake
+++ b/lib/tasks/2018_06_06_users_for_admins_and_gestionnaires.rake
@@ -1,3 +1,5 @@
+require Rails.root.join("lib", "tasks", "task_helper")
+
 namespace :'2018_06_06_users_for_admins_and_gestionnaires' do
   task preactivate: :environment do
     preactivate_users(Gestionnaire, 'accompagnateur') { |g| g.reset_password_token.nil? }
@@ -14,7 +16,7 @@ namespace :'2018_06_06_users_for_admins_and_gestionnaires' do
       .to_a
       .select(&block)
 
-    puts("Sending emails to #{already_activated.count} #{table_name} that were already confirmed")
+    rake_puts "Sending emails to #{already_activated.count} #{table_name} that were already confirmed"
 
     already_activated.each { |m| PreactivateUsersMailer.reinvite(m, role_name).deliver_later }
 
@@ -24,6 +26,6 @@ namespace :'2018_06_06_users_for_admins_and_gestionnaires' do
         .where(confirmed_at: nil)
         .update_all(confirmed_at: DateTime.now)
 
-    puts("Fixed #{count} #{table_name} with unconfirmed user")
+    rake_puts "Fixed #{count} #{table_name} with unconfirmed user"
   end
 end

--- a/lib/tasks/task_helper.rb
+++ b/lib/tasks/task_helper.rb
@@ -1,0 +1,10 @@
+# Write the given objects to the standard output – except if Rake is configured
+# to be quiet.
+#
+# This is useful when running tests (when Rake is configured to be quiet),
+# to avoid spamming the output with extra informations.
+def rake_puts(*args)
+  if Rake.verbose
+    puts(*args)
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -118,6 +118,8 @@ RSpec.configure do |config|
   end
 
   config.before(:all) {
+    Rake.verbose false
+
     Warden.test_mode!
 
     Typhoeus::Expectation.clear


### PR DESCRIPTION
Currently, when running specs, the output of rake tasks is spamming the tests results. It makes warnings occuring during tests more difficult to catch, and errors harder to spot.

```
$ bin/rspec spec/lib/rake

Randomized with seed 6544
1 Mails::ClosedMail to clean
cleaning Mails::ClosedMail #1
1 Mails::InitiatedMail to clean
cleaning Mails::InitiatedMail #1
1 Mails::ReceivedMail to clean
cleaning Mails::ReceivedMail #1
1 Mails::RefusedMail to clean
cleaning Mails::RefusedMail #1
1 Mails::WithoutContinuationMail to clean
cleaning Mails::WithoutContinuationMail #1
.....Champ 0/1
.Champ 0/1
.
```

This PR configures Rake so that it runs in quiet mode during specs. This
disables the internal messages of rake during tests.

However our own `puts` also need to be conditionned to the verbosity of
rake. Using a simple `rake_puts` helper allows the info messages to be
displayed when running the rake task manually, but not during tests.

### With this PR

```
$ bin/rspec spec/lib/rake

Randomized with seed 6544
.......
```