### PR TITLE
Correction de l'affichage du tooltip de publication

### DIFF
--- a/app/views/admin/procedures/show.html.haml
+++ b/app/views/admin/procedures/show.html.haml
@@ -10,7 +10,7 @@
           - message += 'Affectez des accompagnateurs à votre procédure.'
         - if procedure.service.nil?
           - message += 'Affectez un service à votre procédure.'
-        %a.action_button.btn.btn-success#publish-procedure{ style: 'float: right; margin-top: 10px;', disabled: 'disabled', 'data-toggle' => :tooltip, title: message }
+        %a.action_button.btn.btn-success#publish-procedure{ style: 'float: right; margin-top: 10px;', disabled: 'disabled', 'data-toggle' => :tooltip, 'data-placement' => :bottom, title: message }
           %i.fa.fa-eraser
           Publier
       - else

--- a/app/views/admin/procedures/show.html.haml
+++ b/app/views/admin/procedures/show.html.haml
@@ -5,11 +5,12 @@
   #procedure_show
     - if procedure.brouillon?
       - if procedure.gestionnaires.empty? || procedure.service.nil?
-        - message = ''
+        - missing_elements = []
         - if procedure.gestionnaires.empty?
-          - message += 'Affectez des accompagnateurs à votre procédure.'
+          - missing_elements << 'des accompagnateurs'
         - if procedure.service.nil?
-          - message += 'Affectez un service à votre procédure.'
+          - missing_elements << 'un service'
+        - message = "Affectez #{missing_elements.join(' et ')} à votre procédure."
         %a.action_button.btn.btn-success#publish-procedure{ style: 'float: right; margin-top: 10px;', disabled: 'disabled', 'data-toggle' => :tooltip, 'data-placement' => :bottom, title: message }
           %i.fa.fa-eraser
           Publier


### PR DESCRIPTION
Le tooltip indiquant pourquoi une procédure ne peut pas être publiée était clippé par la barre de navigation. C'est dommage pour un texte d'aide.

## Avant

<img width="940" alt="avant" src="https://user-images.githubusercontent.com/179923/41343063-ef70d4b0-6efd-11e8-8586-296a68735ad9.png">

## Après

<img width="941" alt="apres" src="https://user-images.githubusercontent.com/179923/41343072-f3c7997c-6efd-11e8-9251-1a815b1507e5.png">
