### PR TITLE
Affiche les informations du service en bas du formulaire du dossier

### DIFF
--- a/app/assets/stylesheets/new_design/auth.scss
+++ b/app/assets/stylesheets/new_design/auth.scss
@@ -111,3 +111,11 @@ $auth-breakpoint: $two-columns-breakpoint;
     }
   }
 }
+
+.identity-form {
+  @media (max-width: $two-columns-breakpoint) {
+    input[type=submit] {
+      margin-bottom: 2 * $default-padding;
+    }
+  }
+}

--- a/app/assets/stylesheets/new_design/common.scss
+++ b/app/assets/stylesheets/new_design/common.scss
@@ -29,6 +29,10 @@ h2 {
   border-bottom: 1px solid $border-grey;
 }
 
+strong {
+  font-weight: bold;
+}
+
 a {
   color: $blue;
 }

--- a/app/assets/stylesheets/new_design/common.scss
+++ b/app/assets/stylesheets/new_design/common.scss
@@ -23,6 +23,12 @@ h1 {
   font-weight: bold;
 }
 
+h2 {
+  font-size: 30px;
+  margin-bottom: 15px;
+  border-bottom: 1px solid $border-grey;
+}
+
 a {
   color: $blue;
 }

--- a/app/assets/stylesheets/new_design/forms.scss
+++ b/app/assets/stylesheets/new_design/forms.scss
@@ -254,9 +254,11 @@
 
   .send-wrapper {
     text-align: right;
+    margin-top: 2 * $default-padding;
+    margin-bottom: 2 * $default-padding;
 
-    .send {
-      margin-bottom: $default-padding;
+    .button {
+      margin-bottom: 0;
     }
   }
 

--- a/app/assets/stylesheets/new_design/new_footer.scss
+++ b/app/assets/stylesheets/new_design/new_footer.scss
@@ -4,11 +4,19 @@
 @import "placeholders";
 
 footer {
-  @include vertical-padding(72px);
   background-color: $light-grey;
   border-top: 1px solid $border-grey;
   bottom: 0;
   width: 100%;
+}
+
+.landing-footer {
+  @include vertical-padding(72px);
+}
+
+.dossier-footer {
+  @include vertical-padding(48px);
+  line-height: 24px;
 }
 
 .footer-columns {
@@ -34,6 +42,12 @@ footer {
   list-style-type: none;
   padding: 0;
   margin: 0;
+}
+
+.footer-header {
+  font-size: 14px;
+  font-weight: bold;
+  margin-bottom: 10px;
 }
 
 .footer-link {
@@ -78,4 +92,11 @@ footer {
     color: $blue;
     text-decoration: none;
   }
+}
+
+.footer-bottom-line {
+  margin-top: 30px;
+  margin-bottom: -30px;
+  text-align: center;
+  font-size: small;
 }

--- a/app/views/layouts/new_application.html.haml
+++ b/app/views/layouts/new_application.html.haml
@@ -30,8 +30,8 @@
       = render partial: "layouts/flash_messages"
       = yield
 
-      - if content_for?(:display_footer)
-        = render partial: "layouts/new_footer"
+      - if content_for?(:footer)
+        = content_for(:footer)
       = render partial: "layouts/mailjet_newsletter"
 
       = javascript_include_tag "new_design/application", "data-turbolinks-eval": false

--- a/app/views/new_administrateur/services/_form.html.haml
+++ b/app/views/new_administrateur/services/_form.html.haml
@@ -16,6 +16,10 @@
 
   = f.select :type_organisme, Service.type_organismes.keys.map { |key| [ I18n.t("type_organisme.#{key}"), key] }
 
+  %h2 Informations de contact
+
+  %p.explication Ces informations seront visibles par les utilisateurs du formulaire.
+
   = f.label :email do
     Courriel
     %span.mandatory *

--- a/app/views/new_user/dossiers/_footer.html.haml
+++ b/app/views/new_user/dossiers/_footer.html.haml
@@ -1,0 +1,39 @@
+%footer.dossier-footer
+  .container
+    %ul.footer-columns
+
+      - service = dossier.procedure.service
+      - if service.present?
+        %li.footer-column
+          %h3.footer-header Cette démarche est gérée par :
+          %p
+            = service.nom
+            %br
+            = service.organisme
+            %br
+            = string_to_html(service.adresse)
+
+        %li.footer-column
+          %h3.footer-header Poser une question sur votre dossier :
+          %p
+            - if dossier.brouillon?
+              Par email :
+              = link_to service.email, "mailto:#{service.email}"
+            - else
+              Directement
+              = link_to "par la messagerie", users_dossier_recapitulatif_path(dossier)
+          %p
+            Par téléphone :
+            %a{ href: "tel:#{service.telephone}" }= service.telephone
+
+          %p
+            Horaires : #{ service.horaires.sub(/\S/, &:downcase) }
+
+    .footer-bottom-line
+      = link_to "Accessibilité", accessibilite_index_path, :class => "footer-link"
+      –
+      = link_to "CGU", CGU_URL, :class => "footer-link", :target => "_blank", rel: "noopener noreferrer"
+      –
+      = link_to "Mentions légales", MENTIONS_LEGALES_URL, :class => "footer-link", :target => "_blank", rel: "noopener noreferrer"
+      –
+      = link_to "Contact technique", "mailto:#{CONTACT_EMAIL}", :class => "footer-link"

--- a/app/views/new_user/dossiers/identite.html.haml
+++ b/app/views/new_user/dossiers/identite.html.haml
@@ -1,3 +1,6 @@
+- content_for :footer do
+  = render partial: "new_user/dossiers/footer", locals: { dossier: @dossier }
+
 .two-columns
   .columns-container
     .column.preview
@@ -11,7 +14,7 @@
       .procedure-description
         = h string_to_html(@dossier.procedure.description)
 
-    .column
+    .column.identity-form
       = form_for @dossier.individual, url: update_identite_dossier_path(@dossier), html: { class: "form" } do |f|
         %h1 Données d'identité
 

--- a/app/views/new_user/dossiers/modifier.html.haml
+++ b/app/views/new_user/dossiers/modifier.html.haml
@@ -1,3 +1,6 @@
+- content_for :footer do
+  = render partial: "new_user/dossiers/footer", locals: { dossier: @dossier }
+
 .dossier-edit
   .dossier-header
     .container

--- a/app/views/root/_footer.html.haml
+++ b/app/views/root/_footer.html.haml
@@ -1,6 +1,7 @@
-%footer
+%footer.landing-footer
   .container
     %ul.footer-columns
+
       %li.footer-column
         %ul.footer-logos
           %li.footer-text

--- a/app/views/root/landing.html.haml
+++ b/app/views/root/landing.html.haml
@@ -1,4 +1,5 @@
-- content_for(:display_footer, true)
+- content_for :footer do
+  = render partial: "root/footer"
 
 .landing
   .landing-panel.hero-panel

--- a/spec/factories/dossier.rb
+++ b/spec/factories/dossier.rb
@@ -18,6 +18,12 @@ FactoryBot.define do
       end
     end
 
+    trait :with_service do
+      after(:build) do |dossier, _evaluator|
+        dossier.procedure.service = create(:service)
+      end
+    end
+
     trait :for_individual do
       after(:build) do |dossier, _evaluator|
         dossier.individual = create(:individual)

--- a/spec/factories/dossier.rb
+++ b/spec/factories/dossier.rb
@@ -20,7 +20,7 @@ FactoryBot.define do
 
     trait :for_individual do
       after(:build) do |dossier, _evaluator|
-        dossier.individual = create :individual
+        dossier.individual = create(:individual)
         dossier.save
       end
     end

--- a/spec/factories/procedure.rb
+++ b/spec/factories/procedure.rb
@@ -20,6 +20,12 @@ FactoryBot.define do
       end
     end
 
+    trait :with_service do
+      after(:build) do |procedure, _evaluator|
+        procedure.service = create(:service)
+      end
+    end
+
     trait :with_api_carto do
       after(:build) do |procedure, _evaluator|
         procedure.module_api_carto.use_api_carto = true

--- a/spec/views/new_user/dossiers/_footer.html.haml_spec.rb
+++ b/spec/views/new_user/dossiers/_footer.html.haml_spec.rb
@@ -1,0 +1,30 @@
+describe 'new_user/dossiers/_footer.html.haml', type: :view do
+  let(:service) { create(:service) }
+  let(:dossier) {
+    dossier = create(:dossier)
+    dossier.procedure.service = service
+    return dossier
+  }
+
+  subject { render 'new_user/dossiers/footer.html.haml', dossier: dossier }
+
+  it "affiche les informations de contact" do
+    expect(subject).to have_text(service.nom)
+    expect(subject).to have_text(service.organisme)
+    expect(subject).to have_text(service.telephone)
+  end
+
+  it "affiche les liens usuels requis" do
+    expect(subject).to have_link("Accessibilité")
+    expect(subject).to have_link("CGU")
+    expect(subject).to have_link("Mentions légales")
+  end
+
+  context "quand le dossier n'a pas de service associé" do
+    let(:service) { nil }
+
+    it { is_expected.to have_selector("footer") }
+    it { is_expected.to have_link("Accessibilité") }
+    it { is_expected.not_to have_text('téléphone') }
+  end
+end

--- a/spec/views/new_user/dossiers/identite.html.haml_spec.rb
+++ b/spec/views/new_user/dossiers/identite.html.haml_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+describe 'new_user/dossiers/identite.html.haml', type: :view do
+  let(:dossier) { create(:dossier, :with_entreprise, :with_service, state: 'brouillon', procedure: create(:procedure, :with_api_carto, :with_two_type_de_piece_justificative, for_individual: true)) }
+  let(:footer) { view.content_for(:footer) }
+
+  before do
+    sign_in dossier.user
+    assign(:dossier, dossier)
+  end
+
+  context 'test de composition de la page' do
+    before do
+      render
+    end
+
+    it 'affiche les informations de la procédure' do
+      expect(rendered).to have_text(dossier.procedure.libelle)
+    end
+
+    it 'prépare le footer' do
+      expect(footer).to have_selector('footer')
+    end
+  end
+end

--- a/spec/views/new_user/dossiers/modifier.html.haml_spec.rb
+++ b/spec/views/new_user/dossiers/modifier.html.haml_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+describe 'new_user/dossiers/modifier.html.haml', type: :view do
+  let(:dossier) { create(:dossier, :with_entreprise, :with_service, state: 'brouillon', procedure: create(:procedure, :with_api_carto, :with_two_type_de_piece_justificative, for_individual: true)) }
+  let(:footer) { view.content_for(:footer) }
+
+  before do
+    sign_in dossier.user
+    assign(:dossier, dossier)
+  end
+
+  context 'test de composition de la page' do
+    before do
+      render
+    end
+
+    it 'affiche le libellé de la procédure' do
+      expect(rendered).to have_text(dossier.procedure.libelle)
+    end
+
+    it 'affiche les boutons de validation' do
+      expect(rendered).to have_selector('.send-wrapper')
+    end
+
+    it 'prépare le footer' do
+      expect(footer).to have_selector('footer')
+    end
+  end
+end


### PR DESCRIPTION
Fix #1699

Pour permettre à l'utilisateur de contacter le service ayant créé le formulaire en cas de question, on affiche les coordonnées du service en bas du formulaire. L'idée est de faire un premiet jet (qui tienne quand même la route), et d'itérer après.

<img width="1186" alt="contact edit" src="https://user-images.githubusercontent.com/179923/41359792-8ffcb656-6f2b-11e8-9095-10efaac4578f.png">

Pour faire bien, la page de création ou d'édition d'un service est également modifiée pour expliquer à quoi servent les infos de contact,  et éviter que les Administrateurs y mettent des infos bidon.

![screenshot_2018-06-13 demarches-simplifiees fr](https://user-images.githubusercontent.com/179923/41360092-366dcf0c-6f2c-11e8-9561-9afad8253fde.png)

## TODO

- [ ] Afficher le footer aussi sur le formulaire d'identité
- [ ] Écrire les tests

## Questions ouvertes

- **Est-ce qu'on affiche ce footer quel que soit l'état du formulaire, ou seulement sur les brouillons ?** Une fois que le dossier a été déposé, on est supposé plutôt communiquer via la messagerie, plutôt que par téléphone ou email.
- Des avis sur l'apparence, le style ou la formulation ?