### PR TITLE
Pimp checkboxes

### DIFF
--- a/app/assets/stylesheets/new_design/forms.scss
+++ b/app/assets/stylesheets/new_design/forms.scss
@@ -54,6 +54,20 @@
     .etablissement-titre {
       margin-bottom: 2 * $default-padding;
     }
+
+    // Align checkboxes on the top-left side of the label
+    &.editable-champ-checkbox,
+    &.editable-champ-engagement {
+      label {
+        padding-left: 28px;
+      }
+
+      input[type=checkbox] {
+        position: absolute;
+        top: 1px;
+        left: 0px;
+      }
+    }
   }
 
   .radios {
@@ -112,7 +126,16 @@
 
   input[type=checkbox],
   input[type=radio] {
+    margin-left: 5px;
+    margin-right: 4px;
     margin-bottom: 2 * $default-padding;
+  }
+
+  input[type=checkbox] {
+    // Firefox tends to display checkbox controls smaller than other browsers.
+    // Ensure a consistency of size between browsers.
+    width: 16px;
+    height: 16px;
   }
 
   input[type=date] {

--- a/app/helpers/champ_helper.rb
+++ b/app/helpers/champ_helper.rb
@@ -1,5 +1,6 @@
 module ChampHelper
-  def is_not_header_nor_explication?(champ)
-    !['header_section', 'explication'].include?(champ.type_champ)
+  def has_label?(champ)
+    types_without_label = ['header_section', 'explication']
+    !types_without_label.include?(champ.type_champ)
   end
 end

--- a/app/views/shared/dossiers/editable_champs/_checkbox.html.haml
+++ b/app/views/shared/dossiers/editable_champs/_checkbox.html.haml
@@ -2,5 +2,3 @@
   { required: champ.mandatory? },
   'on',
   'off'
-
-%br

--- a/app/views/shared/dossiers/editable_champs/_editable_champ.html.haml
+++ b/app/views/shared/dossiers/editable_champs/_editable_champ.html.haml
@@ -1,5 +1,5 @@
-.editable-champ
-  - if is_not_header_nor_explication?(champ)
+.editable-champ{ class: "editable-champ-#{champ.type_champ}" }
+  - if has_label?(champ)
     = render partial: 'shared/dossiers/editable_champs/champ_label', locals: { form: form, champ: champ, seen_at: defined?(seen_at) ? seen_at : nil }
 
   = render partial: "shared/dossiers/editable_champs/#{champ.type_champ}",


### PR DESCRIPTION
Suite aux retours de @odtvince, cette PR améliore le positionnement des cases à cocher dans les champs "checkboxes" :

## Partie utilisateur

La case à cocher est avant le titre et la description du champ.

**Avant**
<img width="1080" alt="checkbox-utilisateur-avant" src="https://user-images.githubusercontent.com/179923/41421723-b1512cde-6ff7-11e8-94f5-a211accbd43d.png">

**Après**
<img width="1077" alt="checkbox-utilisateur-apres" src="https://user-images.githubusercontent.com/179923/41421727-b296da26-6ff7-11e8-9bf1-5cf731910f73.png">

Fix #1279

## ~~Partie prévisualisation~~

~~La position de la case est cohérente avec ce que voit l'utilisateur.~~ EDIT: remplacé par #2114

@odtvince @gregoirenovel vous en pensez quoi ?