### PR TITLE
deploy: don't seed the database

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -140,9 +140,8 @@ task :deploy => :environment do
       queue "/etc/init.d/#{user} upgrade "
       queue! %[sudo service delayed_job_#{user!} start]
 
-      queue "cd #{deploy_to}/#{current_path}/"
-      queue "bundle exec rake db:seed RAILS_ENV=#{rails_env}"
-      queue %[echo "-----> Rake Seeding Completed."]
+      # If you are deploying a review app on a fresh testing environment,
+      # now can be a good time to seed the database.
     end
   end
 end


### PR DESCRIPTION
**À merger lundi**

The database should be seeded only when deploying on a fresh new environment – like a local setup or a review app.

Persistent testing and production environment shouldn't be seeded.

This fixes an error during deployment:

```
       Create test user 'test@exemple.fr'
       rake aborted!
       ActiveRecord::RecordInvalid: translation missing: fr.activerecord.errors.messages.record_invalid
```

(The error is actually caused by a missing translation, but the seed shouldn't be run in the first place).