### PR TITLE
Ajoute spring aux binstubs par défaut

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,6 +4,7 @@ require:
 AllCops:
   Exclude:
     - "db/schema.rb"
+    - "bin/*"
 
 Bundler/DuplicatedGem:
   Enabled: true

--- a/bin/rails
+++ b/bin/rails
@@ -1,4 +1,9 @@
 #!/usr/bin/env ruby
+begin
+  load File.expand_path('../spring', __FILE__)
+rescue LoadError => e
+  raise unless e.message.include?('spring')
+end
 APP_PATH = File.expand_path('../config/application', __dir__)
 require_relative '../config/boot'
 require 'rails/commands'

--- a/bin/rake
+++ b/bin/rake
@@ -1,4 +1,9 @@
 #!/usr/bin/env ruby
+begin
+  load File.expand_path('../spring', __FILE__)
+rescue LoadError => e
+  raise unless e.message.include?('spring')
+end
 require_relative '../config/boot'
 require 'rake'
 Rake.application.run

--- a/bin/rspec
+++ b/bin/rspec
@@ -1,3 +1,8 @@
 #!/usr/bin/env ruby
+begin
+  load File.expand_path('../spring', __FILE__)
+rescue LoadError => e
+  raise unless e.message.include?('spring')
+end
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
 load Gem.bin_path('rspec-core', 'rspec')

--- a/bin/spring
+++ b/bin/spring
@@ -1,0 +1,17 @@
+#!/usr/bin/env ruby
+
+# This file loads spring without using Bundler, in order to be fast.
+# It gets overwritten when you run the `spring binstub` command.
+
+unless defined?(Spring)
+  require 'rubygems'
+  require 'bundler'
+
+  lockfile = Bundler::LockfileParser.new(Bundler.default_lockfile.read)
+  spring = lockfile.specs.detect { |spec| spec.name == "spring" }
+  if spring
+    Gem.use_paths Gem.dir, Bundler.bundle_path.to_s, *Gem.path
+    gem 'spring', spring.version
+    require 'spring/binstub'
+  end
+end


### PR DESCRIPTION
Cette PR fait tourner `bundle exec spring binstub`, et commite le résultat.

Avec cette commande, les binstubs utilisent maintenant de [Spring](https://github.com/rails/spring) par défaut. Ça permet d'accélérer grandement le temps de lancement par défaut des commandes usuelles :

- Avant : `bin/rake -T` -> 5.6s
- Après : `bin/rake -T` -> 0.25s

Même améliorations quand on lance `bin/rspec` ou `bin/rails`.

## Motifs

Pourquoi intégrer spring directement dans les binstubs – plutôt que de simplement préfixer manuellement les commandes par `spring` ?

- C'est le fonctionnement par défaut des nouveaux projets Rails 5.0 (ça rapproche donc le projet d'un setup standard de Rails) ;
- Ça permet d'être "rapide par défaut" (plutôt que de prendre 5s dans la tronche à chaque fois qu'on lance les tests, et de devoir connaître la bonne invocation pour rendre le bouzin rapide) ;
- Ça rend le démarrage de `overmind s` plus rapide (vu que le Procfile utilise `bin/rails`, il se met à bénéficier de spring) ;
- C'est ok pour la production (Spring n'est déclaré que dans le Gemfile de développement, donc il ne sera pas utilisé en prod) ;
- C'est désactivable facilement (`DISABLE_SPRING=1 bin/rails`, ou `echo "DISABLE_SPRING=1" >> ~/.bash_profile`).