### PR TITLE
UI fixes

### DIFF
--- a/app/assets/stylesheets/admin_procedures_modal.scss
+++ b/app/assets/stylesheets/admin_procedures_modal.scss
@@ -16,4 +16,9 @@
   .tt-menu {
     width: 300px;
   }
+
+  // Fix the input not being displayed on the same line than the text before
+  .tt-input {
+    vertical-align: initial !important;
+  }
 }

--- a/app/views/shared/dossiers/_edit.html.haml
+++ b/app/views/shared/dossiers/_edit.html.haml
@@ -4,7 +4,7 @@
       Pour vous aider à remplir votre dossier, vous pouvez consulter
       = link_to 'le guide de cette démarche', notice_url(dossier.procedure), { target: '_blank'  }
 
-  %p.thanks Les champs avec une asterisque (*) sont obligatoires.
+  %p.thanks Les champs avec une astérisque (*) sont obligatoires.
 
   - if apercu
     - form_options = { url: '', method: :get, html: { class: 'form', multipart: true } }

--- a/app/views/shared/dossiers/_edit.html.haml
+++ b/app/views/shared/dossiers/_edit.html.haml
@@ -64,6 +64,6 @@
               data: { action: 'submit', disable_with: 'Envoi...' }
 
         - else
-          = f.button 'Modifier le dossier',
+          = f.button 'Enregistrer les modifications du dossier',
             class: 'button send primary',
             data: { action: 'submit', disable_with: 'Envoi...' }


### PR DESCRIPTION
Quelques petites améliorations sur l'interface utilisateur en vrac.

## Corrige l'alignement du slug de l'URL

### Avant

![fix-url-before](https://user-images.githubusercontent.com/179923/41595612-c2122ea0-73c7-11e8-94b9-9ed5c22c51bd.gif)

### Après

![fix-url-after](https://user-images.githubusercontent.com/179923/41595615-c5411a3c-73c7-11e8-948b-614718032d57.gif)

## Améliore le titre du bouton "Enregistrer" sur les brouillons

### Avant

<img width="1090" alt="bouton-avant" src="https://user-images.githubusercontent.com/179923/41595625-d8a49fcc-73c7-11e8-9e54-307f5d8f6b85.png">

### Après

<img width="1084" alt="bouton-apres" src="https://user-images.githubusercontent.com/179923/41595633-e400c8dc-73c7-11e8-8930-1382740f59f3.png">

## Correction d'une coquille

Sur la page d'un formulaire avec des champs obligatoires : `asterisque` → `astérisque`.