### PR TITLE
config: make assets compilation faster in development

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -30,7 +30,7 @@ Rails.application.configure do
   # Debug mode disables concatenation and preprocessing of assets.
   # This option may cause significant delays in view rendering with a large
   # number of complex assets.
-  config.assets.debug = true
+  config.assets.debug = false
 
   # Asset digests allow you to set far-future HTTP expiration dates on all assets,
   # yet still be able to expire them through the digest params.


### PR DESCRIPTION
En développement, la compilation des assets prend un temps dingue sur certaines pages (jusqu'à 20s à chaque rechargement).

Il y a plusieurs manières d'optimiser ça : enlever bootstrap, faire une passe sur les `//- require`, utiliser d'autres backends de compilation, etc.

Mais une bonne manière de gagner du temps est de servir une seule feuille de style concaténant tous les assets, même en développement. On parle d'un gain de temps d'environ x4 sur les grosses pages.

j'ai l'impression qu'il vaut mieux être "rapide par défaut" (quitte à perdre l'individualité des feuilles de style) – et activer le debug au cas-par-cas quand on débogue de la CSS. Ce que fait cette PR.