### PR TITLE
Fix CVE-2018-3760

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -714,7 +714,7 @@ GEM
       activesupport (>= 4.2)
     spring-commands-rspec (1.0.4)
       spring (>= 0.9.1)
-    sprockets (3.7.1)
+    sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.2.1)


### PR DESCRIPTION
https://blog.heroku.com/rails-asset-pipeline-vulnerability