### PR TITLE
spec: only load tasks once

### DIFF
--- a/spec/lib/rake/2018_03_06_clean_html_textareas_spec.rb
+++ b/spec/lib/rake/2018_03_06_clean_html_textareas_spec.rb
@@ -10,7 +10,6 @@ describe '2018_03_06_clean_html_textareas#clean' do
 
   before do
     Timecop.freeze(champ_date) { champ }
-    TPS::Application.load_tasks
     Timecop.freeze(rake_date) { rake_task.invoke }
     champ.reload
   end

--- a/spec/lib/rake/2018_03_29_remove_code_tags_from_mail_templates_spec.rb
+++ b/spec/lib/rake/2018_03_29_remove_code_tags_from_mail_templates_spec.rb
@@ -10,7 +10,6 @@ describe '2018_03_29_remove_code_tags_from_mail_templates#clean' do
   let!(:dirty_without_continuation_mail) { create(:without_continuation_mail, body: "<h1>Salut</h1><br>Voici ton email avec une balise <code>--balise--</code>") }
 
   before do
-    TPS::Application.load_tasks
     rake_task.invoke
     dirty_closed_mail.reload
     dirty_initiated_mail.reload

--- a/spec/lib/rake/2018_05_14_add_annotation_privee_to_procedure_spec.rb
+++ b/spec/lib/rake/2018_05_14_add_annotation_privee_to_procedure_spec.rb
@@ -24,8 +24,6 @@ describe '2018_05_14_add_annotation_privee_to_procedure' do
   let!(:dossier) { Dossier.create(procedure: procedure, user: user, state: 'brouillon') }
   let(:rake_task) { Rake::Task['2018_05_14_add_annotation_privee_to_procedure:add'] }
 
-  before(:all) { TPS::Application.load_tasks }
-
   before do
     ENV['PROCEDURE_ID'] = procedure.id.to_s
     rake_task.invoke

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -69,6 +69,8 @@ end
 
 DatabaseCleaner.strategy = :transaction
 
+TPS::Application.load_tasks
+
 SIADETOKEN = :valid_token if !defined? SIADETOKEN
 
 include Warden::Test::Helpers


### PR DESCRIPTION
Le test `add_annotation_privee_to_procedure_spec.rb` échoue de manière aléatoire chez moi en local.

```shell
$ bin/rspec spec/lib/rake/ --seed 2
Run options:
  include {:focus=>true}
  exclude {:disable=>true}

All examples were filtered out; ignoring {:focus=>true}

Randomized with seed 2
...FF..

Failures:

  1) 2018_05_14_add_annotation_privee_to_procedure should eq 11
     Failure/Error: it { expect(procedure.types_de_champ_private.count).to eq(11) }

       expected: 11
            got: 14

       (compared using ==)
     # ./spec/lib/rake/2018_05_14_add_annotation_privee_to_procedure_spec.rb:38:in `block (2 levels) in <top (required)>'

  2) 2018_05_14_add_annotation_privee_to_procedure should match [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
     Failure/Error: it { expect(dossier.champs_private.includes(:type_de_champ).map(&:order_place).sort).to match((0..10).to_a) }
       expected [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13] to match [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
     # ./spec/lib/rake/2018_05_14_add_annotation_privee_to_procedure_spec.rb:39:in `block (2 levels) in <top (required)>'

Finished in 2.22 seconds (files took 8.54 seconds to load)
7 examples, 2 failures

Failed examples:

rspec ./spec/lib/rake/2018_05_14_add_annotation_privee_to_procedure_spec.rb:38 # 2018_05_14_add_annotation_privee_to_procedure should eq 11
rspec ./spec/lib/rake/2018_05_14_add_annotation_privee_to_procedure_spec.rb:39 # 2018_05_14_add_annotation_privee_to_procedure should match [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
```

J'ai un peu creusé pourquoi : apparemment c'est parce que quand une tâche Rake est chargée plusieurs fois, un seul appel de `task.invoke` va lancer la tâche plusieurs fois. Et effectivement, si une autre spec de task est déjà passée avant, la tâche `add_annotation_privee_to_procedure` est exécutée deux fois, même s'il n'y a qu'un seul test.

Du coup cette PR charge les tâches rakes une seule fois au début des specs, et basta.

```
$ bin/rspec spec/lib/rake --seed 2
Running via Spring preloader in process 4395
Run options:
  include {:focus=>true}
  exclude {:disable=>true}

All examples were filtered out; ignoring {:focus=>true}

Randomized with seed 2
.......

Finished in 1.21 seconds (files took 1.16 seconds to load)
7 examples, 0 failures
```

_NB : à une époque Rails chargeait automatiquement les tâches Rake – puis ils ont arrêté, puis repris, puis apparemment ça change encore dans Rails 5.2. Mais bref, pour l'instant il faut encore le faire manuellement au moins une fois, sinon ça marche pas._