### PR TITLE
Affiche les accompagnants d'une démarche dans le Manager (et vice-versa)

### DIFF
--- a/app/dashboards/gestionnaire_dashboard.rb
+++ b/app/dashboards/gestionnaire_dashboard.rb
@@ -14,6 +14,7 @@ class GestionnaireDashboard < Administrate::BaseDashboard
     updated_at: Field::DateTime,
     current_sign_in_at: Field::DateTime,
     dossiers: Field::HasMany,
+    procedures: Field::HasMany
   }.freeze
 
   # COLLECTION_ATTRIBUTES
@@ -29,6 +30,7 @@ class GestionnaireDashboard < Administrate::BaseDashboard
   # SHOW_PAGE_ATTRIBUTES
   # an array of attributes that will be displayed on the model's show page.
   SHOW_PAGE_ATTRIBUTES = [
+    :procedures,
     :dossiers,
     :id,
     :email,

--- a/app/dashboards/procedure_dashboard.rb
+++ b/app/dashboards/procedure_dashboard.rb
@@ -12,6 +12,7 @@ class ProcedureDashboard < Administrate::BaseDashboard
     types_de_champ: TypesDeChampCollectionField,
     path: ProcedureLinkField,
     dossiers: Field::HasMany,
+    gestionnaires: Field::HasMany,
     administrateur: Field::BelongsTo,
     id: Field::Number,
     libelle: Field::String,
@@ -64,6 +65,7 @@ class ProcedureDashboard < Administrate::BaseDashboard
     :for_individual,
     :individual_with_siret,
     :auto_archive_on,
+    :gestionnaires
   ].freeze
 
   # FORM_ATTRIBUTES


### PR DESCRIPTION
J'ai eu à déboguer un pépin en prod où un accompagnant ne se voyait affecté aucun dossier. Après avoir creusé, il se trouve que c'est un quasi-homonyme qui était affecté comme accompagnant (au lieu de la bonne personne).

Pour éviter d'avoir à creuser la prod dans des cas de ce type, cette PR affiche les gestionnaires d'un projet sur la page "/manager/procedures/:id". Elle affiche également sur la page "/manager/gestionnaire/:id" les projets sur lesquels l'accompagnant est affecté.

(Et aussi je ne connaissais pas `Administrate`, mais ça rox ! 🤘 )