### PR TITLE
Fix design

### DIFF
--- a/app/assets/stylesheets/new_design/common.scss
+++ b/app/assets/stylesheets/new_design/common.scss
@@ -23,12 +23,6 @@ h1 {
   font-weight: bold;
 }
 
-h2 {
-  font-size: 30px;
-  margin-bottom: 15px;
-  border-bottom: 1px solid $border-grey;
-}
-
 strong {
   font-weight: bold;
 }

--- a/app/views/new_administrateur/services/_form.html.haml
+++ b/app/views/new_administrateur/services/_form.html.haml
@@ -16,7 +16,7 @@
 
   = f.select :type_organisme, Service.type_organismes.keys.map { |key| [ I18n.t("type_organisme.#{key}"), key] }
 
-  %h2 Informations de contact
+  %h2.header-section Informations de contact
 
   %p.explication Ces informations seront visibles par les utilisateurs du formulaire.
 


### PR DESCRIPTION
Corrige le rendu des H2 dans le nouveau design.

Un exemple entre autres :
avant :
<img width="808" alt="capture d ecran 2018-06-21 a 12 25 56" src="https://user-images.githubusercontent.com/847942/41718451-4a4306fa-755d-11e8-803f-0b0fe7c1410c.png">
après :
<img width="813" alt="capture d ecran 2018-06-21 a 12 25 04" src="https://user-images.githubusercontent.com/847942/41718457-52fefb82-755d-11e8-946e-8e5241d476df.png">

C'est un fix temporaire, en effet ce serait pas mal d'avoir des styles par défaut pour les balises H1...6 .
Si on le met en place il faut repasser sur les vues existantes pour adapter.