### PR TITLE
Usager : amélioration de la liste des dossiers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,9 @@ gem 'haml-rails'
 # bootstrap saas
 gem 'bootstrap-sass', '~> 3.3.5'
 
+# Automatically set a class on active links
+gem 'active_link_to'
+
 # Pagination
 gem 'kaminari'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,6 +44,9 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.0.3)
+    active_link_to (1.0.5)
+      actionpack
+      addressable
     active_model_serializers (0.10.7)
       actionpack (>= 4.1, < 6)
       activemodel (>= 4.1, < 6)
@@ -785,6 +788,7 @@ PLATFORMS
 
 DEPENDENCIES
   aasm
+  active_link_to
   active_model_serializers
   administrate
   apipie-rails
@@ -877,4 +881,4 @@ DEPENDENCIES
   xray-rails
 
 BUNDLED WITH
-   1.16.1
+   1.16.2

--- a/app/assets/stylesheets/new_design/_colors.scss
+++ b/app/assets/stylesheets/new_design/_colors.scss
@@ -14,3 +14,4 @@ $light-green: lighten($green, 25%);
 $dark-green: darken($green, 20%);
 $orange: #F28900;
 $orange-bg: lighten($orange, 35%);
+$light-yellow: #FFFFDE;

--- a/app/assets/stylesheets/new_design/card.scss
+++ b/app/assets/stylesheets/new_design/card.scss
@@ -6,6 +6,12 @@
   border: 1px solid $border-grey;
   margin-bottom: $default-spacer * 2;
 
+  .card-title {
+    font-weight: bold;
+    font-size: 20px;
+    margin-bottom: $default-spacer * 2;
+  }
+
   &.featured {
     border-top: 8px solid $blue;
 
@@ -14,9 +20,16 @@
     }
   }
 
-  .card-title {
-    font-weight: bold;
-    font-size: 20px;
-    margin-bottom: $default-spacer * 2;
+  &.feedback {
+    max-width: 600px;
+    margin: 30px auto;
+    padding: ($default-spacer * 2) ($default-spacer * 4);
+    font-size: small;
+    border: 1px dashed $border-grey;
+    background: $light-yellow;
+
+    .card-title {
+      margin-bottom: $default-spacer;
+    }
   }
 }

--- a/app/assets/stylesheets/new_design/dossiers_headers.scss
+++ b/app/assets/stylesheets/new_design/dossiers_headers.scss
@@ -1,0 +1,5 @@
+.dossiers-headers {
+  .new-demarche {
+    float: right;
+  }
+}

--- a/app/assets/stylesheets/new_design/dossiers_table.scss
+++ b/app/assets/stylesheets/new_design/dossiers_table.scss
@@ -77,3 +77,7 @@
     padding-right: $default-spacer;
   }
 }
+
+.dossiers-table-empty {
+  text-align: center;
+}

--- a/app/assets/stylesheets/new_design/new_header.scss
+++ b/app/assets/stylesheets/new_design/new_header.scss
@@ -26,7 +26,7 @@ $landing-breakpoint: 1040px;
   margin-right: 4 * $default-spacer;
 
   img {
-    height: 36px;
+    height: 34px;
 
     @media (max-width: $landing-breakpoint) {
       height: 18px;

--- a/app/controllers/new_user/dossiers_controller.rb
+++ b/app/controllers/new_user/dossiers_controller.rb
@@ -1,5 +1,7 @@
 module NewUser
   class DossiersController < UserController
+    helper_method :new_demarche_url
+
     before_action :ensure_ownership!, except: [:index, :modifier, :update]
     before_action :ensure_ownership_or_invitation!, only: [:modifier, :update]
     before_action :ensure_dossier_can_be_updated, only: [:update_identite, :update]
@@ -110,6 +112,10 @@ module NewUser
         flash.notice = "L'instruction de votre dossier a commencé, il n'est plus possible de supprimer votre dossier. Si vous souhaitez annuler l'instruction contactez votre administration par la messagerie de votre dossier."
         redirect_to users_dossier_path(dossier)
       end
+    end
+
+    def new_demarche_url
+      "https://doc.demarches-simplifiees.fr/listes-des-demarches"
     end
 
     private

--- a/app/views/layouts/_new_header.haml
+++ b/app/views/layouts/_new_header.haml
@@ -36,7 +36,7 @@
       - if nav_bar_profile == :user
         %ul.header-tabs
           %li
-            = link_to "Mes dossiers", users_dossiers_path, class: 'tab-link'
+            = active_link_to "Dossiers", dossiers_path, active: :inclusive, class: 'tab-link'
 
     %ul.header-right-content
       - if nav_bar_profile == :gestionnaire && gestionnaire_signed_in?

--- a/app/views/layouts/_new_header.haml
+++ b/app/views/layouts/_new_header.haml
@@ -13,10 +13,10 @@
         %ul.header-tabs
           - if current_gestionnaire.visible_procedures.count > 0
             %li
-              = link_to "Procédures", gestionnaire_procedures_path, class: (controller_name != 'avis') ? "tab-link active" : 'tab-link'
+              = active_link_to "Procédures", gestionnaire_procedures_path, active: :inclusive, class: 'tab-link'
           - if current_gestionnaire.avis.count > 0
             %li
-              = link_to gestionnaire_avis_index_path, class: (controller_name == 'avis') ? "tab-link active" : 'tab-link' do
+              = active_link_to gestionnaire_avis_index_path, active: :inclusive, class: 'tab-link' do
                 Avis
                 - avis_counter = current_gestionnaire.avis.without_answer.count
                 - if avis_counter > 0

--- a/app/views/new_user/dossiers/index.html.haml
+++ b/app/views/new_user/dossiers/index.html.haml
@@ -14,31 +14,34 @@
             dossiers invités
 
 .container
-  %table.table.dossiers-table.hoverable
-    %thead
-      %tr
-        %th.notification-col
-        %th.number-col Nº dossier
-        %th Procédure
-        %th.status-col Statut
-        %th.updated-at-col Mis à jour
-      %tbody
-        - @dossiers.each do |dossier|
-          %tr
-            %td.folder-col
-              = link_to(users_dossier_recapitulatif_path(dossier), class: 'cell-link') do
-                %span.icon.folder
-            %td.number-col
-              = link_to(users_dossier_recapitulatif_path(dossier), class: 'cell-link') do
-                = dossier.id
-            %td
-              = link_to(users_dossier_recapitulatif_path(dossier), class: 'cell-link') do
-                = dossier.procedure.libelle
-            %td.status-col
-              = link_to(users_dossier_recapitulatif_path(dossier), class: 'cell-link') do
-                = render partial: 'shared/dossiers/status', locals: { dossier: dossier }
-            %td.updated-at-col
-              = link_to(users_dossier_recapitulatif_path(dossier), class: 'cell-link') do
-                = dossier.updated_at.localtime.strftime("%d/%m/%Y")
+  - if @dossiers.present?
+    %table.table.dossiers-table.hoverable
+      %thead
+        %tr
+          %th.notification-col
+          %th.number-col Nº dossier
+          %th Procédure
+          %th.status-col Statut
+          %th.updated-at-col Mis à jour
+        %tbody
+          - @dossiers.each do |dossier|
+            %tr
+              %td.folder-col
+                = link_to(users_dossier_recapitulatif_path(dossier), class: 'cell-link') do
+                  %span.icon.folder
+              %td.number-col
+                = link_to(users_dossier_recapitulatif_path(dossier), class: 'cell-link') do
+                  = dossier.id
+              %td
+                = link_to(users_dossier_recapitulatif_path(dossier), class: 'cell-link') do
+                  = dossier.procedure.libelle
+              %td.status-col
+                = link_to(users_dossier_recapitulatif_path(dossier), class: 'cell-link') do
+                  = render partial: 'shared/dossiers/status', locals: { dossier: dossier }
+              %td.updated-at-col
+                = link_to(users_dossier_recapitulatif_path(dossier), class: 'cell-link') do
+                  = dossier.updated_at.localtime.strftime("%d/%m/%Y")
+    = paginate(@dossiers)
 
-  = paginate(@dossiers)
+  - else
+    %h2.empty-text Aucun dossier.

--- a/app/views/new_user/dossiers/index.html.haml
+++ b/app/views/new_user/dossiers/index.html.haml
@@ -1,13 +1,14 @@
 .dossiers-headers.sub-header
   .container
-    %h1.page-title Les dossiers
+    - if @dossiers_invites.count == 0
+      %h1.page-title Mes dossiers
 
-    %ul.tabs
-      - if @user_dossiers.count > 0
+    - else
+      %h1.page-title Dossiers
+      %ul.tabs
         %li{ class: (@current_tab == 'mes-dossiers') ? 'active' : nil }>
           = link_to(dossiers_path(current_tab: 'mes-dossiers')) do
             mes dossiers
-      - if @dossiers_invites.count > 0
         %li{ class: (@current_tab == 'dossiers-invites') ? 'active' : nil }>
           = link_to(dossiers_path(current_tab: 'dossiers-invites')) do
             dossiers invités

--- a/app/views/new_user/dossiers/index.html.haml
+++ b/app/views/new_user/dossiers/index.html.haml
@@ -26,19 +26,19 @@
         - @dossiers.each do |dossier|
           %tr
             %td.folder-col
-              = link_to(modifier_dossier_path(dossier), class: 'cell-link') do
+              = link_to(users_dossier_recapitulatif_path(dossier), class: 'cell-link') do
                 %span.icon.folder
             %td.number-col
-              = link_to(modifier_dossier_path(dossier), class: 'cell-link') do
+              = link_to(users_dossier_recapitulatif_path(dossier), class: 'cell-link') do
                 = dossier.id
             %td
-              = link_to(modifier_dossier_path(dossier), class: 'cell-link') do
+              = link_to(users_dossier_recapitulatif_path(dossier), class: 'cell-link') do
                 = dossier.procedure.libelle
             %td.status-col
-              = link_to(modifier_dossier_path(dossier), class: 'cell-link') do
+              = link_to(users_dossier_recapitulatif_path(dossier), class: 'cell-link') do
                 = render partial: 'shared/dossiers/status', locals: { dossier: dossier }
             %td.updated-at-col
-              = link_to(modifier_dossier_path(dossier), class: 'cell-link') do
+              = link_to(users_dossier_recapitulatif_path(dossier), class: 'cell-link') do
                 = dossier.updated_at.localtime.strftime("%d/%m/%Y")
 
   = paginate(@dossiers)

--- a/app/views/new_user/dossiers/index.html.haml
+++ b/app/views/new_user/dossiers/index.html.haml
@@ -1,5 +1,7 @@
 .dossiers-headers.sub-header
   .container
+    = link_to "Commencer une nouvelle démarche", new_demarche_url, class: "button secondary new-demarche"
+
     - if @dossiers_invites.count == 0
       %h1.page-title Mes dossiers
 
@@ -52,4 +54,6 @@
     = paginate(@dossiers)
 
   - else
-    %h2.empty-text Aucun dossier.
+    .dossiers-table-empty
+      %h2.empty-text Aucun dossier.
+      = link_to "Commencer une nouvelle démarche", new_demarche_url, class: "button primary"

--- a/app/views/new_user/dossiers/index.html.haml
+++ b/app/views/new_user/dossiers/index.html.haml
@@ -15,6 +15,14 @@
 
 .container
   - if @dossiers.present?
+    - if @dossiers.total_pages >= 2
+      .card.feedback
+        .card-title Nous avons redesigné la liste des dossiers.
+        %p
+          Une suggestion pour améliorer cette page&nbsp;? Votre avis nous intéresse&nbsp;! Écrivez-nous à
+          = mail_to CONTACT_EMAIL, CONTACT_EMAIL, subject: "Amélioration de la liste des dossiers"
+          \.
+
     %table.table.dossiers-table.hoverable
       %thead
         %tr

--- a/app/views/root/patron.html.haml
+++ b/app/views/root/patron.html.haml
@@ -84,6 +84,11 @@
         Titre de la carte mise en avant
       Et voici le contenu de la carte
 
+    .card.feedback
+      .card-title
+        Titre de la carte pour demander un avis
+      Utilisez cette carte pour informer d’une nouveauté produit ou demander l’avis des utilisateurs.
+
     %h1 Table
 
     %table.table

--- a/spec/views/layouts/_new_header_spec.rb
+++ b/spec/views/layouts/_new_header_spec.rb
@@ -15,6 +15,7 @@ describe 'layouts/_new_header.html.haml', type: :view do
       let(:profile) { :user }
 
       it { is_expected.to have_css("a.header-logo[href=\"#{users_dossiers_path}\"]") }
+      it { is_expected.to have_link("Dossiers", href: dossiers_path) }
     end
 
     context 'when rendering for gestionnaire' do

--- a/spec/views/new_user/dossiers/index.html.haml_spec.rb
+++ b/spec/views/new_user/dossiers/index.html.haml_spec.rb
@@ -18,6 +18,13 @@ describe 'new_user/dossiers/index.html.haml', type: :view do
     expect(rendered).to have_selector('.dossiers-table tbody tr', count: 2)
   end
 
+  it 'affiche les informations des dossiers' do
+    dossier = user_dossiers.first
+    expect(rendered).to have_text(dossier.id)
+    expect(rendered).to have_text(dossier.procedure.libelle)
+    expect(rendered).to have_link(dossier.id, href: users_dossier_recapitulatif_path(dossier))
+  end
+
   context 'quand il n’y a pas de dossiers invités' do
     let(:dossiers_invites) { [] }
 

--- a/spec/views/new_user/dossiers/index.html.haml_spec.rb
+++ b/spec/views/new_user/dossiers/index.html.haml_spec.rb
@@ -7,6 +7,7 @@ describe 'new_user/dossiers/index.html.haml', type: :view do
   let(:current_tab) { 'mes-dossiers' }
 
   before do
+    allow(view).to receive(:new_demarche_url).and_return('#')
     assign(:user_dossiers, Kaminari.paginate_array(user_dossiers).page(1))
     assign(:dossiers_invites, Kaminari.paginate_array(dossiers_invites).page(1))
     assign(:dossiers, Kaminari.paginate_array(user_dossiers).page(1))

--- a/spec/views/new_user/dossiers/index.html.haml_spec.rb
+++ b/spec/views/new_user/dossiers/index.html.haml_spec.rb
@@ -1,0 +1,46 @@
+require 'spec_helper'
+
+describe 'new_user/dossiers/index.html.haml', type: :view do
+  let(:user) { create(:user) }
+  let(:user_dossiers) { create_list(:dossier, 2, state: 'brouillon', user: user) }
+  let(:dossiers_invites) { [] }
+  let(:current_tab) { 'mes-dossiers' }
+
+  before do
+    assign(:user_dossiers, Kaminari.paginate_array(user_dossiers).page(1))
+    assign(:dossiers_invites, Kaminari.paginate_array(dossiers_invites).page(1))
+    assign(:dossiers, Kaminari.paginate_array(user_dossiers).page(1))
+    assign(:current_tab, current_tab)
+    render
+  end
+
+  it 'affiche la liste des dossiers' do
+    expect(rendered).to have_selector('.dossiers-table tbody tr', count: 2)
+  end
+
+  context 'quand il n’y a pas de dossiers invités' do
+    let(:dossiers_invites) { [] }
+
+    it 'affiche un titre adapté' do
+      expect(rendered).to have_selector('h1', text: 'Mes dossiers')
+    end
+
+    it 'n’affiche pas la barre d’onglets' do
+      expect(rendered).not_to have_selector('ul.tabs')
+    end
+  end
+
+  context 'avec des dossiers invités' do
+    let(:dossiers_invites) { create_list(:dossier, 1) }
+
+    it 'affiche un titre adapté' do
+      expect(rendered).to have_selector('h1', text: 'Dossiers')
+    end
+
+    it 'affiche la barre d’onglets' do
+      expect(rendered).to have_selector('ul.tabs')
+      expect(rendered).to have_selector('ul.tabs li', count: 2)
+      expect(rendered).to have_selector('ul.tabs li.active', count: 1)
+    end
+  end
+end

--- a/spec/views/new_user/dossiers/index.html.haml_spec.rb
+++ b/spec/views/new_user/dossiers/index.html.haml_spec.rb
@@ -25,6 +25,19 @@ describe 'new_user/dossiers/index.html.haml', type: :view do
     expect(rendered).to have_link(dossier.id, href: users_dossier_recapitulatif_path(dossier))
   end
 
+  context 'quand il n’y a aucun dossier' do
+    let(:user_dossiers)    { [] }
+    let(:dossiers_invites) { [] }
+
+    it 'n’affiche pas la table' do
+      expect(rendered).not_to have_selector('.dossiers-table')
+    end
+
+    it 'affiche un message' do
+      expect(rendered).to have_text('Aucun dossier')
+    end
+  end
+
   context 'quand il n’y a pas de dossiers invités' do
     let(:dossiers_invites) { [] }
 
@@ -37,7 +50,7 @@ describe 'new_user/dossiers/index.html.haml', type: :view do
     end
   end
 
-  context 'avec des dossiers invités' do
+  context 'quand il y a des dossiers invités' do
     let(:dossiers_invites) { create_list(:dossier, 1) }
 
     it 'affiche un titre adapté' do

--- a/spec/views/users/dossiers/index_html.haml_spec.rb
+++ b/spec/views/users/dossiers/index_html.haml_spec.rb
@@ -27,14 +27,16 @@ describe 'users/dossiers/index.html.haml', type: :view do
 
     subject { rendered }
 
-    describe 'columns' do
-      it { is_expected.to have_content(decorate_dossier_at_check.id) }
-      it { is_expected.to have_content(decorate_dossier_at_check.procedure.libelle) }
-      it { is_expected.to have_content(decorate_dossier_at_check.display_state) }
-      it { is_expected.to have_content(decorate_dossier_at_check.last_update) }
+    it 'displays the total count' do
+      expect(dossiers_to_display.count).to eq total_dossiers
     end
 
-    it { expect(dossiers_to_display.count).to eq total_dossiers }
+    it 'displays data in columns' do
+      expect(rendered).to have_content(decorate_dossier_at_check.id)
+      expect(rendered).to have_content(decorate_dossier_at_check.procedure.libelle)
+      expect(rendered).to have_content(decorate_dossier_at_check.display_state)
+      expect(rendered).to have_content(decorate_dossier_at_check.last_update)
+    end
   end
 
   describe 'on tab en construction' do


### PR DESCRIPTION
Cette première PR implémente la première partie de #1623.

Elle améliore divers aspects du fonctionnement de la nouvelle liste des dossiers pour l'utilisateur (qui existait déjà, mais n'était pas encore câblée) :

- Cliquer sur un dossier dans la liste redirige vers la page individuelle d'un dossier,
- Simplification de l'affichage quand il n'y a pas de dossiers invités,
- Correction des liens dans le header modernisé,
- Ajout d'un état "Aucun dossier",
- Divers petits correctifs.

La PR suivante activera l'utilisation de cette page, en remplaçant tous les liens vers l'ancienne liste par des liens vers la nouvelle liste.

## Simplification de l'affichage quand il n'y a pas de dossiers invités

Petit détail : avec cette PR, quand il n'y a pas de dossiers invités (ce qui est sans doute le cas le plus courant pour la majorité des utilisateurs), on évite d'afficher un onglet qui ne sert à rien.

### Sans dossiers invité

<img width="1104" alt="capture d ecran 2018-06-25 a 14 29 40" src="https://user-images.githubusercontent.com/179923/41850591-5dfac0a4-7885-11e8-9d3e-0a3cdf1cdd15.png">

### Avec des dossiers invités

<img width="1108" alt="capture d ecran 2018-06-25 a 14 29 12" src="https://user-images.githubusercontent.com/179923/41850594-64159ea0-7885-11e8-89ca-3b1e37734190.png">
