### PR TITLE
dossiers: move link back to the old UI

### DIFF
--- a/app/views/layouts/_new_header.haml
+++ b/app/views/layouts/_new_header.haml
@@ -36,7 +36,7 @@
       - if nav_bar_profile == :user
         %ul.header-tabs
           %li
-            = active_link_to "Dossiers", dossiers_path, active: :inclusive, class: 'tab-link'
+            = active_link_to "Dossiers", users_dossiers_path, active: :inclusive, class: 'tab-link'
 
     %ul.header-right-content
       - if nav_bar_profile == :gestionnaire && gestionnaire_signed_in?

--- a/spec/views/layouts/_new_header_spec.rb
+++ b/spec/views/layouts/_new_header_spec.rb
@@ -15,7 +15,7 @@ describe 'layouts/_new_header.html.haml', type: :view do
       let(:profile) { :user }
 
       it { is_expected.to have_css("a.header-logo[href=\"#{users_dossiers_path}\"]") }
-      it { is_expected.to have_link("Dossiers", href: dossiers_path) }
+      it { is_expected.to have_link("Dossiers", href: users_dossiers_path) }
     end
 
     context 'when rendering for gestionnaire' do


### PR DESCRIPTION
Il était possible de cliquer sur ce lien depuis le formulaire, et d'arriver sur la nouvelle liste des dossiers avant qu'elle ne soit prête.

cc @LeSim