### PR TITLE
Dossier : pas de Javascript pour l'action d'envoi

### DIFF
--- a/app/assets/javascripts/new_design/direct_uploads.js
+++ b/app/assets/javascripts/new_design/direct_uploads.js
@@ -43,15 +43,3 @@ addEventListener("direct-upload:end", function (event) {
 
   element.classList.add("direct-upload--complete");
 });
-
-addEventListener('load', function() {
-    var submitButtons = document.querySelectorAll('form button[type=submit][data-action]');
-    var hiddenInput = document.querySelector('form input[type=hidden][name=submit_action]');
-    submitButtons = [].slice.call(submitButtons);
-
-    submitButtons.forEach(function(button) {
-      button.addEventListener('click', function() {
-        hiddenInput.value = button.getAttribute('data-action');
-      });
-    });
-});

--- a/app/views/shared/dossiers/_edit.html.haml
+++ b/app/views/shared/dossiers/_edit.html.haml
@@ -50,20 +50,24 @@
 
     - if !apercu
       .send-wrapper
-        = hidden_field_tag 'submit_action', 'draft'
-
         - if dossier.brouillon?
           = f.button 'Enregistrer le brouillon',
             formnovalidate: true,
             class: 'button send',
-            data: { action: 'draft', disable_with: 'Envoi...' }
+            name: 'submit_action',
+            value: 'draft',
+            data: { disable_with: 'Envoi...' }
 
           - if current_user.owns?(dossier)
             = f.button 'Soumettre le dossier',
               class: 'button send primary',
-              data: { action: 'submit', disable_with: 'Envoi...' }
+              name: 'submit_action',
+              value: 'submit',
+              data: { disable_with: 'Envoi...' }
 
         - else
           = f.button 'Enregistrer les modifications du dossier',
             class: 'button send primary',
-            data: { action: 'submit', disable_with: 'Envoi...' }
+            name: 'submit_action',
+            value: 'submit',
+            data: { disable_with: 'Envoi...' }


### PR DESCRIPTION
Aujourd'hui, sur la page d'un dossier, on utilise un bout de Javascript pour déterminer quel bouton d'envoi a été cliqué ("Enregistrer le brouillon" ou "Soumettre le dossier").

Ça cause un bug d'interaction avec Turbolinks, où la mauvaise action est parfois envoyée quand on navigue d'une page à l'autre. Exemple :

- Commencer une nouvelle démarche, sans la sauvegarder,
- Cliquer sur l'onglet "Dossiers" pour naviguer jusqu'à la liste des dossiers,
- Cliquer sur le dossier en brouillon pour y revenir,
- Cliquer sur "Soumettre le dossier".

La page affiche alors "Le brouillon a été enregistré", au lieu de soumettre le formulaire.

Avant le bug n'apparaissait pas, parce que le changement de design forçait un rechargement complet de la page. Mais maintenant que le design est cohérent, la page est juste mise à jour avec Turbolinks, le Javascript s'emmêle les pinceaux, et envoie la mauvaise action. 

Ça tombe bien, parce qu'en fait y'a pas besoin de JS pour faire ça : du HTML suffit largement. On met un `name` et un `value` sur les boutons d'envoi, et ça envoie la bonne valeur dans le formulaire. Pas besoin d'input caché.

Et au passage, ça résout le bug en question.