### PR TITLE
specs: automatically save a screenshot of failing integration tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -124,19 +124,23 @@ gem "administrate"
 gem 'rack-mini-profiler'
 
 group :test do
-  gem 'capybara'
   gem 'launchy'
   gem 'factory_bot'
   gem 'database_cleaner'
   gem 'webmock'
   gem 'shoulda-matchers', require: false
-  gem 'capybara-selenium'
   gem 'timecop'
   gem 'guard'
   gem 'guard-rspec', require: false
   gem 'guard-livereload', require: false
   gem 'vcr'
   gem 'rails-controller-testing'
+
+  # Integration testing
+  gem 'capybara'
+  gem 'capybara-selenium'
+  # Save a dump of the page when an integration test fails
+  gem 'capybara-screenshot'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -118,6 +118,9 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (>= 2.0, < 4.0)
+    capybara-screenshot (1.0.21)
+      capybara (>= 1.0, < 4)
+      launchy
     capybara-selenium (0.0.6)
       capybara
       selenium-webdriver
@@ -798,6 +801,7 @@ DEPENDENCIES
   browser
   byebug
   capybara
+  capybara-screenshot
   capybara-selenium
   carrierwave
   carrierwave-i18n

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,6 +22,7 @@ ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../config/environment', __dir__)
 require 'rspec/rails'
 require 'capybara/rspec'
+require 'capybara-screenshot/rspec'
 require 'database_cleaner'
 require 'webmock/rspec'
 require 'shoulda-matchers'
@@ -49,6 +50,15 @@ end
 ActiveSupport::Deprecation.silenced = true
 
 Capybara.default_max_wait_time = 1
+
+# Save a snapshot of the HTML page when an integration test fails
+Capybara::Screenshot.autosave_on_failure = true
+# Keep only the screenshots generated from the last failing test suite
+Capybara::Screenshot.prune_strategy = :keep_last_run
+# Tell Capybara::Screenshot how to take screenshots when using the headless_chrome driver
+Capybara::Screenshot.register_driver :headless_chrome do |driver, path|
+  driver.browser.save_screenshot(path)
+end
 
 # Requires supporting ruby files with custom matchers and macros, etc,
 # in spec/support/ and its subdirectories.


### PR DESCRIPTION
Le chemin vers le screenshot est affiché avec le test qui échoue.

```shell
$ bin/rspec spec/features --example "save an incomplete dossier as draft"
Running via Spring preloader in process 22648
Run options: include {:full_description=>/save\ an\ incomplete\ dossier\ as\ draft/}

Randomized with seed 60745
F  HTML screenshot: file:///Users/beta.gouv.fr/Programmes/tps/tmp/capybara/screenshot_2018-07-02-12-29-31.229.html
  Image screenshot: file:///Users/beta.gouv.fr/Programmes/tps/tmp/capybara/screenshot_2018-07-02-12-29-31.229.png


Failures:

  1) The user save an incomplete dossier as draft but cannot not submit it
     Failure/Error: expect(user_dossier.reload.en_construction?).to be(true)

       expected true
            got false
     # ./spec/features/new_user/dossier_spec.rb:110:in `block (2 levels) in <top (required)>'
     # -e:1:in `<main>'

Finished in 8.66 seconds (files took 1.58 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/features/new_user/dossier_spec.rb:91 # The user save an incomplete dossier as draft but cannot not submit it
```