### PR TITLE
pipedrive: fix deals when no deals are returned

### DIFF
--- a/app/lib/pipedrive/deal_adapter.rb
+++ b/app/lib/pipedrive/deal_adapter.rb
@@ -22,8 +22,8 @@ class Pipedrive::DealAdapter
   end
 
   def self.get_deals_ids_for_person(person_id)
-    Pipedrive::API.get_deals_for_person(person_id)
-      .map { |datum| datum['id'] }
+    deals = Pipedrive::API.get_deals_for_person(person_id) || []
+    deals.map { |datum| datum['id'] }
   end
 
   def self.update_deal_owner_and_stage(deal_id, owner_id, stage_id)

--- a/spec/lib/pipedrive/deal_adapter_spec.rb
+++ b/spec/lib/pipedrive/deal_adapter_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+describe Pipedrive::DealAdapter do
+  let(:url) { PIPEDRIVE_API_URL }
+  let(:status) { 200 }
+  let(:body) { '{}' }
+
+  before do
+    stub_request(:get, url)
+      .to_return(status: status, body: body)
+  end
+
+  describe ".get_deals_ids_for_person" do
+    let(:url) { %r{/persons/1/deals\?*} }
+    subject { Pipedrive::DealAdapter.get_deals_ids_for_person('1') }
+
+    context "with valid data" do
+      let(:body) { '{ "success": true, "data": [ { "id": 34 }, { "id": 35 } ] }' }
+      it { is_expected.to eq [34, 35] }
+    end
+
+    context "when no data are returned" do
+      let(:body) { '{ "success": true, "data": null }' }
+      it { is_expected.to eq [] }
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -72,6 +72,7 @@ DatabaseCleaner.strategy = :transaction
 TPS::Application.load_tasks
 
 SIADETOKEN = :valid_token if !defined? SIADETOKEN
+PIPEDRIVE_TOKEN = :pipedrive_test_token if !defined? PIPEDRIVE_TOKEN
 
 include Warden::Test::Helpers
 


### PR DESCRIPTION
Fix https://sentry.apientreprise.fr/apientreprise/tps/issues/2913/ : "app/lib/pipedrive/deal_adapter.rb in get_deals_ids_for_person: undefined method `map' for nil:NilClass".

Effectivement, quand il n'y a pas de deals, l'API de Pipedrive renvoie un `data: null` :

```json
{
    "success": true,
    "data": null,
    "additional_data": {
        "pagination": {
            "start": 0,
            "limit": 100,
            "more_items_in_collection": false
        }
    }
}
```