### PR TITLE
Groupe les procédures clonables par organisation

### DIFF
--- a/app/controllers/admin/procedures_controller.rb
+++ b/app/controllers/admin/procedures_controller.rb
@@ -186,8 +186,8 @@ class Admin::ProceduresController < AdminController
 
     @grouped_procedures = Procedure
       .where(id: significant_procedure_ids)
-      .group_by(&:administrateur)
-      .sort_by { |a, _| a.created_at }
+      .group_by(&:organisation_name)
+      .sort_by { |_, procedures| procedures.first.created_at }
   end
 
   def active_class

--- a/app/controllers/admin/procedures_controller.rb
+++ b/app/controllers/admin/procedures_controller.rb
@@ -185,6 +185,7 @@ class Admin::ProceduresController < AdminController
       .pluck('procedures.id')
 
     @grouped_procedures = Procedure
+      .includes(:administrateur, :service)
       .where(id: significant_procedure_ids)
       .group_by(&:organisation_name)
       .sort_by { |_, procedures| procedures.first.created_at }

--- a/app/controllers/admin/procedures_controller.rb
+++ b/app/controllers/admin/procedures_controller.rb
@@ -174,16 +174,18 @@ class Admin::ProceduresController < AdminController
     redirect_to admin_procedures_path
   end
 
+  SIGNIFICANT_DOSSIERS_THRESHOLD = 30
+
   def new_from_existing
-    procedures_with_more_than_30_dossiers_ids = Procedure
+    significant_procedure_ids = Procedure
       .publiees_ou_archivees
       .joins(:dossiers)
       .group("procedures.id")
-      .having("count(dossiers.id) > ?", 30)
+      .having("count(dossiers.id) >= ?", SIGNIFICANT_DOSSIERS_THRESHOLD)
       .pluck('procedures.id')
 
     @grouped_procedures = Procedure
-      .where(id: procedures_with_more_than_30_dossiers_ids)
+      .where(id: significant_procedure_ids)
       .group_by(&:administrateur)
       .sort_by { |a, _| a.created_at }
   end

--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -152,6 +152,10 @@ class Procedure < ApplicationRecord
     libelle.parameterize.first(50)
   end
 
+  def organisation_name
+    service&.nom || organisation
+  end
+
   def types_de_champ_ordered
     types_de_champ.order(:order_place)
   end

--- a/app/views/admin/procedures/new_from_existing.html.haml
+++ b/app/views/admin/procedures/new_from_existing.html.haml
@@ -12,7 +12,7 @@
     %br
     - @grouped_procedures.each do |_, procedures|
       %b
-        = procedures.first.organisation
+        = procedures.first.organisation_name
       %table{ style: 'margin-bottom: 40px;' }
         - procedures.sort_by(&:id).each do |procedure|
           %tr{ style: 'height: 36px;' }

--- a/spec/controllers/admin/procedures_controller_spec.rb
+++ b/spec/controllers/admin/procedures_controller_spec.rb
@@ -553,6 +553,20 @@ describe Admin::ProceduresController, type: :controller do
         expect(response_procedures).not_to include(large_draft_procedure)
       end
     end
+
+    describe 'grouping' do
+      let(:service_1) { create(:service, nom: 'DDT des Vosges') }
+      let(:service_2) { create(:service, nom: 'DDT du Loiret') }
+      let!(:procedure_with_service_1)  { create(:procedure_with_dossiers, :published, organisation: nil, service: service_1, dossiers_count: 2) }
+      let!(:procedure_with_service_2)  { create(:procedure_with_dossiers, :published, organisation: nil, service: service_2, dossiers_count: 2) }
+      let!(:procedure_without_service) { create(:procedure_with_dossiers, :published, organisation: 'DDT du Loiret', dossiers_count: 2) }
+
+      it 'groups procedures with services as well as procedures with organisations' do
+        expect(grouped_procedures.length).to eq 2
+        expect(grouped_procedures.find{ |o, p| o == 'DDT des Vosges' }.last).to contain_exactly(procedure_with_service_1)
+        expect(grouped_procedures.find{ |o, p| o == 'DDT du Loiret'  }.last).to contain_exactly(procedure_with_service_2, procedure_without_service)
+      end
+    end
   end
 
   describe 'GET #path_list' do

--- a/spec/factories/procedure.rb
+++ b/spec/factories/procedure.rb
@@ -12,6 +12,16 @@ FactoryBot.define do
     duree_conservation_dossiers_dans_ds 3
     duree_conservation_dossiers_hors_ds 6
 
+    factory :procedure_with_dossiers do
+      transient do
+        dossiers_count 1
+      end
+
+      after(:build) do |procedure, _evaluator|
+        procedure.dossiers << create_list(:dossier, _evaluator.dossiers_count, procedure: procedure)
+      end
+    end
+
     after(:build) do |procedure, _evaluator|
       if procedure.module_api_carto.nil?
         module_api_carto = create(:module_api_carto)

--- a/spec/models/procedure_spec.rb
+++ b/spec/models/procedure_spec.rb
@@ -735,6 +735,19 @@ describe Procedure do
     it { expect(Champ.count).to eq(0) }
   end
 
+  describe "#organisation_name" do
+    subject { procedure.organisation_name }
+    context 'when the procedure has a service (and no organization)' do
+      let(:procedure) { create(:procedure, :with_service, organisation: nil) }
+      it { is_expected.to eq procedure.service.nom }
+    end
+
+    context 'when the procedure has an organization (and no service)' do
+      let(:procedure) { create(:procedure, organisation: 'DDT des Vosges', service: nil) }
+      it { is_expected.to eq procedure.organisation }
+    end
+  end
+
   describe '#juridique_required' do
     it 'automatically jumps to true once cadre_juridique or deliberation have been set' do
       p = create(


### PR DESCRIPTION
Cette PR groupe les procédures affichés sur la page `/admin/procedures/new_from_existing` par `organisation`. Elle rajoute également des tests à ce code.

Auparavant c'était visuellement le cas, mais en réalité les procédures étaient groupées par `administrator_id`. 

Voir #2197 pour le détail du problème et la solution.