### PR TITLE
Améliore la page /admin/gestionnaires

### DIFF
--- a/app/views/admin/gestionnaires/index.html.haml
+++ b/app/views/admin/gestionnaires/index.html.haml
@@ -1,8 +1,17 @@
-%h1 Gestion des accompagnateurs
-%br
+%h1 Accompagnateurs disponibles
+
+%p
+  Cette page vous permet de gérer la liste des accompagnateurs disponibles pour être affectés à une procédure.
+
+%p{ style: 'font-style: italic' }
+  N.B. : cette page ne concerne que la liste des personnes disponibles. Si vous souhaitez affecter ou enlever un accompagnateur d'une procédure particulière,
+  utilisez plutôt la
+  = link_to "page de la procédure", admin_procedures_path
+  concernée.
 
 .row
   .col-xs-4
+
     = smart_listing_render :gestionnaires
   .col-xs-1
     &nbsp;


### PR DESCRIPTION
Rajoute un texte explicatif sur le rôle de la page `/admin/gestionnaires`. Le fonctionnement de cette page n'était clair pour personne, pas même pour les développeurs :)

## Avant

![screenshot_2018-07-04 demarches-simplifiees fr 1](https://user-images.githubusercontent.com/179923/42269546-b2a3d898-7f7e-11e8-89e8-aa96e5d7c7e3.png)

## Après

![screenshot_2018-07-04 demarches-simplifiees fr](https://user-images.githubusercontent.com/179923/42269552-b801118e-7f7e-11e8-88b1-582dfd4f8ec5.png)

Fix #2187