### PR TITLE
Temporary fix to allow users to download files with extensions

### DIFF
--- a/app/views/shared/champs/piece_justificative/_pj_link.html.haml
+++ b/app/views/shared/champs/piece_justificative/_pj_link.html.haml
@@ -1,7 +1,8 @@
 - pj = champ.piece_justificative_file
 - if champ.virus_scan.present?
   - if champ.virus_scan.safe?
-    = link_to pj.filename.to_s, url_for(pj), target: '_blank'
+    #FIXME : use url_for(pj) and remove download attribute when Riak content_disposition bug is solved https://github.com/betagouv/tps/issues/2180
+    = link_to pj.filename.to_s, pj.service_url(expires_in: 1.hour), target: '_blank', download: pj.filename.to_s
   - else
     = pj.filename.to_s
     - if champ.virus_scan.pending?


### PR DESCRIPTION
Le but de cette PR est d'utiliser l'attribut `download` sur les liens de téléchargement de PJ pour forcer le nom du fichier télécharger.
Dans l'état actuel cela ne suffisait pas car le lien derrière `url_for` effectuait un redirect vers le service de stockage et l'attribut download ne fonctionnait plus. Pour contrer ce comportement on pointe directement sur le service de stockage.

Side effect : le lien expire au bout d'une heure.