### PR TITLE
Sépare les paragraphes dans les descriptions des champs

### DIFF
--- a/app/assets/stylesheets/new_design/forms.scss
+++ b/app/assets/stylesheets/new_design/forms.scss
@@ -25,6 +25,10 @@
       @include notice-text-style;
       display: block;
       margin-top: $default-spacer;
+
+      p {
+        margin-bottom: $default-spacer;
+      }
     }
 
     &.required {
@@ -249,7 +253,10 @@
   .explication {
     background-color: $light-grey;
     padding: $default-padding;
-    margin-bottom: 2 * $default-padding;
+
+    p:not(:last-child) {
+      margin-bottom: $default-padding;
+    }
   }
 
   .send-wrapper {

--- a/app/assets/stylesheets/new_design/forms.scss
+++ b/app/assets/stylesheets/new_design/forms.scss
@@ -251,8 +251,9 @@
   }
 
   .explication {
-    background-color: $light-grey;
+    margin-bottom: 2 * $default-padding;
     padding: $default-padding;
+    background-color: $light-grey;
 
     p:not(:last-child) {
       margin-bottom: $default-padding;


### PR DESCRIPTION
## Avant

<img width="745" alt="capture d ecran 2018-07-09 a 18 21 21" src="https://user-images.githubusercontent.com/179923/42462927-fca87e7e-83a4-11e8-8e2c-bd14374b004f.png">

## Après

<img width="748" alt="capture d ecran 2018-07-09 a 18 19 04" src="https://user-images.githubusercontent.com/179923/42462930-ff9e33f8-83a4-11e8-98e9-9090eacd0753.png">

Fix #2228 (/cc @clemenceleurent)