### PR TITLE
Revert "Temporary fix to allow users to download files with extensions"

### DIFF
--- a/app/views/shared/champs/piece_justificative/_pj_link.html.haml
+++ b/app/views/shared/champs/piece_justificative/_pj_link.html.haml
@@ -1,8 +1,7 @@
 - pj = champ.piece_justificative_file
 - if champ.virus_scan.present?
   - if champ.virus_scan.safe?
-    #FIXME : use url_for(pj) and remove download attribute when Riak content_disposition bug is solved https://github.com/betagouv/tps/issues/2180
-    = link_to pj.filename.to_s, pj.service_url(expires_in: 1.hour), target: '_blank', download: pj.filename.to_s
+    = link_to pj.filename.to_s, url_for(pj), target: '_blank'
   - else
     = pj.filename.to_s
     - if champ.virus_scan.pending?


### PR DESCRIPTION
This reverts commit 1fb1d92fe7f35be7597414064d8b8a526144a6b9.

Après tests en dev, le fix ne fonctionne pas comme prévu, je propose donc de revert.