### PR TITLE
Amélioration de l'aperçu

### DIFF
--- a/app/views/new_administrateur/procedures/apercu.html.haml
+++ b/app/views/new_administrateur/procedures/apercu.html.haml
@@ -1,6 +1,6 @@
 .dossiers-headers.sub-header
   .container
-    %h1.page-title Prévisualisation de la procédure #{@dossier.procedure.libelle}
+    %h1.page-title Prévisualisation de la procédure «&nbsp;#{@dossier.procedure.libelle}&nbsp;»
 
     %ul.tabs
       %li{ class: (@tab == 'dossier') ? 'active' : nil }>

--- a/app/views/new_administrateur/procedures/apercu.html.haml
+++ b/app/views/new_administrateur/procedures/apercu.html.haml
@@ -9,7 +9,7 @@
       - if @dossier.champs_private.size > 0
         %li{ class: (@tab == 'annotations-privees') ? 'active' : nil }>
           = link_to(apercu_procedure_path(@dossier.procedure, tab: 'annotations-privees')) do
-            les annotations privees
+            les annotations privées
 
 - if @tab == 'dossier'
   = render partial: "shared/dossiers/edit", locals: { dossier: @dossier, apercu: true }


### PR DESCRIPTION
- Correction d'une coquille (`annotation privees`)
- Le header du formulaire est maintenant affiché de la même manière dans l'aperçu et dans la page réelle
- Ajout d'une bannière pour signaler le mode "aperçu"

## Avant

<img width="1086" alt="capture d ecran 2018-07-11 a 18 27 10" src="https://user-images.githubusercontent.com/179923/42586899-694ef824-8539-11e8-971f-b29c36e7f101.png">

## Après

<img width="1070" alt="capture d ecran 2018-07-11 a 18 35 08" src="https://user-images.githubusercontent.com/179923/42586902-6ce2bdd6-8539-11e8-9d9e-f883c7fefa7d.png">
