### PR TITLE
[emails] Mentionne le nom de la procédure supprimée

### DIFF
--- a/app/views/dossier_mailer/notify_deletion_to_administration.html.haml
+++ b/app/views/dossier_mailer/notify_deletion_to_administration.html.haml
@@ -3,7 +3,9 @@
 %h1 Bonjour,
 
 %p
-  À la demande de l'usager le dossier n° #{@deleted_dossier.dossier_id} a été supprimé.
+  À la demande de l'usager, le dossier n° #{@deleted_dossier.dossier_id}
+  (sur la démarche «&nbsp;#{@deleted_dossier.procedure.libelle}&nbsp;»)
+  a été supprimé.
 
 %p
   Bonne journée,

--- a/app/views/dossier_mailer/notify_deletion_to_user.html.haml
+++ b/app/views/dossier_mailer/notify_deletion_to_user.html.haml
@@ -3,7 +3,8 @@
 %h1 Bonjour,
 
 %p
-  Votre dossier n° #{@deleted_dossier.dossier_id} a bien été supprimé.
+  Votre dossier n° #{@deleted_dossier.dossier_id}
+  («&nbsp;#{@deleted_dossier.procedure.libelle}&nbsp;») a bien été supprimé.
   Une trace anonyme de ce traitement sera conservée pour l’administration.
 
 %p

--- a/app/views/dossier_mailer/notify_unhide_to_user.html.haml
+++ b/app/views/dossier_mailer/notify_unhide_to_user.html.haml
@@ -3,7 +3,8 @@
 %h1 Bonjour,
 
 %p
-  L'instruction de votre dossier n° #{@dossier.id} ayant commencé, il n'a pas pu être supprimé.
+  L'instruction de votre dossier n° #{@dossier.id} («&nbsp;#{@dossier.procedure.libelle}&nbsp;»)
+  ayant commencé, il n'a pas pu être supprimé.
   Le dossier a été rétabli dans votre tableau de bord.
 
 %p

--- a/spec/factories/deleted_dossier.rb
+++ b/spec/factories/deleted_dossier.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :deleted_dossier do
+    dossier_id  1111
+    state       'en_construction'
+    deleted_at  DateTime.now
+
+    association :procedure, :published
+  end
+end

--- a/spec/mailers/dossier_mailer_spec.rb
+++ b/spec/mailers/dossier_mailer_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+RSpec.describe DossierMailer, type: :mailer do
+  let(:to_email) { 'gestionnaire@exemple.gouv.fr' }
+
+  describe '.notify_deletion_to_user' do
+    let(:deleted_dossier) { build(:deleted_dossier) }
+
+    subject { described_class.notify_deletion_to_user(deleted_dossier, to_email) }
+
+    it { expect(subject.subject).to eq("Votre dossier n° #{deleted_dossier.dossier_id} a bien été supprimé") }
+    it { expect(subject.body).to include("Votre dossier") }
+    it { expect(subject.body).to include(deleted_dossier.dossier_id) }
+    it { expect(subject.body).to include("a bien été supprimé") }
+  end
+
+  describe '.notify_deletion_to_administration' do
+    let(:deleted_dossier) { build(:deleted_dossier) }
+
+    subject { described_class.notify_deletion_to_administration(deleted_dossier, to_email) }
+
+    it { expect(subject.subject).to eq("Le dossier n° #{deleted_dossier.dossier_id} a été supprimé à la demande de l'usager") }
+    it { expect(subject.body).to include("À la demande de l'usager") }
+    it { expect(subject.body).to include(deleted_dossier.dossier_id) }
+  end
+
+  describe '.notify_unhide_to_user' do
+    let(:dossier) { create(:dossier) }
+
+    subject { described_class.notify_unhide_to_user(dossier) }
+
+    it { expect(subject.subject).to eq("Votre dossier n° #{dossier.id} n'a pas pu être supprimé") }
+    it { expect(subject.body).to include(dossier.id) }
+    it { expect(subject.body).to include("n'a pas pu être supprimé") }
+  end
+end

--- a/spec/mailers/dossier_mailer_spec.rb
+++ b/spec/mailers/dossier_mailer_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe DossierMailer, type: :mailer do
     it { expect(subject.body).to include("Votre dossier") }
     it { expect(subject.body).to include(deleted_dossier.dossier_id) }
     it { expect(subject.body).to include("a bien été supprimé") }
+    it { expect(subject.body).to include(deleted_dossier.procedure.libelle) }
   end
 
   describe '.notify_deletion_to_administration' do
@@ -22,6 +23,7 @@ RSpec.describe DossierMailer, type: :mailer do
     it { expect(subject.subject).to eq("Le dossier n° #{deleted_dossier.dossier_id} a été supprimé à la demande de l'usager") }
     it { expect(subject.body).to include("À la demande de l'usager") }
     it { expect(subject.body).to include(deleted_dossier.dossier_id) }
+    it { expect(subject.body).to include(deleted_dossier.procedure.libelle) }
   end
 
   describe '.notify_unhide_to_user' do
@@ -32,5 +34,6 @@ RSpec.describe DossierMailer, type: :mailer do
     it { expect(subject.subject).to eq("Votre dossier n° #{dossier.id} n'a pas pu être supprimé") }
     it { expect(subject.body).to include(dossier.id) }
     it { expect(subject.body).to include("n'a pas pu être supprimé") }
+    it { expect(subject.body).to include(dossier.procedure.libelle) }
   end
 end


### PR DESCRIPTION
> J'ai également constaté récemment la réception du mail avertissant "Le dossier n° xxxxxx a été supprimé à la demande de l'usager".
>
> Est-il envisageable d'indiquer le formulaire associé au dossier car pour des administrateurs/accompagnateurs qui suivent plusieurs procédures l'information n'est pas évidente.

`HS #4693`

Fix #2253