### PR TITLE
[Manager] Confirmer l'email

### DIFF
--- a/app/controllers/manager/users_controller.rb
+++ b/app/controllers/manager/users_controller.rb
@@ -1,4 +1,17 @@
 module Manager
   class UsersController < Manager::ApplicationController
+    def resend_confirmation_instructions
+      user = User.find(params[:id])
+      user.resend_confirmation_instructions
+      flash[:notice] = "Le message de confirmation de l’adresse email a été renvoyé."
+      redirect_to manager_user_path(user)
+    end
+
+    def confirm
+      user = User.find(params[:id])
+      user.confirm
+      flash[:notice] = "L’adresse email de l’utilisateur a été marquée comme confirmée."
+      redirect_to manager_user_path(user)
+    end
   end
 end

--- a/app/dashboards/user_dashboard.rb
+++ b/app/dashboards/user_dashboard.rb
@@ -10,6 +10,7 @@ class UserDashboard < Administrate::BaseDashboard
   ATTRIBUTE_TYPES = {
     id: Field::Number,
     email: Field::String,
+    confirmed?: Field::Boolean,
     created_at: Field::DateTime,
     updated_at: Field::DateTime,
     current_sign_in_at: Field::DateTime,
@@ -32,6 +33,7 @@ class UserDashboard < Administrate::BaseDashboard
     :dossiers,
     :id,
     :email,
+    :confirmed?,
     :current_sign_in_at,
     :created_at,
   ].freeze

--- a/app/views/manager/users/show.html.erb
+++ b/app/views/manager/users/show.html.erb
@@ -1,0 +1,57 @@
+<%#
+# Show
+
+This view is the template for the show page.
+It renders the attributes of a resource,
+as well as a link to its edit page.
+
+## Local variables:
+
+- `page`:
+  An instance of [Administrate::Page::Show][1].
+  Contains methods for accessing the resource to be displayed on the page,
+  as well as helpers for describing how each attribute of the resource
+  should be displayed.
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Page/Show
+%>
+
+<% content_for(:title) { t("administrate.actions.show_resource", name: page.page_title) } %>
+<% user = page.resource %>
+
+<header class="main-content__header" role="banner">
+  <h1 class="main-content__page-title">
+    <%= content_for(:title) %>
+  </h1>
+
+  <div>
+    <%= link_to(
+      t("administrate.actions.edit_resource", name: page.page_title),
+      [:edit, namespace, page.resource],
+      class: "button",
+    ) if valid_action?(:edit) && show_action?(:edit, page.resource) %>
+  </div>
+
+  <div>
+    <% if !user.confirmed? %>
+      <%= link_to('Renvoyer l’email de confirmation', [:resend_confirmation_instructions, namespace, page.resource], method: :post, class: 'button') %>
+      <%= link_to('Confirmer l’email', confirm_manager_user_path(user), method: :post, class: 'button') %>
+    <% end %>
+  <div>
+</header>
+
+<section class="main-content__body">
+  <dl>
+    <% page.attributes.each do |attribute| %>
+      <dt class="attribute-label" id="<%= attribute.name %>">
+      <%= t(
+        "helpers.label.#{resource_name}.#{attribute.name}",
+        default: attribute.name.titleize,
+      ) %>
+      </dt>
+
+      <dd class="attribute-data attribute-data--<%=attribute.html_class%>"
+          ><%= render_field attribute %></dd>
+    <% end %>
+  </dl>
+</section>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,7 +15,11 @@ Rails.application.routes.draw do
       put 'enable_feature', on: :member
     end
 
-    resources :users, only: [:index, :show]
+    resources :users, only: [:index, :show] do
+      post 'resend_confirmation_instructions', on: :member
+      post 'confirm', on: :member
+    end
+
     resources :gestionnaires, only: [:index, :show] do
       post 'reinvite', on: :member
     end


### PR DESCRIPTION
Cette PR rajoute deux actions au manager :

- Renvoyer l'email de confirmation,
- Confirmer l'adresse email manuellement.

On peut également voir si l'adresse email d'un utilisateur est confirmée ou pas.

<img width="1119" alt="capture d ecran 2018-07-17 a 12 19 44" src="https://user-images.githubusercontent.com/179923/42811697-b623a70e-89bb-11e8-8c31-9efc86663bcf.png">

/cc @clemenceleurent 