### PR TITLE
[Manager] amélioration des dossiers ; recherche

### DIFF
--- a/app/dashboards/dossier_dashboard.rb
+++ b/app/dashboards/dossier_dashboard.rb
@@ -8,7 +8,7 @@ class DossierDashboard < Administrate::BaseDashboard
   # which determines how the attribute is displayed
   # on pages throughout the dashboard.
   ATTRIBUTE_TYPES = {
-    id: Field::Number,
+    id: Field::Number.with_options(searchable: true),
     procedure: Field::HasOne,
     state: Field::String,
     text_summary: Field::String.with_options(searchable: false),

--- a/app/dashboards/dossier_dashboard.rb
+++ b/app/dashboards/dossier_dashboard.rb
@@ -11,7 +11,7 @@ class DossierDashboard < Administrate::BaseDashboard
     id: Field::Number,
     procedure: Field::HasOne,
     state: Field::String,
-    text_summary: Field::String,
+    text_summary: Field::String.with_options(searchable: false),
     created_at: Field::DateTime,
     updated_at: Field::DateTime,
     types_de_champ: TypesDeChampCollectionField,

--- a/app/dashboards/procedure_dashboard.rb
+++ b/app/dashboards/procedure_dashboard.rb
@@ -14,7 +14,7 @@ class ProcedureDashboard < Administrate::BaseDashboard
     dossiers: Field::HasMany,
     gestionnaires: Field::HasMany,
     administrateur: Field::BelongsTo,
-    id: Field::Number,
+    id: Field::Number.with_options(searchable: true),
     libelle: Field::String,
     description: Field::String,
     organisation: Field::String,

--- a/app/views/manager/application/_navigation.html.erb
+++ b/app/views/manager/application/_navigation.html.erb
@@ -23,6 +23,6 @@ as defined by the routes in the `admin/` namespace
 
   <hr />
 
-  <%= link_to "Delayed Job", manager_delayed_job_path, class: "navigation__link" %>
+  <%= link_to "Delayed Jobs", manager_delayed_job_path, class: "navigation__link" %>
   <%= link_to "Features", manager_flipflop_path, class: "navigation__link" %>
 </nav>

--- a/config/locales/models/dossier/fr.yml
+++ b/config/locales/models/dossier/fr.yml
@@ -1,7 +1,9 @@
 fr:
   activerecord:
     models:
-      dossier: 'Dossier'
+      dossier:
+        one: "Dossier"
+        other: "Dossiers"
     attributes:
       dossier:
         montant_projet: 'Le montant du projet'


### PR DESCRIPTION
- Correction de coquilles dans le manager ;
- Correction d'une exception lorsqu'on essaie de chercher un dossier ;
- On peut maintenant utiliser l'id d'un dossier ou d'une procédure dans le champ de recherche du manager.
