### PR TITLE
[Manager] Affiche les dossiers supprimés dans la recherche

### DIFF
--- a/app/controllers/manager/dossiers_controller.rb
+++ b/app/controllers/manager/dossiers_controller.rb
@@ -1,5 +1,25 @@
 module Manager
   class DossiersController < Manager::ApplicationController
+    #
+    # Administrate overrides
+    #
+
+    # Override this if you have certain roles that require a subset
+    # this will be used to set the records shown on the `index` action.
+    def scoped_resource
+      if unfiltered_list?
+        # Don't display deleted dossiers in the unfiltered list…
+        Dossier
+      else
+        # … but allow them to be searched and displayed.
+        Dossier.unscope(:where)
+      end
+    end
+
+    #
+    # Custom actions
+    #
+
     def change_state_to_instruction
       dossier = Dossier.find(params[:id])
       dossier.update(state: 'en_instruction', processed_at: nil, motivation: nil)
@@ -7,6 +27,12 @@ module Manager
       logger.info("Le dossier #{dossier.id} est repassé en instruction par #{current_administration.email}")
       flash[:notice] = "Le dossier #{dossier.id} est repassé en instruction"
       redirect_to manager_dossier_path(dossier)
+    end
+
+    private
+
+    def unfiltered_list?
+      action_name == "index" && !params[:search]
     end
   end
 end

--- a/app/dashboards/dossier_dashboard.rb
+++ b/app/dashboards/dossier_dashboard.rb
@@ -14,6 +14,7 @@ class DossierDashboard < Administrate::BaseDashboard
     text_summary: Field::String.with_options(searchable: false),
     created_at: Field::DateTime,
     updated_at: Field::DateTime,
+    hidden_at: Field::DateTime,
     types_de_champ: TypesDeChampCollectionField,
   }.freeze
 
@@ -38,6 +39,7 @@ class DossierDashboard < Administrate::BaseDashboard
     :types_de_champ,
     :created_at,
     :updated_at,
+    :hidden_at
   ].freeze
 
   # FORM_ATTRIBUTES

--- a/app/views/manager/dossiers/show.html.erb
+++ b/app/views/manager/dossiers/show.html.erb
@@ -22,6 +22,9 @@ as well as a link to its edit page.
 <header class="main-content__header" role="banner">
   <h1 class="main-content__page-title">
     <%= content_for(:title) %>
+    <% if dossier.hidden_at %>
+      (SUPPRIMÉ)
+    <% end %>
   </h1>
 
   <div>


### PR DESCRIPTION
Pour rendre plus simple l'investigation sur des dossiers supprimés par l'usager, cette PR permet au Manager d'afficher les dossiers supprimés dans certains cas :

- Dans une recherche (typiquement par ID)
- Dans la page d'un dossier spécifique (/manager/dossiers/78532)

En revanche les dossiers supprimés **ne s'affichent pas dans la liste générale** des dossiers. 

Typiquement ça veut dire qu'on ne peut pas trouver un dossier supprimé, à moins de connaître son ID.

<img width="801" alt="capture d ecran 2018-07-23 a 13 05 52" src="https://user-images.githubusercontent.com/179923/43073247-251d7e5c-8e79-11e8-812e-872b02ceeadd.png">

