### PR TITLE
mailer: remove last mention of TPS

### DIFF
--- a/app/views/notification_mailer/closed_mail_with_attestation.html.haml
+++ b/app/views/notification_mailer/closed_mail_with_attestation.html.haml
@@ -14,7 +14,7 @@
   Bonne journée,
 
 %p
-  L'équipe demarches-simplifiees.fr (anciennement Téléprocédures Simplifiées)
+  L'équipe demarches-simplifiees.fr
 
 %p
   —


### PR DESCRIPTION
C'est la dernière mention de Téléprocédures Simplifiées dans des messages publics.