### PR TITLE
Supprimer un brouillon

### DIFF
--- a/app/assets/stylesheets/new_design/buttons.scss
+++ b/app/assets/stylesheets/new_design/buttons.scss
@@ -45,6 +45,18 @@
     }
   }
 
+  &.danger {
+    color: $black;
+    border-color: $border-grey;
+    background-color: #FFFFFF;
+
+    &:hover {
+      color: #FFFFFF;
+      border-color: $medium-red;
+      background-color: $medium-red;
+    }
+  }
+
   &.accepted {
     color: #FFFFFF;
     border-color: $green;

--- a/app/assets/stylesheets/new_design/buttons.scss
+++ b/app/assets/stylesheets/new_design/buttons.scss
@@ -11,6 +11,7 @@
   background-color: #FFFFFF;
   color: $black;
   cursor: pointer;
+  text-align: center;
   -webkit-appearance: none;
 
   &:hover {

--- a/app/assets/stylesheets/new_design/forms.scss
+++ b/app/assets/stylesheets/new_design/forms.scss
@@ -281,15 +281,43 @@
   }
 
   .send-wrapper {
-    text-align: right;
-    margin-top: 2 * $default-padding;
+    display: flex;
+    width: 100%;
+    justify-content: flex-end;
+    margin-top: $default-padding;
     margin-bottom: 2 * $default-padding;
 
     .button {
+      margin-top: $default-padding;
       margin-bottom: 0;
     }
-    .button.danger {
-      float:left;
+
+    // Wide layout: align buttons on a single row
+    @media (min-width: 550px) {
+      flex-direction: row;
+
+      .button:not(:first-of-type) {
+        margin-left: $default-spacer;
+      }
+
+      .button.danger {
+        margin-right: auto;
+      }
+    }
+
+    // Narrow layout: stack buttons vertically
+    @media (max-width: 550px) {
+      flex-direction: column-reverse;
+      align-items: center;
+
+      .button,
+      .button.danger {
+        width: 100%;
+        max-width: 350px;
+        line-height: 30px;
+        margin-left: none;
+        margin-right: none;
+      }
     }
   }
 

--- a/app/assets/stylesheets/new_design/forms.scss
+++ b/app/assets/stylesheets/new_design/forms.scss
@@ -288,6 +288,9 @@
     .button {
       margin-bottom: 0;
     }
+    .button.danger {
+      float:left;
+    }
   }
 
   .inline-champ {

--- a/app/views/root/patron.html.haml
+++ b/app/views/root/patron.html.haml
@@ -49,7 +49,6 @@
 
       = link_to ".button.secondary", "#", class: "button secondary"
 
-      = link_to ".button.accepted", "#", class: "button accepted"
 
       = link_to "#", class: "button" do
         %span.icon.follow
@@ -57,6 +56,13 @@
 
       = link_to "#", class: "button icon-only" do
         %span.icon.follow
+
+    %p
+      = link_to ".button.accepted", "#", class: "button accepted"
+
+      = link_to ".button.refused", "#", class: "button refused"
+
+      = link_to ".button.without-continuation", "#", class: "button without-continuation"
 
     %p
       = link_to ".button.large", "#", class: "button large"

--- a/app/views/root/patron.html.haml
+++ b/app/views/root/patron.html.haml
@@ -49,6 +49,7 @@
 
       = link_to ".button.secondary", "#", class: "button secondary"
 
+      = link_to ".button.danger", "#", class: "button danger"
 
       = link_to "#", class: "button" do
         %span.icon.follow

--- a/app/views/shared/dossiers/_edit.html.haml
+++ b/app/views/shared/dossiers/_edit.html.haml
@@ -62,9 +62,16 @@
         = hidden_field_tag 'submit_action', 'draft'
 
         - if dossier.brouillon?
+          - if current_user.owns?(dossier)
+            = link_to ask_deletion_dossier_path(dossier),
+              method: :post,
+              class: 'button danger',
+              data: { confirm: "En continuant, vous allez supprimer ce dossier ainsi que les informations qu’il contient. Toute suppression entraine l’annulation de la démarche en cours.\n\nConfirmer la suppression ?" } do
+              Supprimer le brouillon
+
           = f.button 'Enregistrer le brouillon',
             formnovalidate: true,
-            class: 'button send',
+            class: 'button send secondary',
             data: { action: 'draft', disable_with: 'Envoi...' }
 
           - if current_user.owns?(dossier) && dossier.can_transition_to_en_construction?

--- a/spec/features/new_user/dossier_spec.rb
+++ b/spec/features/new_user/dossier_spec.rb
@@ -112,6 +112,20 @@ feature 'The user' do
     expect(page).to have_current_path(merci_dossier_path(user_dossier))
   end
 
+  scenario 'delete a draft', js: true do
+    log_in(user.email, password, simple_procedure)
+    fill_individual
+
+    page.accept_alert('Confirmer la suppression ?') do
+      click_on 'Supprimer le brouillon'
+    end
+
+    expect(page).to have_current_path(dossiers_path)
+    expect(page).to have_text('Votre dossier a bien été supprimé')
+    expect(page).not_to have_text(user_dossier.procedure.libelle)
+    expect(user_dossier.reload.hidden_at).to be_present
+  end
+
   private
 
   def log_in(email, password, procedure)


### PR DESCRIPTION
Cette PR rajoute un bouton dans la page d'un formulaire pour supprimer un brouillon.

La fonctionnalité existait dans l'ancien design, mais elle a sauté depuis trois semaines. On a eu pas mal de retour clients là dessus.

## Disposition sur écran large

<img width="840" alt="capture d ecran 2018-07-24 a 18 23 35" src="https://user-images.githubusercontent.com/179923/43152866-ffd12ad4-8f6f-11e8-9eb4-eaca9516a7ff.png">

## Disposition sur écran étroit

<img width="200" alt="capture d ecran 2018-07-24 a 18 24 17" src="https://user-images.githubusercontent.com/179923/43152872-08248aaa-8f70-11e8-9f46-47f2c3288bf9.png">

## Bouton "Supprimer"

Le bouton "Supprimer le brouillon" devient rouge au survol. Comme ça il n'attire pas trop l'œil, mais au survol on voit qu'il est dangereux.

<img width="300" alt="capture d ecran 2018-07-24 a 18 34 44" src="https://user-images.githubusercontent.com/179923/43152953-4236b63c-8f70-11e8-9225-3156a53997ab.png">


Fix #2211