### PR TITLE
dossiers: rename "Éditer" to "Modifier"

### DIFF
--- a/app/views/dossiers/_edit_carto.html.haml
+++ b/app/views/dossiers/_edit_carto.html.haml
@@ -2,4 +2,4 @@
   - if user_signed_in? && (current_user.owns_or_invite?(@facade.dossier))
     %a#maj_carte.action{ href: "/users/dossiers/#{@facade.dossier.id}/carte" }
       .col-lg-2.col-md-2.col-sm-2.col-xs-2.action
-        = 'ÉDITER'
+        = 'MODIFIER'

--- a/app/views/dossiers/_edit_dossier.html.haml
+++ b/app/views/dossiers/_edit_dossier.html.haml
@@ -2,4 +2,4 @@
   - if user_signed_in? && (current_user.owns_or_invite?(@facade.dossier))
     = link_to modifier_dossier_path(@facade.dossier), class: 'action', id: 'maj_infos' do
       #edit-dossier.col-lg-2.col-md-2.col-sm-2.col-xs-2.action
-        = "ÉDITER"
+        = "MODIFIER"


### PR DESCRIPTION
"Éditer" est un anglicisme, qui n'est pas compris par certains utilisateurs. 