### PR TITLE
Fix text align on dropdown button

### DIFF
--- a/app/assets/stylesheets/new_design/buttons.scss
+++ b/app/assets/stylesheets/new_design/buttons.scss
@@ -150,6 +150,7 @@
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.2);
   position: absolute;
   right: 0;
+  text-align: left;
   top: 5 * $default-spacer;
   cursor: default;
   z-index: 10;


### PR DESCRIPTION
Petite régression introduite récemment.
Avant cette PR :
<img width="407" alt="capture d ecran 2018-07-25 a 14 31 48" src="https://user-images.githubusercontent.com/847942/43201327-76be4408-9018-11e8-8459-607ebe6a862f.png">

Après cette PR (mais aussi avant régression) :
<img width="375" alt="capture d ecran 2018-07-25 a 14 31 41" src="https://user-images.githubusercontent.com/847942/43201332-790afc24-9018-11e8-9870-bffb83b6cb86.png">
