### PR TITLE
Fix Sentry error 2755

### DIFF
--- a/app/controllers/new_gestionnaire/dossiers_controller.rb
+++ b/app/controllers/new_gestionnaire/dossiers_controller.rb
@@ -101,8 +101,10 @@ module NewGestionnaire
         NotificationMailer.send_without_continuation_notification(dossier).deliver_later
       when "accepter"
         dossier.accepte!
-        dossier.attestation = dossier.build_attestation
-        dossier.save
+        if dossier.attestation.nil?
+          dossier.attestation = dossier.build_attestation
+          dossier.save
+        end
         flash.notice = "Dossier traité avec succès."
         NotificationMailer.send_closed_notification(dossier).deliver_later
       end

--- a/spec/controllers/new_gestionnaire/dossiers_controller_spec.rb
+++ b/spec/controllers/new_gestionnaire/dossiers_controller_spec.rb
@@ -227,6 +227,14 @@ describe NewGestionnaire::DossiersController, type: :controller do
 
           is_expected.to redirect_to redirect_to gestionnaire_dossier_path(procedure, dossier)
         end
+
+        context 'and the dossier has already an attestation' do
+          it 'should not crash' do
+            dossier.attestation = Attestation.new
+            dossier.save
+            expect(subject).to redirect_to redirect_to gestionnaire_dossier_path(procedure, dossier)
+          end
+        end
       end
 
       context 'when the attestation template uses the motivation field' do


### PR DESCRIPTION
https://sentry.apientreprise.fr/apientreprise/tps/issues/2755/events/

Ce problème peut se produire si un accompagnateur ouvre le même dossier dans 2 onglets différents et l'accepte deux fois.

Je ne sais pas si c'est la bonne solution de ne pas régénérer l'attestation. On pourrait aussi détruire la première puis la recréer. Je suis à votre écoute :)