### PR TITLE
Améliorations sur les tests

### DIFF
--- a/spec/jobs/application_job_spec.rb
+++ b/spec/jobs/application_job_spec.rb
@@ -1,12 +1,16 @@
 require 'rails_helper'
 include ActiveJob::TestHelper
 
-RSpec.describe ApplicationJob, type: :job, skip: true do
+RSpec.describe ApplicationJob, type: :job do
   describe 'perform' do
-    it do
-      expect(Rails.logger).to receive(:info).with(/.+started at.+/)
-      expect(Rails.logger).to receive(:info).with(/.+ended at.+/)
+    before do
+      allow(Rails.logger).to receive(:info)
+    end
+
+    it 'logs start time and end time' do
       perform_enqueued_jobs { ChildJob.perform_later }
+      expect(Rails.logger).to have_received(:info).with(/started at/).once
+      expect(Rails.logger).to have_received(:info).with(/ended at/).once
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -118,6 +118,9 @@ RSpec.configure do |config|
   config.filter_run :focus => true
 
   config.order = 'random'
+  # Fix the seed not changing between runs when using Spring
+  # See https://github.com/rails/spring/issues/113
+  config.seed = srand % 0xFFFF unless ARGV.any? { |arg| arg =~ /seed/ || arg =~ /rand:/ }
 
   config.include Devise::Test::ControllerHelpers, type: :controller
   config.include Devise::Test::ControllerHelpers, type: :view


### PR DESCRIPTION
- Correction de l'unique test en `pending` qui rendait les logs moches ;
- Curieusement, quand on utilise Spring, la seed de `bin/rspec` est toujours la même. Cette PR implémente un workaround.