### PR TITLE
Ne pas afficher les email des gestionnaires dans l'interface de messagerie

### DIFF
--- a/app/models/commentaire.rb
+++ b/app/models/commentaire.rb
@@ -14,7 +14,13 @@ class Commentaire < ApplicationRecord
   after_create :notify
 
   def header
-    "#{email}, #{I18n.l(created_at.localtime, format: '%d %b %Y %H:%M')}"
+    "#{sender}, #{I18n.l(created_at.localtime, format: '%d %b %Y %H:%M')}"
+  end
+
+  def sender
+    if email.present?
+      email.split('@').first
+    end
   end
 
   def file_url

--- a/spec/features/users/flux_de_commentaires_spec.rb
+++ b/spec/features/users/flux_de_commentaires_spec.rb
@@ -9,7 +9,7 @@ feature 'users: flux de commentaires' do
   let(:champ2) { create(:champ, dossier: dossier, type_de_champ: create(:type_de_champ, libelle: "subtitle")) }
 
   let!(:commentaire1) { create(:commentaire, dossier: dossier, champ: champ1) }
-  let!(:commentaire2) { create(:commentaire, dossier: dossier) }
+  let!(:commentaire2) { create(:commentaire, dossier: dossier, email: 'paul.chavard@beta.gouv.fr') }
   let!(:commentaire3) { create(:commentaire, dossier: dossier, champ: champ2) }
   let!(:commentaire4) { create(:commentaire, dossier: dossier, champ: champ1) }
 
@@ -21,5 +21,7 @@ feature 'users: flux de commentaires' do
   scenario "seuls les commentaires généraux sont affichés" do
     comments = find(".commentaires")
     expect(comments).to have_selector(".content", count: 1)
+    expect(comments).to have_content('paul.chavard')
+    expect(comments).not_to have_content('paul.chavard@beta.gouv.fr')
   end
 end


### PR DESCRIPTION
Le quick fix c'est d'afficher uniquement la première partie de l'email
Ça va empêcher l'envoi des emails direct.

À terme, on veut probablement afficher dans le header du message le nom du service plutôt que le nom du gestionnaire.