### PR TITLE
Corrige le bouton "Soumettre le dossier" sous IE11

### DIFF
--- a/app/assets/stylesheets/new_design/forms.scss
+++ b/app/assets/stylesheets/new_design/forms.scss
@@ -283,7 +283,6 @@
   .send-wrapper {
     display: flex;
     width: 100%;
-    justify-content: flex-end;
     margin-top: $default-padding;
     margin-bottom: 2 * $default-padding;
 


### PR DESCRIPTION
Y'a une propriété flexbox qui n'est même pas nécessaire, mais qui casse le layout sous IE11. (#2311)

## Ancien rendu sous IE11

![43387791-ac79685c-93e7-11e8-8ed3-ca57ac2976fb](https://user-images.githubusercontent.com/179923/43391230-6b9cde64-93f0-11e8-9d74-e8446c32c345.png)


## Nouveau rendu sous IE11

<img width="893" alt="capture d ecran 2018-07-30 a 11 49 51" src="https://user-images.githubusercontent.com/179923/43390894-9ae0ccf4-93ef-11e8-9cb9-138a926d0d2b.png">

## Nouveau rendu sous IE10

_(Pour la forme, parce qu'on ne gère pas officiellement IE10 (et que personne ne l'utilise de toute façon). Mais c'est bon de savoir que ça n'empêche pas de soumettre un formulaire quand même.)_

<img width="848" alt="capture d ecran 2018-07-30 a 11 55 03" src="https://user-images.githubusercontent.com/179923/43390957-b93e0b76-93ef-11e8-99a3-36d6f65bb48c.png">

Fix #2311

