### PR TITLE
invite: don't display email of following accompagnateurs

### DIFF
--- a/app/views/layouts/navbars/_navbar_users_recapitulatifcontroller_show.html.haml
+++ b/app/views/layouts/navbars/_navbar_users_recapitulatifcontroller_show.html.haml
@@ -10,13 +10,6 @@
         .badge.progress-bar-info
           = @facade.dossier.invites.count
       .dropdown-menu.dropdown-menu-right.dropdown-pannel
-        %h4= t('dynamics.dossiers.followers.title')
-        %ul
-          - if @facade.followers.present?
-            - @facade.followers.each do |follower|
-              %li= follower.email
-          - else
-            = t('dynamics.dossiers.followers.empty')
         %h4= t('dynamics.dossiers.invites.title')
         %ul
           - if @facade.invites.present?

--- a/config/locales/dynamics/fr.yml
+++ b/config/locales/dynamics/fr.yml
@@ -7,9 +7,6 @@ fr:
     dossiers:
       depositaite: "Dépositaire"
       numéro: 'Dossier nº '
-      followers:
-        title: "Personnes suivant l'activité de ce dossier"
-        empty: "Aucune personne ne suit ce dossier"
       invites:
         title: "Personnes invitées à voir ce dossier"
         empty: "Aucune personne invitée"


### PR DESCRIPTION
We don't want the individual contact of Accompagnateurs to be displayed, for privacy reasons.

## Avant

<img width="430" alt="capture d ecran 2018-07-31 a 17 16 03" src="https://user-images.githubusercontent.com/179923/43468988-7b4d05be-94e5-11e8-83c7-44f6bf26a177.png">

## Après

<img width="422" alt="capture d ecran 2018-07-31 a 17 16 24" src="https://user-images.githubusercontent.com/179923/43468991-7e88761e-94e5-11e8-9267-7bfb8591d7b5.png">
