### PR TITLE
Améliore la stabilité de tests peu fiables

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,7 +5,8 @@ module.exports = {
     sourceType: 'module'
   },
   globals: {
-    '$': true
+    '$': true,
+    'process': true
   },
   plugins: ['prettier'],
   extends: ['eslint:recommended', 'prettier'],

--- a/app/javascript/packs/application-old.js
+++ b/app/javascript/packs/application-old.js
@@ -18,8 +18,14 @@ Rails.start();
 Turbolinks.start();
 ActiveStorage.start();
 
+// Disable jQuery-driven animations during tests
+if (process.env['RAILS_ENV'] === 'test') {
+  jQuery.fx.off = true;
+}
+
 // Expose globals
 window.Bloodhound = Bloodhound;
 window.Chartkick = Chartkick;
+// Export jQuery globally for legacy Javascript files used in the old design
 window.$ = jQuery;
 window.jQuery = jQuery;

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -4,6 +4,7 @@ import * as ActiveStorage from 'activestorage';
 
 import Chartkick from 'chartkick';
 import Highcharts from 'highcharts';
+import jQuery from 'jquery';
 
 import 'select2';
 import 'typeahead.js';
@@ -44,6 +45,11 @@ Chartkick.addAdapter(Highcharts);
 Rails.start();
 Turbolinks.start();
 ActiveStorage.start();
+
+// Disable jQuery-driven animations during tests
+if (process.env['RAILS_ENV'] === 'test') {
+  jQuery.fx.off = true;
+}
 
 // Expose globals
 window.DS = window.DS || DS;

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -14,7 +14,6 @@
     = stylesheet_link_tag    'print', media: 'print', 'data-turbolinks-track': "reload"
     = javascript_pack_tag    'application-old', defer: true, 'data-turbolinks-track': 'reload'
     = javascript_include_tag 'application', defer: true, 'data-turbolinks-track': 'reload'
-
     = csrf_meta_tags
 
     :javascript
@@ -26,13 +25,7 @@
       #beta
         Env Test
 
-    - if Rails.env == 'test'
-      %script{ type: 'text/javascript' }
-        (typeof jQuery !== 'undefined') && (jQuery.fx.off = true);
-
-
     = render partial: 'layouts/ie_lt_10'
-
 
     #wrap
       .row

--- a/app/views/layouts/new_application.html.haml
+++ b/app/views/layouts/new_application.html.haml
@@ -44,6 +44,3 @@
         = javascript_include_tag :xray
 
       = yield :charts_js
-      - if Rails.env == "test"
-        %script{ type: "text/javascript" }
-          (typeof jQuery !== "undefined") && (jQuery.fx.off = true);

--- a/spec/features/users/dossier_creation_spec.rb
+++ b/spec/features/users/dossier_creation_spec.rb
@@ -78,6 +78,8 @@ feature 'As a User I wanna create a dossier' do
 
       page.find_by_id('dossier-siret').set siret
       page.find_by_id('submit-siret').click
+      wait_for_ajax
+
       expect(page).to have_css('#recap-info-entreprise')
       find(:css, "#dossier_autorisation_donnees[value='1']").set(true)
       page.find_by_id('etape_suivante').click

--- a/spec/features/users/dossier_creation_spec.rb
+++ b/spec/features/users/dossier_creation_spec.rb
@@ -66,7 +66,7 @@ feature 'As a User I wanna create a dossier' do
       login_as user, scope: :user
       visit commencer_path(procedure_path: procedure_with_siret.path)
       expect(page).to have_current_path(users_dossier_path(procedure_with_siret.dossiers.last.id.to_s))
-      fill_in 'dossier-siret', with: siret
+
       stub_request(:get, /https:\/\/entreprise.api.gouv.fr\/v2\/etablissements\/#{siret}?.*token=/)
         .to_return(status: 200, body: File.read('spec/support/files/etablissement.json'))
       stub_request(:get, /https:\/\/entreprise.api.gouv.fr\/v2\/entreprises\/#{siren}?.*token=/)
@@ -75,6 +75,7 @@ feature 'As a User I wanna create a dossier' do
         .to_return(status: 200, body: File.read('spec/support/files/exercices.json'))
       stub_request(:get, /https:\/\/entreprise.api.gouv.fr\/v2\/associations\/#{siret}?.*token=/)
         .to_return(status: 404, body: '')
+
       page.find_by_id('dossier-siret').set siret
       page.find_by_id('submit-siret').click
       expect(page).to have_css('#recap-info-entreprise')

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -47,8 +47,6 @@ Capybara.register_driver :headless_chrome do |app|
     desired_capabilities: capabilities
 end
 
-ActiveSupport::Deprecation.silenced = true
-
 Capybara.default_max_wait_time = 1
 
 # Save a snapshot of the HTML page when an integration test fails
@@ -68,6 +66,8 @@ Dir[Rails.root.join('spec', 'factories', '**', '*.rb')].each { |f| require f }
 # Checks for pending migrations before tests are run.
 # If you are not using ActiveRecord, you can remove this line.
 ActiveRecord::Migration.check_pending! if defined?(ActiveRecord::Migration)
+
+ActiveSupport::Deprecation.silenced = true
 
 VCR.configure do |c|
   c.ignore_localhost = true

--- a/spec/support/wait_for_ajax.rb
+++ b/spec/support/wait_for_ajax.rb
@@ -1,4 +1,3 @@
-# spec/support/wait_for_ajax.rb
 module WaitForAjax
   def wait_for_ajax
     Timeout.timeout(Capybara.default_max_wait_time) do


### PR DESCRIPTION
- Rajoute un `wait_for_ajax` requis dans un test SIRET qui échoue régulièrement ;
- Répare la désactivation des animations jQuery pendant les tests (cassée lors du passage à Webpack) ;
- Corrections mineures.

@tchak please review