### PR TITLE
Améliore la fiabilité des tests Capybara

### DIFF
--- a/app/views/admin/procedures/_modal_publish.html.haml
+++ b/app/views/admin/procedures/_modal_publish.html.haml
@@ -1,4 +1,4 @@
-#publish-modal.modal.fade{ "aria-labelledby" => "myModalLabel", :role => "dialog", :tabindex => "-1" }
+#publish-modal.modal{ "aria-labelledby" => "myModalLabel", :role => "dialog", :tabindex => "-1" }
   .modal-dialog.modal-lg{ :role => "document" }
     = form_tag admin_procedure_publish_path(procedure_id: @procedure.id), method: :put, remote: true do
       .modal-content

--- a/spec/features/users/dossier_creation_spec.rb
+++ b/spec/features/users/dossier_creation_spec.rb
@@ -81,7 +81,7 @@ feature 'As a User I wanna create a dossier' do
       wait_for_ajax
 
       expect(page).to have_css('#recap-info-entreprise')
-      find(:css, "#dossier_autorisation_donnees[value='1']").set(true)
+      check 'dossier_autorisation_donnees'
       page.find_by_id('etape_suivante').click
       expect(page).to have_current_path(users_dossier_carte_path(procedure_with_siret.dossiers.last.id.to_s))
       page.find_by_id('etape_suivante').click

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -47,7 +47,7 @@ Capybara.register_driver :headless_chrome do |app|
     desired_capabilities: capabilities
 end
 
-Capybara.default_max_wait_time = 1
+Capybara.default_max_wait_time = 2
 
 # Save a snapshot of the HTML page when an integration test fails
 Capybara::Screenshot.autosave_on_failure = true


### PR DESCRIPTION
- Ré-écriture des tests de création de dossier, pour avoir plus de point d'attente
- Augmentation du timeout général (pour les cas où les machines sur lesquelles les tests tournent sont lentes)