### PR TITLE
ci: retry when yarn fails because of a transcient error

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ yarn_save_cache: &yarn_save_cache
 yarn_install: &yarn_install
   run:
     name: Install JS Dependencies
-    command: yarn install --non-interactive
+    command: yarn install --non-interactive || yarn install --non-interactive
 
 jobs:
   build:


### PR DESCRIPTION
Régulièrement la CI pète parce que yarn prend une erreur 500 sur un des modules.

```
#!/bin/bash -eo pipefail
yarn install --non-interactive

yarn install v1.5.1
[1/5] Validating package.json...
[2/5] Resolving packages...
[3/5] Fetching packages...
error An unexpected error occurred: "https://registry.yarnpkg.com/class-utils/-/class-utils-0.3.6.tgz: Request failed \"500 Internal Server Error\"".
info If you think this is a bug, please open a bug report with the information provided in "/home/circleci/tps/yarn-error.log".
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
Exited with code 1
```

Cette PR fait en sorte de ré-essayer immédiatement d'installer les modules si jamais une erreur se produit.

![Meh](https://user-images.githubusercontent.com/179923/43528621-ae7b210e-95a9-11e8-85d6-a88a24eab25d.gif)

