### PR TITLE
Améliore la détection des navigateurs périmés 

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Pour les lister: `bin/rake -D support:`.
 
 ## Compatibilité navigateurs
 
-L'application supporte les navigateurs récents Firefox, Chrome, Internet Explorer (Edge, 11).
+L'application supporte les navigateurs récents : Firefox, Chrome, Safari, Edge et Internet Explorer 11 (voir `config/browser.rb`).
 
 La compatibilité est testée par Browserstack.
 

--- a/app/assets/stylesheets/new_design/support_navigator_banner.scss
+++ b/app/assets/stylesheets/new_design/support_navigator_banner.scss
@@ -1,0 +1,20 @@
+@import "colors";
+@import "constants";
+
+#support-navigator-banner {
+  position: fixed;
+  width: 100%;
+  bottom: 0;
+  left: 0;
+  margin: 0;
+  padding: $default-padding;
+  text-align: center;
+  color: #FFFFFF;
+  background-color: $medium-red;
+  z-index: 1000;
+
+  a {
+    color: #C3D9FF;
+    text-decoration: underline;
+  }
+}

--- a/app/views/layouts/_ie_lt_10.html.haml
+++ b/app/views/layouts/_ie_lt_10.html.haml
@@ -1,8 +1,0 @@
-<!--[if lt IE 10]>
-
-.center{ style: 'width: 100%; background-color: white; position: fixed; top: 0; left: 0; z-index: 100000;' }
-  %h3.text-danger
-    %b
-      Votre version d'Internet Explorer est trop ancienne pour être utilisée sur demarches-simplifiees.fr. Version minimum : Internet Explorer 10
-
-<![endif]-->

--- a/app/views/layouts/_support_navigator_banner.html.haml
+++ b/app/views/layouts/_support_navigator_banner.html.haml
@@ -4,4 +4,9 @@
       = browser.name
       = browser.version
       \-
-      Attention, votre navigateur n'est pas recommandé pour la navigation sur ce site internet. Aucun support ne pourra vous être prodigué en cas de dysfonctionnement.
+      Attention, votre navigateur est trop ancien pour utiliser Démarches Simplifiées : certaines parties du site ne fonctionneront pas correctement.
+      %br/
+      %br/
+      Nous vous recommendons fortement de
+      %a{ href: "https://browser-update.org/fr/update.html" }mettre à jour votre navigateur
+      \.

--- a/app/views/layouts/_support_navigator_banner.html.haml
+++ b/app/views/layouts/_support_navigator_banner.html.haml
@@ -1,3 +1,4 @@
+-# See config/browser.rb
 - if !browser.modern?
   #support-navigator-banner.row
     .col-xs-12

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -25,8 +25,6 @@
       #beta
         Env Test
 
-    = render partial: 'layouts/ie_lt_10'
-
     #wrap
       .row
         #header.navbar

--- a/app/views/layouts/new_application.html.haml
+++ b/app/views/layouts/new_application.html.haml
@@ -26,7 +26,6 @@
   %body
     .page-wrapper
       = render partial: "layouts/support_navigator_banner"
-      = render partial: "layouts/ie_lt_10"
       = render partial: 'layouts/pre_maintenance'
       - if Rails.env == "staging"
         #beta


### PR DESCRIPTION
## Amélioration du design.

- Corrige la feuille de style de la bannière "Navigateur périmé" sur le nouveau design (le nouveau design n'avait pas la feuille de style du tout 😱 )
- Amélioration du message d'erreur, avec un lien vers https://browser-update.org/fr/update.html pour faciliter les mises à jour.

<img width="895" alt="C'est mieux comme ça." src="https://user-images.githubusercontent.com/179923/43718338-a86e461c-998a-11e8-95e8-5e2704e47c04.png">

## Suppression de la détection de navigateur spécifique à Internet Explorer

La détection spécifique-IE est redondante, et ne fonctionne pas avec IE >= 10 de toute façon (les commentaires conditionnels ne sont plus supportés à partir de cette version).

<img width="1020" alt="Le message du haut est inutile." src="https://user-images.githubusercontent.com/179923/43718382-c7d63c1c-998a-11e8-915a-eaedf228e424.png">

_Le message du haut est inutile._

## Ajouts de commentaires dans le code et le README

Je clair, Luc, ne pas ?