### PR TITLE
browsers: enforce IE 11 as the minimum required IE version

### DIFF
--- a/config/initializers/browser.rb
+++ b/config/initializers/browser.rb
@@ -1,6 +1,6 @@
 Browser.modern_rules.clear
 Browser.modern_rules << -> b { b.chrome? && b.version.to_i >= 40 }
-Browser.modern_rules << -> b { b.ie?([">=10"]) }
+Browser.modern_rules << -> b { b.ie?([">=11"]) }
 Browser.modern_rules << -> b { b.edge? }
 Browser.modern_rules << -> b { b.firefox? && b.version.to_i >= 45 }
 Browser.modern_rules << -> b { b.opera? && b.version.to_i >= 19 }


### PR DESCRIPTION
This is already documented in the [README](https://github.com/betagouv/tps/blob/dev/README.md#compatibilit%C3%A9-navigateurs), but not enforced.

IE 10 users will now see the "Browser deprecated" red banner.