### PR TITLE
Corrige la soumission des dossiers sous Internet Explorer

### DIFF
--- a/app/javascript/packs/application-old.js
+++ b/app/javascript/packs/application-old.js
@@ -6,6 +6,11 @@ import Highcharts from 'highcharts';
 import Bloodhound from 'bloodhound-js';
 import jQuery from 'jquery';
 
+// Include runtime-polyfills for older browsers.
+// Due to .babelrc's 'useBuiltIns', only polyfills actually
+// required by the browsers we support will be included.
+import 'babel-polyfill';
+
 import 'select2';
 import 'typeahead.js';
 

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -6,6 +6,11 @@ import Chartkick from 'chartkick';
 import Highcharts from 'highcharts';
 import jQuery from 'jquery';
 
+// Include runtime-polyfills for older browsers.
+// Due to .babelrc's 'useBuiltIns', only polyfills actually
+// required by the browsers we support will be included.
+import 'babel-polyfill';
+
 import 'select2';
 import 'typeahead.js';
 


### PR DESCRIPTION
La séquence du bug est la suivante :

1. Le JS de soumission d'un dossier a une boucle `for… in`
1. Babel (qu'on utilise maintenant qu'on a Webpack) détecte que les `for… in` ne sont pas dispo dans tous les navigateurs qu'on veut gérer. Il compile donc cette fonctionnalité en boucle + générateurs + `Symbol`
1. Quand on utilise des `Symbol`, il faut aussi un polyfill au runtime pour les anciens navigateurs. Normalement `babel-polyfill` inclut ça automatiquement. Mais nous on a oublié de faire un `import "babel-polyfill"`, donc ils ne sont pas présents dans l'app.
1. IE 11 ne gère pas les `Symbol`, lève une "Symbol is undefined" et abandonne tout le JS
1. Comme le JS n'est plus exécuté, le input-invisible reste en `"brouillon"`, et le dossier est enregistré comme brouillon au lieu d'être soumis.

Cette PR inclut les polyfills nécessaires. Ça devrait corriger le JS qui plante sous IE 11, et avec un peu de chance la plupart des cas de soumission des dossiers.

Fix #2300