### PR TITLE
javascript: transpile compatible JS for all browsers we support

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -3,7 +3,16 @@
     ["env", {
       "modules": false,
       "targets": {
-        "browsers": "> 1%",
+        // See config/browser.rb
+        "browsers": [
+          "> 1%",
+          "Chrome 40",
+          "IE 11",
+          "Edge 12",
+          "Firefox 45",
+          "Safari 8",
+          "iOS 8"
+        ],
         "uglify": true
       },
       "useBuiltIns": true

--- a/config/initializers/browser.rb
+++ b/config/initializers/browser.rb
@@ -1,3 +1,4 @@
+# See .babelrc
 Browser.modern_rules.clear
 Browser.modern_rules << -> b { b.chrome? && b.version.to_i >= 40 }
 Browser.modern_rules << -> b { b.ie?([">=11"]) }


### PR DESCRIPTION
Dans le fichier `config/browser.rb` on définit tous les navigateurs qu'on gère officiellement.

Mais rien ne dit à Babel de transpiler du code Javascript qui fonctionne dans ces navigateurs. Le ["browsers: 1%"](http://browserl.ist/?q=%3E1%25) n'est largement pas suffisant. Par exemple il manque tous les vieux Safari (et les gens coincés sous une vieille version de macOS n'ont pas la possibilité de le mettre à jour).

Cette PR s'assure que Babel émette du JS correct pour tous les navigateurs qu'on support. Ça devrait aider pour #2300.