### PR TITLE
Supprime un hack sur les URLs "DossiersController#show"

### DIFF
--- a/app/views/shared/dossiers/_edit.html.haml
+++ b/app/views/shared/dossiers/_edit.html.haml
@@ -4,7 +4,7 @@
   - if apercu
     - form_options = { url: '', method: :get, html: { class: 'form', multipart: true } }
   - else
-    - form_options = { html: { class: 'form', multipart: true, novalidate: dossier.brouillon? } }
+    - form_options = { url: modifier_dossier_url(dossier), method: :patch, html: { class: 'form', multipart: true, novalidate: dossier.brouillon? } }
 
   = form_for dossier, form_options do |f|
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -243,6 +243,7 @@ Rails.application.routes.draw do
         get 'identite'
         patch 'update_identite'
         get 'modifier'
+        patch 'modifier', to: 'dossiers#update'
         get 'merci'
         post 'ask_deletion'
         get 'attestation'
@@ -250,9 +251,6 @@ Rails.application.routes.draw do
 
       collection do
         post 'recherche'
-        # FIXME: to remove when show is implemeted
-        # needed to fix refresh after dossier draft save
-        get ':id', to: redirect('/dossiers/%{id}/modifier')
       end
     end
   end

--- a/spec/features/new_user/dossier_spec.rb
+++ b/spec/features/new_user/dossier_spec.rb
@@ -96,12 +96,12 @@ feature 'The user' do
     click_on 'Enregistrer le brouillon'
     expect(user_dossier.reload.brouillon?).to be(true)
     expect(page).to have_content('Votre brouillon a bien été sauvegardé')
-    expect(page).to have_current_path(dossier_path(user_dossier))
+    expect(page).to have_current_path(modifier_dossier_path(user_dossier))
 
     # Check an incomplete dossier cannot be submitted when mandatory fields are missing
     click_on 'Soumettre le dossier'
     expect(user_dossier.reload.brouillon?).to be(true)
-    expect(page).to have_current_path(dossier_path(user_dossier))
+    expect(page).to have_current_path(modifier_dossier_path(user_dossier))
 
     # Check a dossier can be submitted when all mandatory fields are filled
     fill_in('texte obligatoire', with: 'super texte')


### PR DESCRIPTION
En ce moment la modification du formulaire d'un dossier se fait de la manière suivante :

1. On affiche la page `/dossiers/:id/modifier`,
1. Le formulaire POST sur sur `/dossiers/:id`,
1. L'action redirige sur `/dossiers/:id`,
1. `/dossiers/:id` redirige vers `/dossiers/:id/modifier`

À la dernière étape, comme on n'a pas de route pour `DossiersController#show`, on était obligé de hacker une route.

À la place, cette PR rajoute une route `POST /dossiers/:id/modifier`, pour qu'on puisse directement poster le formulaire et rester sur la même page. Ça veut dire qu'on n'a plus besoin de la pseudo-route `/dossiers/:id`.