### PR TITLE
Nouvelle route pour les nouveaux détails d'un dossier

### DIFF
--- a/app/controllers/new_user/dossiers_controller.rb
+++ b/app/controllers/new_user/dossiers_controller.rb
@@ -4,8 +4,8 @@ module NewUser
 
     helper_method :new_demarche_url
 
-    before_action :ensure_ownership!, except: [:index, :modifier, :update, :recherche]
-    before_action :ensure_ownership_or_invitation!, only: [:modifier, :update]
+    before_action :ensure_ownership!, except: [:index, :show, :modifier, :update, :recherche]
+    before_action :ensure_ownership_or_invitation!, only: [:show, :modifier, :update]
     before_action :ensure_dossier_can_be_updated, only: [:update_identite, :update]
     before_action :forbid_invite_submission!, only: [:update]
 
@@ -20,6 +20,14 @@ module NewUser
         @user_dossiers
       when 'dossiers-invites'
         @dossiers_invites
+      end
+    end
+
+    def show
+      if dossier.brouillon?
+        redirect_to modifier_dossier_path(dossier)
+      else
+        redirect_to users_dossier_recapitulatif_path(dossier)
       end
     end
 

--- a/app/controllers/new_user/dossiers_controller.rb
+++ b/app/controllers/new_user/dossiers_controller.rb
@@ -26,9 +26,12 @@ module NewUser
     def show
       if dossier.brouillon?
         redirect_to modifier_dossier_path(dossier)
-      else
+
+      elsif !Flipflop.new_dossier_details?
         redirect_to users_dossier_recapitulatif_path(dossier)
       end
+
+      @dossier = dossier
     end
 
     def attestation

--- a/app/views/new_user/dossiers/show.html.haml
+++ b/app/views/new_user/dossiers/show.html.haml
@@ -1,0 +1,3 @@
+%h1
+  Dossier
+  = @dossier.id

--- a/config/features.rb
+++ b/config/features.rb
@@ -17,6 +17,9 @@ Flipflop.configure do
 
   feature :web_hook
 
+  feature :new_dossier_details,
+    title: "Nouvelle page « Dossier »"
+
   group :production do
     feature :remote_storage,
       default: Rails.env.production? || Rails.env.staging?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -267,7 +267,7 @@ Rails.application.routes.draw do
   #
 
   scope module: 'new_user' do
-    resources :dossiers, only: [:index, :update] do
+    resources :dossiers, only: [:index, :show, :update] do
       member do
         get 'identite'
         patch 'update_identite'

--- a/spec/controllers/new_user/dossiers_controller_spec.rb
+++ b/spec/controllers/new_user/dossiers_controller_spec.rb
@@ -478,6 +478,21 @@ describe NewUser::DossiersController, type: :controller do
     end
   end
 
+  describe '#show' do
+    before { sign_in(user) }
+    subject! { get(:show, params: { id: dossier.id }) }
+
+    context 'when the dossier is a brouillon' do
+      let(:dossier) { create(:dossier, user: user) }
+      it { is_expected.to redirect_to(modifier_dossier_path(dossier)) }
+    end
+
+    context 'when the dossier has been submitted' do
+      let(:dossier) { create(:dossier, :en_construction, user: user) }
+      it { is_expected.to redirect_to(users_dossier_recapitulatif_path(dossier)) }
+    end
+  end
+
   describe '#ask_deletion' do
     before { sign_in(user) }
 

--- a/spec/features/new_user/dossier_details_spec.rb
+++ b/spec/features/new_user/dossier_details_spec.rb
@@ -1,0 +1,28 @@
+describe 'Dossier details:' do
+  let(:user) { create(:user) }
+  let(:dossier) { create(:dossier, :en_construction, user: user) }
+
+  before do
+    Flipflop::FeatureSet.current.test!.switch!(:new_dossier_details, true)
+  end
+
+  scenario 'the user can see the details of their dossier' do
+    visit_dossier dossier
+
+    expect(page).to have_current_path(dossier_path(dossier))
+    expect(page).to have_content(dossier.id)
+  end
+
+  private
+
+  def visit_dossier(dossier)
+    visit dossier_path(dossier)
+
+    expect(page).to have_current_path(new_user_session_path)
+    fill_in 'user_email', with: user.email
+    fill_in 'user_password', with: user.password
+    click_on 'Se connecter'
+
+    expect(page).to have_current_path(dossier_path(dossier))
+  end
+end

--- a/spec/views/new_user/dossiers/show.html.haml_spec.rb
+++ b/spec/views/new_user/dossiers/show.html.haml_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+describe 'new_user/dossiers/show.html.haml', type: :view do
+  let(:dossier) { create(:dossier, :with_service, state: 'brouillon', procedure: create(:procedure)) }
+
+  before do
+    sign_in dossier.user
+    assign(:dossier, dossier)
+  end
+
+  subject! { render }
+
+  it 'affiche les informations du dossier' do
+    expect(rendered).to have_text("Dossier #{dossier.id}")
+  end
+end


### PR DESCRIPTION
Cette PR rajoute une route `/dossiers/:id`, qui servira à afficher la nouvelle page des détails d'un dossier pour les Usagers (#1818).

Cette route est derrière un feature-flag : s'il n'est pas activé, elle redirige vers les anciennes pages.

Pour l'instant la page elle-même n'affiche que le n° du dossier. Mais ça permettra de merger progressivement des PR pour l'améliorer, et de mettre en prod à la fin.