### PR TITLE
[Email] Correction de l'URL vers le brouillon nouvellement créé

### DIFF
--- a/app/views/notification_mailer/send_draft_notification.html.haml
+++ b/app/views/notification_mailer/send_draft_notification.html.haml
@@ -5,7 +5,7 @@
   Vous pouvez retrouver et compléter le brouillon que vous avez créé pour la démarche
   %strong= @dossier.procedure.libelle
   à l'adresse suivante :
-  = link_to users_dossiers_url(liste: 'brouillon'), users_dossiers_url(liste: 'brouillon'), target: '_blank'
+  = link_to dossier_url(@dossier), dossier_url(@dossier), target: '_blank'
 
 %p
   Bonne journée,


### PR DESCRIPTION
Le lien redirige maintenant directement vers le dossier.

(Si le dossier est en brouillon, cette URL redirigera elle-même vers `/dossiers/:id/modifier`. Sinon, elle redirige vers `/dossiers/:id/recapitulatif`)

<img width="545" alt="capture d ecran 2018-08-08 a 12 04 11" src="https://user-images.githubusercontent.com/179923/43831110-52a52604-9b03-11e8-8a0f-faabb2db20a9.png">

Fix #2341