### PR TITLE
[fix #2358] Checkbox: serialize in attestation by oui or non

### DIFF
--- a/app/models/champs/checkbox_champ.rb
+++ b/app/models/champs/checkbox_champ.rb
@@ -4,4 +4,8 @@ class Champs::CheckboxChamp < Champ
       [ libelle ]
     end
   end
+
+  def to_s
+    value == 'on' ? 'oui' : 'non'
+  end
 end

--- a/spec/models/champs/checkbox_champ_spec.rb
+++ b/spec/models/champs/checkbox_champ_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+describe Champs::CheckboxChamp do
+  let(:checkbox) { Champs::CheckboxChamp.new(value: value) }
+
+  describe '#to_s' do
+    subject { checkbox.to_s }
+
+    context 'when the value is on' do
+      let(:value) { 'on' }
+
+      it { is_expected.to eq('oui') }
+    end
+
+    context 'when the value is off' do
+      let(:value) { 'off' }
+
+      it { is_expected.to eq('non') }
+    end
+  end
+end


### PR DESCRIPTION
A noter que cette modif ne change pas les valeurs sorties par l'API car cette dernière utilise directement `champ.value` et pas `champ.to_s`