### PR TITLE
Petites amélioration d'UI

### DIFF
--- a/app/views/shared/dossiers/_edit.html.haml
+++ b/app/views/shared/dossiers/_edit.html.haml
@@ -64,7 +64,7 @@
             = link_to ask_deletion_dossier_path(dossier),
               method: :post,
               class: 'button danger',
-              data: { confirm: "En continuant, vous allez supprimer ce dossier ainsi que les informations qu’il contient. Toute suppression entraine l’annulation de la démarche en cours.\n\nConfirmer la suppression ?" } do
+              data: { disable_with: 'Supprimer le brouillon', confirm: 'En continuant, vous allez supprimer ce dossier ainsi que les informations qu’il contient. Toute suppression entraine l’annulation de la démarche en cours.\n\nConfirmer la suppression ?' } do
               Supprimer le brouillon
 
           = f.button 'Enregistrer le brouillon',
@@ -72,18 +72,18 @@
             name: :save_draft,
             value: true,
             class: 'button send secondary',
-            data: { disable_with: 'Envoi...' }
+            data: { disable_with: 'Enregistrer le brouillon' }
 
           - if dossier.can_transition_to_en_construction?
             = f.button 'Soumettre le dossier',
               class: 'button send primary',
               disabled: !current_user.owns?(dossier),
-              data: { disable_with: 'Envoi...' }
+              data: { disable_with: 'Soumettre le dossier' }
 
         - else
           = f.button 'Enregistrer les modifications du dossier',
             class: 'button send primary',
-            data: { disable_with: 'Envoi...' }
+            data: { disable_with: 'Enregistrer les modifications du dossier' }
 
       - if dossier.brouillon? && !current_user.owns?(dossier)
         .send-notice.invite-cannot-submit

--- a/config/locales/models/type_de_champ/fr.yml
+++ b/config/locales/models/type_de_champ/fr.yml
@@ -10,7 +10,7 @@ fr:
           date: 'Date'
           datetime: 'Date et Heure'
           number: 'Nombre'
-          checkbox: 'Checkbox'
+          checkbox: 'Case à cocher'
           civilite: 'Civilité'
           email: 'Email'
           phone: 'Téléphone'


### PR DESCRIPTION
## Admin

Dans la liste des types de champs, `Checkbox` -> `Case à cocher`


## Usager

Les boutons d'envoi sont maintenant désactivé, mais sans changer de texte.

**Avant**

![before](https://user-images.githubusercontent.com/179923/43842222-2612aa36-9b25-11e8-85a4-a32f6c36d26d.gif)

**Après**

![after](https://user-images.githubusercontent.com/179923/43842226-28fbcaa2-9b25-11e8-8382-e85e098e715b.gif)
