### PR TITLE
Move linters to a Rake task

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,20 +90,8 @@ jobs:
       - *yarn_restore_cache
       - *yarn_install
       - run:
-          name: Run eslint
-          command: yarn lint:js
-      - run:
-          name: Run rubocop
-          command: bundle exec rubocop
-      - run:
-          name: Run brakeman
-          command: bundle exec brakeman
-      - run:
-          name: Run haml-lint
-          command: bundle exec haml-lint app/views/
-      - run:
-          name: Run scss-lint
-          command: bundle exec scss-lint app/assets/stylesheets/
+          name: Run linters
+          command: bundle exec rake lint
   deploy:
     <<: *defaults
     steps:

--- a/README.md
+++ b/README.md
@@ -108,11 +108,9 @@ Une fois `overmind` lancé, et un breakpoint `byebug` inséré dans le code, il 
 
 ## Linting
 
-- Faire tourner RuboCop : `bundle exec rubocop`
-- Faire tourner Brakeman : `bundle exec brakeman`
-- Linter les fichiers HAML : `bundle exec haml-lint app/views/`
-- Linter les fichiers SCSS : `bundle exec scss-lint app/assets/stylesheets/`
-- Linter les fichiers JavaScript : `yarn lint:js` (`yarn lint:js --fix`)
+Le projet utilise plusieurs linters pour vérifier la lisibilité et la qualité code.
+
+- Faire tourner tous les linters : `bin/rake lint`
 - [AccessLint](http://accesslint.com/) tourne automatiquement sur les PRs
 
 ## Déploiement

--- a/Rakefile
+++ b/Rakefile
@@ -5,6 +5,14 @@ require File.expand_path('config/application', __dir__)
 
 Rails.application.load_tasks
 
+task :lint do
+  sh "bundle exec rubocop"
+  sh "bundle exec haml-lint app/views/"
+  sh "bundle exec scss-lint app/assets/stylesheets/"
+  sh "bundle exec brakeman --no-pager"
+  sh "yarn lint:js"
+end
+
 task :deploy do
   domains = %w(37.187.249.111 149.202.72.152 149.202.198.6)
   domains.each do |domain|


### PR DESCRIPTION
This allow running all linters in a single pass, using `bin/rake lint`.