### PR TITLE
Amélioration des icônes de feedback

### DIFF
--- a/app/assets/stylesheets/new_design/dossier_index.scss
+++ b/app/assets/stylesheets/new_design/dossier_index.scss
@@ -7,6 +7,7 @@
 
   .icon {
     padding: 10px 5px;
+    margin: 10px 10px;
 
     &:hover {
       cursor: pointer;

--- a/app/views/new_user/dossiers/index.html.haml
+++ b/app/views/new_user/dossiers/index.html.haml
@@ -17,17 +17,6 @@
 
 .container
   - if @dossiers.present?
-    - if current_user.feedbacks.empty?
-      #user-satisfaction
-        %h3 Que pensez-vous de ce service ?
-        .icons
-          = link_to feedback_path(mark: 0), data: { remote: true, method: :post } do
-            %span.icon.frown
-          = link_to feedback_path(mark: 1), data: { remote: true, method: :post } do
-            %span.icon.meh
-          = link_to feedback_path(mark: 2), data: { remote: true, method: :post } do
-            %span.icon.smile
-
     - if @dossiers.total_pages >= 2
       .card.feedback
         .card-title Nous avons redesigné la liste des dossiers.
@@ -63,6 +52,17 @@
                 = link_to(url_for_dossier(dossier), class: 'cell-link') do
                   = dossier.updated_at.localtime.strftime("%d/%m/%Y")
     = paginate(@dossiers)
+
+    - if current_user.feedbacks.empty?
+      #user-satisfaction
+        %h3 Que pensez-vous de ce service ?
+        .icons
+          = link_to feedback_path(mark: 0), data: { remote: true, method: :post } do
+            %span.icon.frown
+          = link_to feedback_path(mark: 1), data: { remote: true, method: :post } do
+            %span.icon.meh
+          = link_to feedback_path(mark: 2), data: { remote: true, method: :post } do
+            %span.icon.smile
 
   - else
     .dossiers-table-empty

--- a/app/views/new_user/dossiers/index.html.haml
+++ b/app/views/new_user/dossiers/index.html.haml
@@ -15,19 +15,19 @@
           = link_to(dossiers_path(current_tab: 'dossiers-invites')) do
             dossiers invités
 
-- if current_user.feedbacks.empty?
-  .container#user-satisfaction
-    %h3 Que pensez-vous de ce service ?
-    .icons
-      = link_to feedback_path(mark: 0), data: { remote: true, method: :post } do
-        %span.icon.frown
-      = link_to feedback_path(mark: 1), data: { remote: true, method: :post } do
-        %span.icon.meh
-      = link_to feedback_path(mark: 2), data: { remote: true, method: :post } do
-        %span.icon.smile
-
 .container
   - if @dossiers.present?
+    - if current_user.feedbacks.empty?
+      #user-satisfaction
+        %h3 Que pensez-vous de ce service ?
+        .icons
+          = link_to feedback_path(mark: 0), data: { remote: true, method: :post } do
+            %span.icon.frown
+          = link_to feedback_path(mark: 1), data: { remote: true, method: :post } do
+            %span.icon.meh
+          = link_to feedback_path(mark: 2), data: { remote: true, method: :post } do
+            %span.icon.smile
+
     - if @dossiers.total_pages >= 2
       .card.feedback
         .card-title Nous avons redesigné la liste des dossiers.


### PR DESCRIPTION
- On n'affiche plus les icônes de feedback si l'utilisateur n'a aucun dossier (ça fait moche, et ça n'a sans doute pas beaucoup de sens) ;
- Les icônes de feedback sont affichées en dessous de la liste des dossiers (plutôt qu'au dessus) ;
- Ajout de marge autour des icônes (pour qu'elles soient plus facilement tappables sur mobile).

<img width="881" alt="capture d ecran 2018-08-13 a 14 41 34" src="https://user-images.githubusercontent.com/179923/44032341-1a26a282-9f07-11e8-9c5c-41cd3a246150.png">


@LucienMLD tu en penses quoi ?