### PR TITLE
specs: fix order-dependant tests in spec/models/gestionnaire_spec.rb

### DIFF
--- a/spec/models/dossier_spec.rb
+++ b/spec/models/dossier_spec.rb
@@ -453,9 +453,8 @@ describe Dossier do
     let(:dossier) { create(:dossier, state: state) }
     let(:beginning_of_day) { Time.now.beginning_of_day }
 
-    before do
-      Timecop.freeze(beginning_of_day)
-    end
+    before { Timecop.freeze(beginning_of_day) }
+    after { Timecop.return }
 
     context 'when dossier is en_construction' do
       before do


### PR DESCRIPTION
Test run that would fail randomly before:

```
bin/rspec --seed 10002 spec/models/dossier_spec.rb spec/models/gestionnaire_spec.rb
```

(Au passage j'ai découvert `rspec --bisect`, et c'est de la balle ❤️ )

Fix #2140