### PR TITLE
Add stats page in manager

### DIFF
--- a/app/controllers/stats_manager_controller.rb
+++ b/app/controllers/stats_manager_controller.rb
@@ -1,16 +1,42 @@
 class StatsManagerController < ApplicationController
+  layout "new_application"
   before_action :authenticate_administration!
 
   def index
+    excluded_ids = []
+    stats = ['accepte', 'refuse', 'sans_suite', 'en_instruction', 'en_construction', 'brouillon']
+    @dossiers = stats.map do |state|
+      if state == 'brouillon'
+        data, ids = compute_state(state, :created_at, excluded_ids)
+        excluded_ids += ids
+        { name: state, data: data }
+      elsif state == 'en_construction'
+        data, ids = compute_state(state, :en_construction_at, excluded_ids)
+        excluded_ids += ids
+        { name: state, data: data }
+      elsif state == 'en_instruction'
+        data, ids = compute_state(state, :en_instruction_at, excluded_ids)
+        excluded_ids += ids
+        { name: state, data: data }
+      else
+        data, ids = compute_state(state, :updated_at, excluded_ids, true)
+        excluded_ids += ids
+        { name: state, data: data }
+      end
+    end
+
+    satisfied = Feedback.where(mark: 2).count
+    neutral = Feedback.where(mark: 1).count
+    unsatisfied = Feedback.where(mark: 0).count
+    @indice_satisfaction = { 'Satisfait': satisfied, 'Neutre': neutral, 'Insatisfait': unsatisfied }
   end
 
   def download
     data = []
 
-    dossier = Dossier.where(state: ['brouillon', 'en_construction', 'en_instruction'])
     header_file = ['ID du dossier', 'ID de la procédure', 'Nom de la procédure', 'ID utilisateur', 'Etat du fichier', 'Durée en brouillon (jours)', 'Durée en construction', 'Durée en instruction']
 
-    Dossier.all.each do |dossier|
+    Dossier.find_each do |dossier|
       en_brouillon = dossier.en_construction_at.present? ? ((dossier.en_construction_at - dossier.created_at).to_f / 60 / 60 / 24).round(2) : nil
       en_construction = dossier.en_instruction_at.present? ? ((dossier.en_instruction_at - dossier.en_construction_at).to_f / 60 / 60 / 24).round(2) : nil
       en_instruction = dossier.processed_at.present? ? ((dossier.processed_at - dossier.en_instruction_at).to_f / 60 / 60 / 24).round(2) : nil
@@ -23,5 +49,24 @@ class StatsManagerController < ApplicationController
     respond_to do |format|
       format.csv { send_data(SpreadsheetArchitect.to_xlsx(data: data, headers: header_file), filename: "statistiques.csv") }
     end
+  end
+
+  private
+
+  def compute_state(state, date_attr, excluded_ids, need_state = false)
+    ids = []
+    [
+      [0, 1, 2, 3, 4, 5].reduce({}) do |data, month_number|
+        range = (Time.now - month_number.month).beginning_of_month..(Time.now - month_number.month).end_of_month
+        if need_state
+          dossiers = Dossier.where(state: state).where.not(id: excluded_ids.uniq).where("#{date_attr}": range)
+        else
+          dossiers = Dossier.where.not(id: excluded_ids.uniq).where("#{date_attr}": range)
+        end
+        ids += dossiers.ids
+        data["#{Time.now.month - month_number}"] = dossiers.count
+        data
+      end, ids
+    ]
   end
 end

--- a/app/controllers/stats_manager_controller.rb
+++ b/app/controllers/stats_manager_controller.rb
@@ -1,0 +1,27 @@
+class StatsManagerController < ApplicationController
+  before_action :authenticate_administration!
+
+  def index
+  end
+
+  def download
+    data = []
+
+    dossier = Dossier.where(state: ['brouillon', 'en_construction', 'en_instruction'])
+    header_file = ['ID du dossier', 'ID de la procédure', 'Nom de la procédure', 'ID utilisateur', 'Etat du fichier', 'Durée en brouillon (jours)', 'Durée en construction', 'Durée en instruction']
+
+    Dossier.all.each do |dossier|
+      en_brouillon = dossier.en_construction_at.present? ? ((dossier.en_construction_at - dossier.created_at).to_f / 60 / 60 / 24).round(2) : nil
+      en_construction = dossier.en_instruction_at.present? ? ((dossier.en_instruction_at - dossier.en_construction_at).to_f / 60 / 60 / 24).round(2) : nil
+      en_instruction = dossier.processed_at.present? ? ((dossier.processed_at - dossier.en_instruction_at).to_f / 60 / 60 / 24).round(2) : nil
+
+      row = [dossier.id, dossier.procedure.id, dossier.procedure.libelle, dossier.user.id, dossier.state, en_brouillon.to_s, en_construction.to_s, en_instruction.to_s]
+
+      data << row
+    end
+
+    respond_to do |format|
+      format.csv { send_data(SpreadsheetArchitect.to_xlsx(data: data, headers: header_file), filename: "statistiques.csv") }
+    end
+  end
+end

--- a/app/views/manager/application/_navigation.html.erb
+++ b/app/views/manager/application/_navigation.html.erb
@@ -25,4 +25,5 @@ as defined by the routes in the `admin/` namespace
 
   <%= link_to "Delayed Jobs", manager_delayed_job_path, class: "navigation__link" %>
   <%= link_to "Features", manager_flipflop_path, class: "navigation__link" %>
+  <%= link_to "Stats", manager_stats_path, class: "navigation__link" %>
 </nav>

--- a/app/views/stats_manager/index.html.haml
+++ b/app/views/stats_manager/index.html.haml
@@ -1,7 +1,23 @@
-.wrapper
-  .container
-    .row
-      .col-sm-10.col-offset-1
-        %h1 Statistiques
-        %br<>
-        = link_to "Telecharger au format CSV", manager_stats_download_path(format: :csv), class: 'btn btn-primary'
+.container
+  %h1 Statistiques
+  %br<>
+  = link_to "Telecharger au format CSV", manager_stats_download_path(format: :csv), class: 'button secondary'
+
+.statistiques
+  .stat-cards
+    .stat-card.stat-card-half.pull-left
+      %span.stat-card-title
+        Indice de satisfaction usager
+
+      .chart-container
+        .chart
+          = pie_chart @indice_satisfaction,
+            colors: ["rgba(191, 220, 249, 1)", "rgba(113, 176, 239, 1)", "rgba(61, 149, 236, 1)"]
+    .stat-card.stat-card-half.pull-left
+      %span.stat-card-title.pull-left Dossiers par état
+      .clearfix
+
+      .chart-container
+        .chart
+          = line_chart @dossiers, colors: ["#429331", "#CD4728", "#000000", "#3C67C5", "#8D2194", "#F39D39"]
+

--- a/app/views/stats_manager/index.html.haml
+++ b/app/views/stats_manager/index.html.haml
@@ -1,0 +1,7 @@
+.wrapper
+  .container
+    .row
+      .col-sm-10.col-offset-1
+        %h1 Statistiques
+        %br<>
+        = link_to "Telecharger au format CSV", manager_stats_download_path(format: :csv), class: 'btn btn-primary'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,6 +42,9 @@ Rails.application.routes.draw do
     root to: "administrateurs#index"
   end
 
+  get '/manager/stats' => 'stats_manager#index'
+  get '/manager/stats/download' => 'stats_manager#download'
+
   #
   # Monitoring
   #


### PR DESCRIPTION
Cette MR fait suite à cette issue #2381

Ajoute une page statistiques accessible via le menu de gauche sur le manager. possibilité de télécharger un csv avec la liste des dossiers et les champs : ID du dossier, Id de la procedure, nom, User ID, etat du dossier, Durée en brouillon, Durée en construction, Durée en instruction.
Ajout de deux graphiques, un sur la satisfaction des usagers (qui pourra aussi être mis en public, à voir) et un sur l'etat des dossiers sur les 6 derniers mois

L'image donne pas grand chose car faite sur ma bdd local mais ca donne un appercu

<img width="1103" alt="capture d ecran 2018-08-14 a 15 51 45" src="https://user-images.githubusercontent.com/22002486/44096038-907aa0d6-9fda-11e8-9dd2-48b2025f43aa.png">


