### PR TITLE
views: add `tab_item` and `active_tab_item` helpers

### DIFF
--- a/app/helpers/tabs_helper.rb
+++ b/app/helpers/tabs_helper.rb
@@ -1,0 +1,15 @@
+module TabsHelper
+  def tab_item(label, url, active: false, badge: nil, notification: false)
+    render partial: 'shared/tab_item', locals: {
+      label: label,
+      url: url,
+      active: active,
+      badge: badge,
+      notification: notification
+    }
+  end
+
+  def active_tab_item(label, url, badge: nil, notification: false)
+    tab_item(label, url, active: current_page?(url), badge: badge, notification: notification)
+  end
+end

--- a/app/views/new_administrateur/procedures/apercu.html.haml
+++ b/app/views/new_administrateur/procedures/apercu.html.haml
@@ -3,13 +3,13 @@
     %h1.page-title Prévisualisation de la procédure «&nbsp;#{@dossier.procedure.libelle}&nbsp;»
 
     %ul.tabs
-      %li{ class: (@tab == 'dossier') ? 'active' : nil }>
-        = link_to(apercu_procedure_path(@dossier.procedure, tab: 'dossier')) do
-          le dossier
+      = tab_item('le dossier',
+        apercu_procedure_path(@dossier.procedure, tab: 'dossier'),
+        active: @tab == 'dossier')
       - if @dossier.champs_private.size > 0
-        %li{ class: (@tab == 'annotations-privees') ? 'active' : nil }>
-          = link_to(apercu_procedure_path(@dossier.procedure, tab: 'annotations-privees')) do
-            les annotations privées
+        = tab_item('les annotations privées',
+          apercu_procedure_path(@dossier.procedure, tab: 'annotations-privees'),
+          active: @tab == 'annotations-privees')
 
 - if @tab == 'dossier'
   = render partial: "shared/dossiers/edit", locals: { dossier: @dossier, apercu: true }

--- a/app/views/new_gestionnaire/avis/_header.html.haml
+++ b/app/views/new_gestionnaire/avis/_header.html.haml
@@ -5,11 +5,6 @@
       %li= "#{dossier.procedure.libelle}, dossier nº #{dossier.id}"
 
     %ul.tabs
-      %li{ class: current_page?(gestionnaire_avis_path(avis)) ? 'active' : nil }
-        = link_to 'Demande', gestionnaire_avis_path(avis)
-      %li{ class: current_page?(instruction_gestionnaire_avis_path(avis)) ? 'active' : nil }
-        = link_to 'Avis', instruction_gestionnaire_avis_path(avis)
-        - if avis.answer == nil
-          %span.notifications{ 'aria-label': 'notifications' }
-      %li{ class: current_page?(messagerie_gestionnaire_avis_path(avis)) ? 'active' : nil }
-        = link_to 'Messagerie', messagerie_gestionnaire_avis_path(avis)
+      = active_tab_item('Demande', gestionnaire_avis_path(avis))
+      = active_tab_item('Avis', instruction_gestionnaire_avis_path(avis), notification: avis.answer.blank?)
+      = active_tab_item('Messagerie', messagerie_gestionnaire_avis_path(avis))

--- a/app/views/new_gestionnaire/avis/index.html.haml
+++ b/app/views/new_gestionnaire/avis/index.html.haml
@@ -6,17 +6,16 @@
     .width-100
       %h1.tab-title Avis
       %ul.tabs
-        %li{ class: (@statut == NewGestionnaire::AvisController::A_DONNER_STATUS) ? 'active' : nil }>
-          = link_to(gestionnaire_avis_index_path(statut: NewGestionnaire::AvisController::A_DONNER_STATUS)) do
-            avis à donner
-            %span.badge= @avis_a_donner.count
-            - if @avis_a_donner.any?
-              %span.notifications
+        = tab_item('avis à donner',
+          gestionnaire_avis_index_path(statut: NewGestionnaire::AvisController::A_DONNER_STATUS),
+          active: @statut == NewGestionnaire::AvisController::A_DONNER_STATUS,
+          badge: @avis_a_donner.count,
+          notification: @avis_a_donner.any?)
 
-        %li{ class: (@statut == NewGestionnaire::AvisController::DONNES_STATUS) ? 'active' : nil }>
-          = link_to(gestionnaire_avis_index_path(statut: NewGestionnaire::AvisController::DONNES_STATUS)) do
-            avis #{'donné'.pluralize(@avis_donnes.count)}
-            %span.badge= @avis_donnes.count
+        = tab_item("avis #{'donné'.pluralize(@avis_donnes.count)}",
+          gestionnaire_avis_index_path(statut: NewGestionnaire::AvisController::DONNES_STATUS),
+          active: @statut == NewGestionnaire::AvisController::DONNES_STATUS,
+          badge: @avis_donnes.count)
 
 .container
   - if @avis.present?

--- a/app/views/new_gestionnaire/dossiers/_header.html.haml
+++ b/app/views/new_gestionnaire/dossiers/_header.html.haml
@@ -17,26 +17,28 @@
 
         = render partial: "new_gestionnaire/procedures/dossier_actions", locals: { procedure: dossier.procedure, dossier: dossier, dossier_is_followed: current_gestionnaire&.follow?(dossier) }
         = render partial: "state_button", locals: { dossier: dossier }
+
     %ul.tabs
       - notifications_summary = current_gestionnaire.notifications_for_dossier(dossier)
-      %li{ class: current_page?(gestionnaire_dossier_path(dossier.procedure, dossier)) ? 'active' : nil }
-        - if notifications_summary[:demande]
-          %span.notifications{ 'aria-label': 'notifications' }
-        = link_to "Demande", gestionnaire_dossier_path(dossier.procedure, dossier)
-      %li{ class: current_page?(annotations_privees_gestionnaire_dossier_path(dossier.procedure, dossier)) ? 'active' : nil }
-        - if notifications_summary[:annotations_privees]
-          %span.notifications{ 'aria-label': 'notifications' }
-        = link_to "Annotations privées", annotations_privees_gestionnaire_dossier_path(dossier.procedure, dossier)
-      %li{ class: current_page?(avis_gestionnaire_dossier_path(dossier.procedure, dossier)) ? 'active' : nil }
-        - if notifications_summary[:avis]
-          %span.notifications{ 'aria-label': 'notifications' }
-        = link_to "Avis externes", avis_gestionnaire_dossier_path(dossier.procedure, dossier)
-      %li{ class: current_page?(messagerie_gestionnaire_dossier_path(dossier.procedure, dossier)) ? 'active' : nil }
-        - if notifications_summary[:messagerie]
-          %span.notifications{ 'aria-label': 'notifications' }
-        = link_to "Messagerie", messagerie_gestionnaire_dossier_path(dossier.procedure, dossier)
-      %li{ class: current_page?(personnes_impliquees_gestionnaire_dossier_path(dossier.procedure, dossier)) ? 'active' : nil }
-        = link_to "Personnes impliquées", personnes_impliquees_gestionnaire_dossier_path(dossier.procedure, dossier)
+
+      = active_tab_item('Demande',
+        gestionnaire_dossier_path(dossier.procedure, dossier),
+        notification: notifications_summary[:demande])
+
+      = active_tab_item('Annotations privées',
+        annotations_privees_gestionnaire_dossier_path(dossier.procedure, dossier),
+        notification: notifications_summary[:annotations_privees])
+
+      = active_tab_item('Avis externes',
+        avis_gestionnaire_dossier_path(dossier.procedure, dossier),
+        notification: notifications_summary[:avis])
+
+      = active_tab_item('Messagerie',
+        messagerie_gestionnaire_dossier_path(dossier.procedure, dossier),
+        notification: notifications_summary[:messagerie])
+
+      = active_tab_item('Personnes impliquées',
+        personnes_impliquees_gestionnaire_dossier_path(dossier.procedure, dossier))
 
 .container
   .print-header

--- a/app/views/new_gestionnaire/procedures/show.html.haml
+++ b/app/views/new_gestionnaire/procedures/show.html.haml
@@ -9,35 +9,34 @@
 
       .procedure-header
         %h1= procedure_libelle @procedure
+
         %ul.tabs
-          %li{ class: (@statut == 'a-suivre') ? 'active' : nil }>
-            = link_to(gestionnaire_procedure_path(@procedure, statut: 'a-suivre')) do
-              à suivre
-              %span.badge= @a_suivre_dossiers.count
+          = tab_item('à suivre',
+            gestionnaire_procedure_path(@procedure, statut: 'a-suivre'),
+            active: @statut == 'a-suivre',
+            badge: @a_suivre_dossiers.count)
 
-          %li{ class: (@statut == 'suivis') ? 'active' : nil }>
-            - if current_gestionnaire.notifications_for_procedure(@procedure).present?
-              %span.notifications{ 'aria-label': 'notifications' }
-            = link_to(gestionnaire_procedure_path(@procedure, statut: 'suivis')) do
-              = t('pluralize.followed', count: @followed_dossiers.count)
-              %span.badge= @followed_dossiers.count
+          = tab_item(t('pluralize.followed', count: @followed_dossiers.count),
+            gestionnaire_procedure_path(@procedure, statut: 'suivis'),
+            active: @statut == 'suivis',
+            badge: @followed_dossiers.count,
+            notification: current_gestionnaire.notifications_for_procedure(@procedure).present?)
 
-          %li{ class: (@statut == 'traites') ? 'active' : nil }>
-            - if current_gestionnaire.notifications_for_procedure(@procedure, :termine).present?
-              %span.notifications{ 'aria-label': 'notifications' }
-            = link_to(gestionnaire_procedure_path(@procedure, statut: 'traites')) do
-              = t('pluralize.processed', count: @termines_dossiers.count)
-              %span.badge= @termines_dossiers.count
+          = tab_item(t('pluralize.processed', count: @termines_dossiers.count),
+            gestionnaire_procedure_path(@procedure, statut: 'traites'),
+            active: @statut == 'traites',
+            badge: @termines_dossiers.count,
+            notification: current_gestionnaire.notifications_for_procedure(@procedure, :termine).present?)
 
-          %li{ class: (@statut == 'tous') ? 'active' : nil }>
-            = link_to(gestionnaire_procedure_path(@procedure, statut: 'tous')) do
-              tous les dossiers
-              %span.badge= @all_state_dossiers.count
+          = tab_item('tous les dossiers',
+            gestionnaire_procedure_path(@procedure, statut: 'tous'),
+            active: @statut == 'tous',
+            badge: @all_state_dossiers.count)
 
-          %li{ class: (@statut == 'archives') ? 'active' : nil }>
-            = link_to(gestionnaire_procedure_path(@procedure, statut: 'archives')) do
-              = t('pluralize.archived', count: @archived_dossiers.count)
-              %span.badge= @archived_dossiers.count
+          = tab_item(t('pluralize.archived', count: @archived_dossiers.count),
+            gestionnaire_procedure_path(@procedure, statut: 'archives'),
+            active: @statut == 'archives',
+            badge: @archived_dossiers.count)
 
       .procedure-actions
         = render partial: "download_dossiers", locals: { procedure: @procedure }

--- a/app/views/new_user/dossiers/index.html.haml
+++ b/app/views/new_user/dossiers/index.html.haml
@@ -8,12 +8,13 @@
     - else
       %h1.page-title Dossiers
       %ul.tabs
-        %li{ class: (@current_tab == 'mes-dossiers') ? 'active' : nil }>
-          = link_to(dossiers_path(current_tab: 'mes-dossiers')) do
-            mes dossiers
-        %li{ class: (@current_tab == 'dossiers-invites') ? 'active' : nil }>
-          = link_to(dossiers_path(current_tab: 'dossiers-invites')) do
-            dossiers invités
+        = tab_item('mes dossiers',
+          dossiers_path(current_tab: 'mes-dossiers'),
+          active: @current_tab == 'mes-dossiers')
+
+        = tab_item('dossiers invités',
+          dossiers_path(current_tab: 'dossiers-invites'),
+          active: @current_tab == 'dossiers-invites')
 
 .container
   - if @dossiers.present?

--- a/app/views/new_user/dossiers/show/_header.html.haml
+++ b/app/views/new_user/dossiers/show/_header.html.haml
@@ -8,7 +8,5 @@
       %h2 Dossier nº #{dossier.id}
 
     %ul.tabs
-      %li{ class: current_page?(dossier_path(dossier)) ? 'active' : nil }
-        = link_to "Résumé", dossier_path(dossier)
-      %li{ class: current_page?(formulaire_dossier_path(dossier)) ? 'active' : nil }
-        = link_to "Formulaire", formulaire_dossier_path(dossier)
+      = active_tab_item('Résumé', dossier_path(dossier))
+      = active_tab_item('Formulaire', formulaire_dossier_path(dossier))

--- a/app/views/root/patron.html.haml
+++ b/app/views/root/patron.html.haml
@@ -168,14 +168,10 @@
     .container
       Titre
       %ul.tabs
-        %li.active
-          = link_to "Onglet actif", "#"
-        %li
-          = link_to "Onglet inactif", "#"
-        %li
-          = link_to "#" do
-            Onglet avec badge
-            %span.badge 2
+        = tab_item("Onglet actif", "#", active: true)
+        = tab_item("Onglet inactif", "#")
+        = tab_item("Onglet avec badge", "#", badge: 2)
+        = tab_item("Onglet avec notification", "#", notification: true)
 
   .container
     %h1 Breadcrumbs

--- a/app/views/shared/_tab_item.html.haml
+++ b/app/views/shared/_tab_item.html.haml
@@ -1,0 +1,7 @@
+%li{ class: (active ? 'active' : nil) }
+  - if notification
+    %span.notifications{ 'aria-label': 'notifications' }
+  = link_to(url) do
+    = label
+    - if badge.present?
+      %span.badge= badge


### PR DESCRIPTION
Ça ne réduit pas forcément le nombre de ligne de code dans les templates, mais ça les rend plus claires et plus DRY.