### PR TITLE
Add layout for notifications mails

### DIFF
--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -48,7 +48,13 @@ class NotificationMailer < ApplicationMailer
 
     create_commentaire_for_notification(dossier, subject, body)
 
-    mail(subject: subject, to: email) { |format| format.html { body } }
+    @dossier = dossier
+
+    mail(subject: subject, to: email) do |format|
+      # rubocop:disable Rails/OutputSafety
+      format.html { render(html: body.html_safe, layout: 'mailers/notification') }
+      # rubocop:enable Rails/OutputSafety
+    end
   end
 
   def create_commentaire_for_notification(dossier, subject, body)

--- a/app/views/layouts/mailers/notification.html.haml
+++ b/app/views/layouts/mailers/notification.html.haml
@@ -1,0 +1,9 @@
+= yield
+
+%p ---
+
+%p.footer
+  %strong
+    Merci de ne pas répondre à cet email. Pour vous adresser à votre administration, passez directement par votre
+    = succeed '.' do
+      = link_to 'messagerie', users_dossier_recapitulatif_url(@dossier), target: '_blank'

--- a/app/views/notification_mailer/closed_mail.html.haml
+++ b/app/views/notification_mailer/closed_mail.html.haml
@@ -12,9 +12,3 @@
 
 %p
   L'équipe demarches-simplifiees.fr
-
-%p
-  —
-
-%p
-  Merci de ne pas répondre à cet email. Postez directement vos questions dans votre dossier sur la plateforme.

--- a/app/views/notification_mailer/closed_mail_with_attestation.html.haml
+++ b/app/views/notification_mailer/closed_mail_with_attestation.html.haml
@@ -15,9 +15,3 @@
 
 %p
   L'équipe demarches-simplifiees.fr
-
-%p
-  —
-
-%p
-  Merci de ne pas répondre à cet email. Postez directement vos questions dans votre dossier sur la plateforme.

--- a/app/views/notification_mailer/initiated_mail.html.haml
+++ b/app/views/notification_mailer/initiated_mail.html.haml
@@ -12,9 +12,3 @@
 
 %p
   L'équipe demarches-simplifiees.fr
-
-%p
-  —
-
-%p
-  Merci de ne pas répondre à cet email. Postez directement vos questions dans votre dossier sur la plateforme.

--- a/app/views/notification_mailer/received_mail.html.haml
+++ b/app/views/notification_mailer/received_mail.html.haml
@@ -9,9 +9,3 @@
 
 %p
   L'équipe demarches-simplifiees.fr
-
-%p
-  —
-
-%p
-  Merci de ne pas répondre à cet email. Postez directement vos questions dans votre dossier sur la plateforme.

--- a/app/views/notification_mailer/refused_mail.html.haml
+++ b/app/views/notification_mailer/refused_mail.html.haml
@@ -15,9 +15,3 @@
 
 %p
   L'équipe demarches-simplifiees.fr
-
-%p
-  —
-
-%p
-  Merci de ne pas répondre à cet email. Postez directement vos questions dans votre dossier sur la plateforme.

--- a/app/views/notification_mailer/without_continuation_mail.html.haml
+++ b/app/views/notification_mailer/without_continuation_mail.html.haml
@@ -15,9 +15,3 @@
 
 %p
   L'équipe demarches-simplifiees.fr
-
-%p
-  —
-
-%p
-  Merci de ne pas répondre à cet email. Postez directement vos questions dans votre dossier sur la plateforme.

--- a/spec/mailers/notification_mailer_spec.rb
+++ b/spec/mailers/notification_mailer_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe NotificationMailer, type: :mailer do
       klass = Class.new(described_class) do
         # We’re testing the (private) method `NotificationMailer#send_notification`.
         #
-        # The standard trick to test a private method would be to `send(:send_notification`, but doesn’t work here,
+        # The standard trick to test a private method would be to `send(:send_notification)`, but doesn’t work here,
         # because ActionMailer does some magic to expose public instace methods as class methods.
         # So, we use inheritance instead to make the private method public for testing purposes.
         def send_notification(dossier, template)

--- a/spec/mailers/notification_mailer_spec.rb
+++ b/spec/mailers/notification_mailer_spec.rb
@@ -33,7 +33,9 @@ RSpec.describe NotificationMailer, type: :mailer do
     end
 
     it { expect(mail.subject).to eq(email_template.subject_for_dossier) }
-    it { expect(mail.body).to eq(email_template.body_for_dossier) }
+    it { expect(mail.body).to include(email_template.body_for_dossier) }
+    it { expect(mail.body).to have_selector('.footer') }
+
     it_behaves_like "create a commentaire not notified"
   end
 
@@ -47,7 +49,8 @@ RSpec.describe NotificationMailer, type: :mailer do
 
     it do
       expect(mail.subject).to eq(email_template.subject)
-      expect(mail.body).to eq(email_template.body)
+      expect(mail.body).to include(email_template.body)
+      expect(mail.body).to have_selector('.footer')
     end
 
     it_behaves_like "create a commentaire not notified"

--- a/spec/mailers/notification_mailer_spec.rb
+++ b/spec/mailers/notification_mailer_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe NotificationMailer, type: :mailer do
   describe '.send_notification' do
     let(:email_template) { instance_double('email_template', subject_for_dossier: 'subject', body_for_dossier: 'body') }
 
-    subject do
+    subject(:mail) do
       klass = Class.new(described_class) do
         # We’re testing the (private) method `NotificationMailer#send_notification`.
         #
@@ -32,13 +32,13 @@ RSpec.describe NotificationMailer, type: :mailer do
       klass.send_notification(dossier, email_template)
     end
 
-    it { expect(subject.subject).to eq(email_template.subject_for_dossier) }
-    it { expect(subject.body).to eq(email_template.body_for_dossier) }
+    it { expect(mail.subject).to eq(email_template.subject_for_dossier) }
+    it { expect(mail.body).to eq(email_template.body_for_dossier) }
     it_behaves_like "create a commentaire not notified"
   end
 
   describe '.send_dossier_received' do
-    subject { described_class.send_dossier_received(dossier) }
+    subject(:mail) { described_class.send_dossier_received(dossier) }
     let(:email_template) { create(:received_mail) }
 
     before do
@@ -46,8 +46,8 @@ RSpec.describe NotificationMailer, type: :mailer do
     end
 
     it do
-      expect(subject.subject).to eq(email_template.subject)
-      expect(subject.body).to eq(email_template.body)
+      expect(mail.subject).to eq(email_template.subject)
+      expect(mail.body).to eq(email_template.body)
     end
 
     it_behaves_like "create a commentaire not notified"


### PR DESCRIPTION
MR suite a l'issue #2404
Ajout d'un layout pour les mails de notification (ouverture d'un dossier et changements d'état) qui comprend un footer avec une police en gras et un lien vers la messagerie du compte pour inciter les usager à ne pas répondre directement.

<img width="1176" alt="capture d ecran 2018-08-17 a 11 39 30" src="https://user-images.githubusercontent.com/22002486/44259597-437a4e00-a212-11e8-9be1-00d6762b8dcb.png">
