### PR TITLE
Hide the user satisfaction survey for now

### DIFF
--- a/app/views/new_user/dossiers/index.html.haml
+++ b/app/views/new_user/dossiers/index.html.haml
@@ -54,17 +54,6 @@
                   = dossier.updated_at.localtime.strftime("%d/%m/%Y")
     = paginate(@dossiers)
 
-    - if current_user.feedbacks.empty?
-      #user-satisfaction
-        %h3 Que pensez-vous de ce service ?
-        .icons
-          = link_to feedback_path(mark: 0), data: { remote: true, method: :post } do
-            %span.icon.frown
-          = link_to feedback_path(mark: 1), data: { remote: true, method: :post } do
-            %span.icon.meh
-          = link_to feedback_path(mark: 2), data: { remote: true, method: :post } do
-            %span.icon.smile
-
   - else
     .dossiers-table-empty
       %h2.empty-text Aucun dossier.

--- a/spec/views/new_user/dossiers/index.html.haml_spec.rb
+++ b/spec/views/new_user/dossiers/index.html.haml_spec.rb
@@ -71,17 +71,4 @@ describe 'new_user/dossiers/index.html.haml', type: :view do
       expect(rendered).to have_selector('ul.tabs li.active', count: 1)
     end
   end
-
-  context "quand le user n'a aucun feedback" do
-    it "affiche le formulaire de satisfaction" do
-      expect(rendered).to have_selector('#user-satisfaction', text: 'Que pensez-vous de ce service ?')
-    end
-  end
-
-  context "quand le user a un feedback" do
-    let(:user) { create(:user, feedbacks: [build(:feedback)]) }
-    it "n'affiche pas le formulaire de satisfaction" do
-      expect(rendered).to_not have_selector('#user-satisfaction')
-    end
-  end
 end


### PR DESCRIPTION
Je propose de cacher le formulaire de satisfaction.

1. La question, « Que pensez-vous de ce service ? », est ambiguë. Qu’évalue-t-on ? Le site ? Le formulaire ? L’instruction ? Tout ? Comme c’est très flou, les résultats sont difficiles à interpréter.

2. On pourrait donc préciser la question. En particulier, et je pense que c’était l’intention d’origine, on peut demander quelque chose comme « Trouvez-vous ce site simple à utiliser ? ». Mais étant donné que l’interface usager est en pleine refonte, ça ne me semble pas très judicieux.

3. Dans tous les cas, il manque pour moi la possibilité de donner son avis de manière plus approfondie, par exemple avec un lien vers notre adresse de contact ou une textarea pour expliquer sa note. Sans ça j’ai du mal à voir comment on va pouvoir facilement identifier avec précision ce qui a provoqué une mauvaise note et que l’on peut améliorer. Mais il nous faut alors réfléchir à ce qu’on demande et comment on le demande, ainsi qu’au design de ce module (par exemple, il ne me semble pas très judicieux de la mettre en bas de page).