### PR TITLE
Frederic/fix 2179 update dossier search

### DIFF
--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -85,12 +85,12 @@ class Dossier < ApplicationRecord
       user&.email,
       france_connect_information&.given_name,
       france_connect_information&.family_name,
-      *ordered_champs.flat_map(&:search_terms),
+      *champs.flat_map(&:search_terms),
       *etablissement&.search_terms,
       individual&.nom,
       individual&.prenom
     ].compact.join(' ')
-    self.private_search_terms = ordered_champs_private.flat_map(&:search_terms).compact.join(' ')
+    self.private_search_terms = champs_private.flat_map(&:search_terms).compact.join(' ')
   end
 
   def was_piece_justificative_uploaded_for_type_id?(type_id)

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -69,10 +69,11 @@ class Dossier < ApplicationRecord
   delegate :france_connect_information, to: :user
 
   before_validation :update_state_dates, if: -> { state_changed? }
+
+  before_save :build_default_champs, if: Proc.new { procedure_id_changed? }
+  before_save :build_default_individual, if: Proc.new { procedure.for_individual? }
   before_save :update_search_terms
 
-  after_save :build_default_champs, if: Proc.new { saved_change_to_procedure_id? }
-  after_save :build_default_individual, if: Proc.new { procedure.for_individual? }
   after_save :send_dossier_received
   after_save :send_web_hook
   after_create :send_draft_notification_email
@@ -105,14 +106,17 @@ class Dossier < ApplicationRecord
   end
 
   def build_default_champs
-    procedure.all_types_de_champ.each do |type_de_champ|
-      type_de_champ.champ.create(dossier: self)
+    procedure.types_de_champ.each do |type_de_champ|
+      champs << type_de_champ.champ.build
+    end
+    procedure.types_de_champ_private.each do |type_de_champ|
+      champs_private << type_de_champ.champ.build
     end
   end
 
   def build_default_individual
     if Individual.where(dossier_id: self.id).count == 0
-      Individual.create(dossier: self)
+      build_individual
     end
   end
 

--- a/spec/models/dossier_spec.rb
+++ b/spec/models/dossier_spec.rb
@@ -39,16 +39,30 @@ describe Dossier do
       let(:dossier) { create(:dossier, etablissement: etablissement, user: user, procedure: procedure) }
       let(:france_connect_information) { build(:france_connect_information, given_name: 'Chris', family_name: 'Harrisson') }
       let(:user) { build(:user, france_connect_information: france_connect_information) }
+      let(:champ_public) { dossier.champs.first }
+      let(:champ_private) { dossier.champs_private.first }
 
       before do
-        dossier.champs.each { |c| c.update_attribute(:value, "champ public") }
-        dossier.champs_private.each { |c| c.update_attribute(:value, "champ privé") }
+        champ_public.update_attribute(:value, "champ public")
+        champ_private.update_attribute(:value, "champ privé")
 
         dossier.update_search_terms
       end
 
       it { expect(dossier.search_terms).to eq("#{user.email} #{france_connect_information.given_name} #{france_connect_information.family_name} champ public #{etablissement.entreprise_siren} #{etablissement.entreprise_numero_tva_intracommunautaire} #{etablissement.entreprise_forme_juridique} #{etablissement.entreprise_forme_juridique_code} #{etablissement.entreprise_nom_commercial} #{etablissement.entreprise_raison_sociale} #{etablissement.entreprise_siret_siege_social} #{etablissement.entreprise_nom} #{etablissement.entreprise_prenom} #{etablissement.association_rna} #{etablissement.association_titre} #{etablissement.association_objet} #{etablissement.siret} #{etablissement.naf} #{etablissement.libelle_naf} #{etablissement.adresse} #{etablissement.code_postal} #{etablissement.localite} #{etablissement.code_insee_localite}") }
       it { expect(dossier.private_search_terms).to eq('champ privé') }
+
+      context 'with an update' do
+        before do
+          dossier.update(
+            champs_attributes: [{ id: champ_public.id, value: 'nouvelle valeur publique' }],
+            champs_private_attributes: [{ id: champ_private.id, value: 'nouvelle valeur privee' }]
+          )
+        end
+
+        it { expect(dossier.search_terms).to include('nouvelle valeur publique') }
+        it { expect(dossier.private_search_terms).to include('nouvelle valeur privee') }
+      end
     end
 
     describe '#types_de_piece_justificative' do


### PR DESCRIPTION
Corrige ce problème soulevé par @kemenaran dans #2317 :

> Quand on modifie un dossier (par exemple en modifiant un dossier déjà soumis), la valeur précédente des champs est enregistré dans les search terms.

Explication : `ordered_champs` allait chercher les valeurs en base, qui n’avaient pas été mises à jour. Maintenant j’utilise `champs`, qui utilise les nouvelles valeurs updatées, qui sont sur le point d’être persistées en base.

Par contre, ce changement a fait péter un tas de tests unitaires, pour la raison suivante : quand un nouveau dossier est créé, `update_search_terms`, en lisant le contenu de `champs`, provoquait le chargement de l’association, vide à cet instant. Ce n’est qu’après que passait `build_default_champs` passait et créait les champs en base, mais sans mettre à jour `champs`, et ça perturbait des tests unitaires de voir `champs` vide. Théoriquement ça pouvait aussi affecter du code de prod même si je n’ai pas d’exemple concret.
J’aurais pu me contenter de coller un `champs.reload` dans `build_default_champs` mais j’ai l’impression d’avoir fait plus propre.

J’ai fait le même changement sur `build_default_individual`, plus par précaution (je n’ai observé de cas cassant).