### PR TITLE
Add a warning in the attachements part of the form

### DIFF
--- a/app/assets/stylesheets/new_design/dossier_edit.scss
+++ b/app/assets/stylesheets/new_design/dossier_edit.scss
@@ -38,4 +38,11 @@
       flex-shrink: 0; // Display the button label on a single line
     }
   }
+
+  .warning {
+    margin-bottom: 20px;
+    background-color: #f9b91666;
+    padding: 20px;
+    border-radius: 4px;
+  }
 }

--- a/app/views/shared/dossiers/_edit.html.haml
+++ b/app/views/shared/dossiers/_edit.html.haml
@@ -32,6 +32,11 @@
         .card-title
           Pièces jointes
 
+        .warning
+          Pour éviter toute erreur, nous vous conseillons de limiter la taille de chaque pièce jointe à 20 Mo, et de les ajouter une par une, en enregistrant votre
+          = dossier.brouillon? ? "brouillon" : "dossier"
+          après chaque ajout.
+
         - tpjs.each do |tpj|
           .pj-input
             %label{ for: "piece_justificative_#{tpj.id}" }


### PR DESCRIPTION
<img width="1078" alt="screen shot 2018-08-31 at 00 09 51" src="https://user-images.githubusercontent.com/1333173/44882123-4bc29680-acb2-11e8-8444-09fe69a3935c.png">
