### PR TITLE
Utilise bin/setup et bin/update pour créer et maintenir l'environnement de développement

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,10 @@ demarches-simplifiees.fr est un site web conçu afin de répondre au besoin urge
 
 ### Développement
 
-- Mailcatcher : `gem install mailcatcher`
+- Yarn : voir https://yarnpkg.com/en/docs/install
 - Overmind :
   * Mac : `brew install overmind`
   * Linux : voir https://github.com/DarthSim/overmind#installation
-- Yarn : voir https://yarnpkg.com/en/docs/install
 
 ### Tests
 

--- a/README.md
+++ b/README.md
@@ -24,14 +24,7 @@ demarches-simplifiees.fr est un site web conçu afin de répondre au besoin urge
   * Mac : `brew install chromedriver`
   * Linux : voir https://sites.google.com/a/chromium.org/chromedriver/downloads
 
-## Initialisation de l'environnement de développement
-
-Afin d'initialiser l'environnement de développement, exécutez la commande suivante :
-
-    bundle install
-    yarn install
-
-## Création de la base de données
+## Création des rôles de la base de données
 
 Les informations nécessaire à l'initialisation de la base doivent être pré-configurées à la main grâce à la procédure suivante :
 
@@ -41,15 +34,11 @@ Les informations nécessaire à l'initialisation de la base doivent être pré-c
     > create user tps_test with password 'tps_test' superuser;
     > \q
 
-Afin de générer la BDD de l'application, il est nécessaire d'exécuter les commandes suivantes :
+## Initialisation de l'environnement de développement
 
-    # Create and initialize the database
-    bin/rails db:create db:schema:load db:seed
+Afin d'initialiser l'environnement de développement, exécutez la commande suivante :
 
-    # Migrate the development database and the test database
-    bin/rails db:migrate
-
-
+    bin/setup
 
 ## Lancement de l'application
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ L'application tourne à l'adresse `http://localhost:3000`. Un utilisateur de tes
     FindDubiousProceduresJob.set(cron: "0 0 * * *").perform_later
     Administrateurs::ActivateBeforeExpirationJob.set(cron: "0 8 * * *").perform_later
 
+## Mise à jour de l'application
+
+Pour mettre à jour votre environnement de développement, installer les nouvelles dépendances et faire jouer les migrations, exécutez :
+
+    bin/update
+
 ## Exécution des tests (RSpec)
 
 Pour exécuter les tests de l'application, plusieurs possibilités :

--- a/README.md
+++ b/README.md
@@ -49,13 +49,7 @@ Afin de générer la BDD de l'application, il est nécessaire d'exécuter les co
     # Migrate the development database and the test database
     bin/rails db:migrate
 
-## Bouchonnage de la configuration
 
-Créer le fichier de configuration avec les valeurs par défaut :
-
-    cp config/env.example .env
-
-*Note : les vraies valeurs pour ces paramètres sont renseignées dans le Keepass*
 
 ## Lancement de l'application
 

--- a/bin/setup
+++ b/bin/setup
@@ -29,6 +29,7 @@ chdir APP_ROOT do
     cp 'config/env.example', '.env'
   end
 
+  # Create the database, load the schema, and initialize it with the seed data
   puts "\n== Preparing database =="
   system! 'bin/rails db:setup'
 

--- a/bin/setup
+++ b/bin/setup
@@ -24,10 +24,10 @@ chdir APP_ROOT do
   # Install JavaScript dependencies if using Yarn
   # system('bin/yarn')
 
-  # puts "\n== Copying sample files =="
-  # unless File.exist?('config/database.yml')
-  #   cp 'config/database.yml.sample', 'config/database.yml'
-  # end
+  puts "\n== Copying sample files =="
+  unless File.exist?('.env')
+    cp 'config/env.example', '.env'
+  end
 
   puts "\n== Preparing database =="
   system! 'bin/rails db:setup'

--- a/bin/setup
+++ b/bin/setup
@@ -21,8 +21,6 @@ chdir APP_ROOT do
   system('bundle check') || system!('bundle install')
   system! 'bin/yarn install'
 
-  # Install JavaScript dependencies if using Yarn
-  # system('bin/yarn')
 
   puts "\n== Copying sample files =="
   unless File.exist?('.env')

--- a/bin/setup
+++ b/bin/setup
@@ -13,7 +13,10 @@ chdir APP_ROOT do
   # This script is a starting point to setup your application.
   # Add necessary setup steps to this file.
 
-  puts '== Installing dependencies =='
+  puts '== Installing global tools =='
+  system! 'gem install mailcatcher --conservative'
+
+  puts "\n== Installing dependencies =="
   system! 'gem install bundler --conservative'
   system('bundle check') || system!('bundle install')
   system! 'bin/yarn install'

--- a/bin/setup
+++ b/bin/setup
@@ -16,6 +16,7 @@ chdir APP_ROOT do
   puts '== Installing dependencies =='
   system! 'gem install bundler --conservative'
   system('bundle check') || system!('bundle install')
+  system! 'bin/yarn install'
 
   # Install JavaScript dependencies if using Yarn
   # system('bin/yarn')

--- a/bin/setup
+++ b/bin/setup
@@ -36,6 +36,6 @@ chdir APP_ROOT do
   puts "\n== Removing old logs and tempfiles =="
   system! 'bin/rails log:clear tmp:clear'
 
-  puts "\n== Restarting application server =="
-  system! 'bin/rails restart'
+  puts "\n== Done =="
+  puts "You can now start the application server with `overmind start`."
 end

--- a/bin/update
+++ b/bin/update
@@ -16,9 +16,7 @@ chdir APP_ROOT do
   puts '== Installing dependencies =='
   system! 'gem install bundler --conservative'
   system('bundle check') || system!('bundle install')
-
-  # Install JavaScript dependencies if using Yarn
-  # system('bin/yarn')
+  system! 'bin/yarn install'
 
   puts "\n== Updating database =="
   system! 'bin/rails db:migrate'

--- a/bin/update
+++ b/bin/update
@@ -21,8 +21,8 @@ chdir APP_ROOT do
   puts "\n== Updating database =="
   system! 'bin/rails db:migrate'
 
-  puts "\n== Removing old logs and tempfiles =="
-  system! 'bin/rails log:clear tmp:clear'
+  puts "\n== Removing old logs =="
+  system! 'bin/rails log:clear'
 
   puts "\n== Restarting application server =="
   system! 'bin/rails restart'

--- a/bin/update
+++ b/bin/update
@@ -24,6 +24,6 @@ chdir APP_ROOT do
   puts "\n== Removing old logs =="
   system! 'bin/rails log:clear'
 
-  puts "\n== Restarting application server =="
-  system! 'bin/rails restart'
+  puts "\n== Done =="
+  puts "You can now start (or restart) the application server with `overmind start`."
 end


### PR DESCRIPTION
`bin/setup` et `bin/update` sont présent par convention dans Rails 5+.

Ils permettent de diminuer le nombre d'instructions manuelles dans les README, en automatisant tout ça.