### PR TITLE
initializers: check at runtime that env vars declared in env.example are present

### DIFF
--- a/config/initializers/env_vars.rb
+++ b/config/initializers/env_vars.rb
@@ -1,0 +1,13 @@
+# Ensure that the environment variables defined in the reference env vars file
+# are present in the execution environment.
+#
+# This protects against an out-to-date environment leading to runtime errors.
+
+if ENV['RAILS_ENV'] != 'test' && File.basename($0) != 'rake'
+  reference_env_file = File.join('config', 'env.example')
+  Dotenv::Environment.new(Rails.root.join(reference_env_file)).each do |key, value|
+    if !ENV.key?(key.to_s)
+      raise "Configuration error: `#{key}` is not present in the process’ environment variables (declared in `#{reference_env_file}`)"
+    end
+  end
+end


### PR DESCRIPTION
If an environment variable is declared in `config/env.example`, but not present in the actual environment, the server initialization will raise an exception.

Empty strings are allowed (because some values are relevant only in development or production).

Fix #2458 