### PR TITLE
Fix dossier printing page

### DIFF
--- a/app/views/new_gestionnaire/dossiers/print.html.haml
+++ b/app/views/new_gestionnaire/dossiers/print.html.haml
@@ -84,7 +84,7 @@
   %ul.messages-list
     - @dossier.commentaires.each do |commentaire|
       %li
-        = render partial: "new_gestionnaire/shared/messages/message", locals: { commentaire: commentaire, user_email: current_gestionnaire.email, messagerie_seen_at: nil }
+        = render partial: "shared/dossiers/messages/message", locals: { commentaire: commentaire, user_email: current_gestionnaire.email, messagerie_seen_at: nil }
 
 %script{ type: "text/javascript" }
   window.print();

--- a/spec/factories/dossier.rb
+++ b/spec/factories/dossier.rb
@@ -64,6 +64,12 @@ FactoryBot.define do
       end
     end
 
+    trait :with_commentaires do
+      after(:create) do |dossier, _evaluator|
+        dossier.commentaires += create_list(:commentaire, 2)
+      end
+    end
+
     trait :followed do
       after(:create) do |dossier, _evaluator|
         g = create(:gestionnaire)

--- a/spec/views/new_gestionnaire/dossiers/print.html.haml_spec.rb
+++ b/spec/views/new_gestionnaire/dossiers/print.html.haml_spec.rb
@@ -3,7 +3,7 @@ describe 'new_gestionnaire/dossiers/print.html.haml', type: :view do
 
   context "with a dossier" do
     let(:current_gestionnaire) { create(:gestionnaire) }
-    let(:dossier) { create(:dossier, :en_instruction) }
+    let(:dossier) { create(:dossier, :en_instruction, :with_commentaires) }
 
     before do
       assign(:dossier, dossier)


### PR DESCRIPTION
La page d'impression d'un dossier pour les Instructeurs est cassée par la PR récente sur les messages.

- Correction du template invalide ;
- Ajout d'un test.