### PR TITLE
Dossier : affiche le dernier message en date sur la page de Résumé

### DIFF
--- a/app/assets/stylesheets/new_design/dossier_show.scss
+++ b/app/assets/stylesheets/new_design/dossier_show.scss
@@ -38,4 +38,15 @@
   .messagerie-explanation {
     margin-bottom: $default-padding * 2;
   }
+
+  .latest-message-section {
+    display: flex;
+    flex-direction: column;
+    max-width: 700px;
+    margin-bottom: $default-padding * 2;
+
+    .button.send {
+      align-self: flex-end;
+    }
+  }
 }

--- a/app/assets/stylesheets/new_design/message.scss
+++ b/app/assets/stylesheets/new_design/message.scss
@@ -9,6 +9,10 @@
   background: #FFFFFF;
   border-radius: 3px;
 
+  &.inverted-background {
+    background: $light-grey;
+  }
+
   .person-icon {
     margin-right: $default-spacer;
   }

--- a/app/assets/stylesheets/new_design/status_overview.scss
+++ b/app/assets/stylesheets/new_design/status_overview.scss
@@ -3,6 +3,7 @@
 
 .status-overview {
   text-align: center;
+  margin-bottom: $default-padding * 2;
 }
 
 .status-timeline {

--- a/app/helpers/commentaire_helper.rb
+++ b/app/helpers/commentaire_helper.rb
@@ -1,6 +1,6 @@
 module CommentaireHelper
-  def commentaire_is_from_me_class(commentaire, email)
-    if commentaire.email == email
+  def commentaire_is_from_me_class(commentaire, connected_user)
+    if commentaire.email == connected_user.email
       "from-me"
     end
   end

--- a/app/helpers/commentaire_helper.rb
+++ b/app/helpers/commentaire_helper.rb
@@ -1,6 +1,6 @@
 module CommentaireHelper
   def commentaire_is_from_me_class(commentaire, connected_user)
-    if commentaire.email == connected_user.email
+    if commentaire_is_from_me(commentaire, connected_user)
       "from-me"
     end
   end
@@ -13,5 +13,11 @@ module CommentaireHelper
     is_current_year = (commentaire.created_at.year == Date.current.year)
     template = is_current_year ? :message_date : :message_date_with_year
     I18n.l(commentaire.created_at.localtime, format: template)
+  end
+
+  private
+
+  def commentaire_is_from_me(commentaire, connected_user)
+    commentaire.email == connected_user.email
   end
 end

--- a/app/helpers/commentaire_helper.rb
+++ b/app/helpers/commentaire_helper.rb
@@ -5,6 +5,14 @@ module CommentaireHelper
     end
   end
 
+  def commentaire_answer_action(commentaire, connected_user)
+    if commentaire_is_from_me(commentaire, connected_user)
+      "Envoyer un message à l’instructeur"
+    else
+      "Répondre dans la messagerie"
+    end
+  end
+
   def commentaire_is_from_guest(commentaire)
     commentaire.dossier.invites.map(&:email).include?(commentaire.email)
   end

--- a/app/views/new_user/dossiers/show.html.haml
+++ b/app/views/new_user/dossiers/show.html.haml
@@ -5,3 +5,13 @@
 
   .container
     = render partial: 'new_user/dossiers/show/status_overview', locals: { dossier: @dossier }
+
+    - latest_message = @dossier.commentaires.last
+    - if latest_message.present?
+      .latest-message-section
+        %h3.tab-title Dernier message
+
+        .message.inverted-background
+          = render partial: "shared/dossiers/messages/message", locals: { commentaire: latest_message, connected_user: current_user, messagerie_seen_at: nil }
+
+        = link_to commentaire_answer_action(latest_message, current_user), messagerie_dossier_url(@dossier, anchor: 'new_commentaire'), class: 'button send'

--- a/app/views/shared/dossiers/_messagerie.html.haml
+++ b/app/views/shared/dossiers/_messagerie.html.haml
@@ -1,7 +1,7 @@
 .messagerie.container
   %ul.messages-list
     - dossier.commentaires.each do |commentaire|
-      %li.message{ class: commentaire_is_from_me_class(commentaire, connected_user.email) }
+      %li.message{ class: commentaire_is_from_me_class(commentaire, connected_user) }
         = render partial: "shared/dossiers/messages/message", locals: { commentaire: commentaire, connected_user: connected_user, messagerie_seen_at: messagerie_seen_at }
 
   = render partial: "shared/dossiers/messages/form", locals: { commentaire: new_commentaire, form_url: form_url }

--- a/spec/features/new_user/dossier_details_spec.rb
+++ b/spec/features/new_user/dossier_details_spec.rb
@@ -4,7 +4,7 @@ describe 'Dossier details:' do
     tdcs = [create(:type_de_champ, libelle: 'texte obligatoire')]
     create(:procedure, :published, :for_individual, types_de_champ: tdcs)
   end
-  let(:dossier) { create(:dossier, :en_construction, :for_individual, user: user, procedure: simple_procedure) }
+  let(:dossier) { create(:dossier, :en_construction, :for_individual, :with_commentaires, user: user, procedure: simple_procedure) }
 
   before do
     Flipflop::FeatureSet.current.test!.switch!(:new_dossier_details, true)
@@ -16,6 +16,7 @@ describe 'Dossier details:' do
     expect(page).to have_current_path(dossier_path(dossier))
     expect(page).to have_content(dossier.id)
     expect(page).to have_selector('.status-explanation')
+    expect(page).to have_text(dossier.commentaires.last.body)
   end
 
   scenario 'the user can see and edit dossier before instruction' do

--- a/spec/helpers/commentaire_helper_spec.rb
+++ b/spec/helpers/commentaire_helper_spec.rb
@@ -7,13 +7,27 @@ RSpec.describe CommentaireHelper, type: :helper do
     subject { commentaire_is_from_me_class(commentaire, me) }
 
     context "when commentaire is from me" do
-      let(:me) { "michel@pref.fr" }
+      let(:me) { User.new(email: "michel@pref.fr") }
       it { is_expected.to eq("from-me") }
     end
 
     context "when commentaire is not from me" do
-      let(:me) { "roger@usager.fr" }
+      let(:me) { User.new(email: "roger@usager.fr") }
       it { is_expected.to eq nil }
+    end
+  end
+
+  describe '.commentaire_answer_action' do
+    subject { commentaire_answer_action(commentaire, me) }
+
+    context "when commentaire is from me" do
+      let(:me) { User.new(email: "michel@pref.fr") }
+      it { is_expected.to include('Envoyer') }
+    end
+
+    context "when commentaire is not from me" do
+      let(:me) { User.new(email: "roger@usager.fr") }
+      it { is_expected.to include('Répondre') }
     end
   end
 

--- a/spec/helpers/commentaire_helper_spec.rb
+++ b/spec/helpers/commentaire_helper_spec.rb
@@ -1,20 +1,18 @@
 require 'rails_helper'
 
 RSpec.describe CommentaireHelper, type: :helper do
-  describe ".commentaire_is_from_me_class" do
-    let(:commentaire) { create(:commentaire, email: "michel@pref.fr") }
+  let(:commentaire) { create(:commentaire, email: "michel@pref.fr") }
 
+  describe ".commentaire_is_from_me_class" do
     subject { commentaire_is_from_me_class(commentaire, me) }
 
     context "when commentaire is from me" do
       let(:me) { "michel@pref.fr" }
-
       it { is_expected.to eq("from-me") }
     end
 
     context "when commentaire is not from me" do
       let(:me) { "roger@usager.fr" }
-
       it { is_expected.to eq nil }
     end
   end

--- a/spec/views/new_user/dossiers/show.html.haml_spec.rb
+++ b/spec/views/new_user/dossiers/show.html.haml_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'new_user/dossiers/show.html.haml', type: :view do
-  let(:dossier) { create(:dossier, :en_construction, procedure: create(:procedure)) }
+  let(:dossier) { create(:dossier, :en_construction) }
 
   before do
     sign_in dossier.user
@@ -13,5 +13,16 @@ describe 'new_user/dossiers/show.html.haml', type: :view do
   it 'renders a summary of the dossier state' do
     expect(rendered).to have_text("Dossier nº #{dossier.id}")
     expect(rendered).to have_selector('.status-overview')
+  end
+
+  context 'with messages' do
+    let(:first_message) { create(:commentaire, body: 'Premier message') }
+    let(:last_message)  { create(:commentaire, body: 'Second message') }
+    let(:dossier) { create(:dossier, :en_construction, commentaires: [first_message, last_message]) }
+
+    it 'displays the last message' do
+      expect(rendered).not_to have_text(first_message.body)
+      expect(rendered).to have_text(last_message.body)
+    end
   end
 end


### PR DESCRIPTION
### Prérequis

- [x] #2538
- [x] #2534

---

Affichage du dernier message en date sur la page de Résumé (cf. #1818)

### Quand le dernier message est de l'administration

![screenshot_2018-09-06 resume dossier n 133522 demande de subvention au titre de l 39 amenagement du territoire dema](https://user-images.githubusercontent.com/179923/45163435-bc0c7300-b1f0-11e8-95b3-d96d85052a4d.png)

### Quand le dernier message est de l'usager

![screenshot_2018-09-06 resume dossier n 133522 demande de subvention au titre de l 39 amenagement du territoire dema 1](https://user-images.githubusercontent.com/179923/45163440-bf9ffa00-b1f0-11e8-9ac1-97cfd5e3fb06.png)
