### PR TITLE
Améliorations à la messagerie

### DIFF
--- a/app/assets/stylesheets/new_design/dossier_show.scss
+++ b/app/assets/stylesheets/new_design/dossier_show.scss
@@ -34,4 +34,8 @@
   .button.edit-form {
     float: right;
   }
+
+  .messagerie-explanation {
+    margin-bottom: $default-padding * 2;
+  }
 }

--- a/app/controllers/new_user/dossiers_controller.rb
+++ b/app/controllers/new_user/dossiers_controller.rb
@@ -144,7 +144,7 @@ module NewUser
       @commentaire = CommentaireService.create(current_user, dossier, commentaire_params)
 
       if @commentaire.save
-        flash.notice = "Message envoyé"
+        flash.notice = "Votre message a bien été envoyé à l’instructeur en charge de votre dossier."
         redirect_to messagerie_dossier_path(dossier)
       else
         flash.now.alert = @commentaire.errors.full_messages

--- a/app/helpers/commentaire_helper.rb
+++ b/app/helpers/commentaire_helper.rb
@@ -4,4 +4,10 @@ module CommentaireHelper
       "from-me"
     end
   end
+
+  def commentaire_date(commentaire)
+    is_current_year = (commentaire.created_at.year == Date.current.year)
+    template = is_current_year ? :message_date : :message_date_with_year
+    I18n.l(commentaire.created_at.localtime, format: template)
+  end
 end

--- a/app/helpers/commentaire_helper.rb
+++ b/app/helpers/commentaire_helper.rb
@@ -5,6 +5,10 @@ module CommentaireHelper
     end
   end
 
+  def commentaire_is_from_guest(commentaire)
+    commentaire.dossier.invites.map(&:email).include?(commentaire.email)
+  end
+
   def commentaire_date(commentaire)
     is_current_year = (commentaire.created_at.year == Date.current.year)
     template = is_current_year ? :message_date : :message_date_with_year

--- a/app/views/new_user/dossiers/messagerie.html.haml
+++ b/app/views/new_user/dossiers/messagerie.html.haml
@@ -3,4 +3,8 @@
 #dossier-show
   = render partial: 'new_user/dossiers/show/header', locals: { dossier: @dossier }
 
+  .container
+    %p.messagerie-explanation
+      La messagerie vous permet de contacter l’instructeur en charge de votre dossier.
+
   = render partial: "shared/dossiers/messagerie", locals: { dossier: @dossier, user_email: current_user.email, messagerie_seen_at: nil, new_commentaire: @commentaire, form_url: commentaire_dossier_path(@dossier) }

--- a/app/views/shared/dossiers/messages/_form.html.haml
+++ b/app/views/shared/dossiers/messages/_form.html.haml
@@ -8,4 +8,4 @@
           (taille max : 20 Mo)
 
     .send-wrapper
-      = f.submit 'Envoyer', class: 'button send', data: { disable: true }
+      = f.submit 'Envoyer', class: 'button primary send', data: { disable: true }

--- a/app/views/shared/dossiers/messages/_form.html.haml
+++ b/app/views/shared/dossiers/messages/_form.html.haml
@@ -7,5 +7,5 @@
         .notice
           (taille max : 20 Mo)
 
-    .send-wrapper
+    %div
       = f.submit 'Envoyer', class: 'button primary send', data: { disable: true }

--- a/app/views/shared/dossiers/messages/_message.html.haml
+++ b/app/views/shared/dossiers/messages/_message.html.haml
@@ -4,7 +4,7 @@
   %h2
     %span.mail
       = render partial: 'shared/dossiers/messages/message_issuer', locals: { commentaire: commentaire, user_email: user_email }
-    - if ![user_email, commentaire.dossier.user.email, OLD_CONTACT_EMAIL, CONTACT_EMAIL].include?(commentaire.email)
+    - if commentaire_is_from_guest(commentaire)
       %span.guest Invité
     %span.date{ class: highlight_if_unseen_class(messagerie_seen_at, commentaire.created_at) }
       = commentaire_date(commentaire)

--- a/app/views/shared/dossiers/messages/_message.html.haml
+++ b/app/views/shared/dossiers/messages/_message.html.haml
@@ -7,7 +7,7 @@
     - if ![user_email, commentaire.dossier.user.email, OLD_CONTACT_EMAIL, CONTACT_EMAIL].include?(commentaire.email)
       %span.guest Invité
     %span.date{ class: highlight_if_unseen_class(messagerie_seen_at, commentaire.created_at) }
-      = I18n.l(commentaire.created_at.localtime, format: '%d/%m/%Y à %H:%M ')
+      = commentaire_date(commentaire)
   .rich-text= sanitize(commentaire.body)
 
   - if commentaire.piece_justificative

--- a/app/views/shared/dossiers/messages/_message_issuer.html.haml
+++ b/app/views/shared/dossiers/messages/_message_issuer.html.haml
@@ -5,4 +5,4 @@
 - when CONTACT_EMAIL
   Email automatique
 - else
-  = commentaire.email
+  = commentaire.sender

--- a/config/locales/time_format.en.rb
+++ b/config/locales/time_format.en.rb
@@ -1,0 +1,10 @@
+{
+  :en => {
+    :time => {
+      :formats => {
+        :message_date => lambda { |time, _| "%B #{time.day.ordinalize} at %H:%M" },
+        :message_date_with_year => lambda { |time, _| "%B #{time.day.ordinalize} %Y at %H:%M" }
+      }
+    }
+  }
+}

--- a/config/locales/time_format.fr.rb
+++ b/config/locales/time_format.fr.rb
@@ -1,0 +1,10 @@
+{
+  :fr => {
+    :time => {
+      :formats => {
+        :message_date => lambda { |time, _| "le #{time.day == 1 ? '1er' : time.day} %B à %H h %M" },
+        :message_date_with_year => lambda { |time, _| "le #{time.day == 1 ? '1er' : time.day} %B %Y à %H h %M" }
+      }
+    }
+  }
+}

--- a/spec/helpers/commentaire_helper_spec.rb
+++ b/spec/helpers/commentaire_helper_spec.rb
@@ -18,4 +18,34 @@ RSpec.describe CommentaireHelper, type: :helper do
       it { is_expected.to eq nil }
     end
   end
+
+  describe '.commentaire_date' do
+    let(:present_date) { Time.local(2018, 9, 2, 10, 5, 0) }
+    let(:creation_date) { present_date }
+    let(:commentaire) do
+      Timecop.freeze(creation_date) { create(:commentaire, email: "michel@pref.fr") }
+    end
+
+    subject do
+      Timecop.freeze(present_date) { commentaire_date(commentaire) }
+    end
+
+    it 'doesn’t include the creation year' do
+      expect(subject).to eq 'le 2 septembre à 10 h 05'
+    end
+
+    context 'when displaying a commentaire created on a previous year' do
+      let(:creation_date) { present_date.prev_year }
+      it 'includes the creation year' do
+        expect(subject).to eq 'le 2 septembre 2017 à 10 h 05'
+      end
+    end
+
+    context 'when formatting the first day of the month' do
+      let(:present_date) { Time.local(2018, 9, 1, 10, 5, 0) }
+      it 'includes the ordinal' do
+        expect(subject).to eq 'le 1er septembre à 10 h 05'
+      end
+    end
+  end
 end

--- a/spec/helpers/commentaire_helper_spec.rb
+++ b/spec/helpers/commentaire_helper_spec.rb
@@ -19,6 +19,23 @@ RSpec.describe CommentaireHelper, type: :helper do
     end
   end
 
+  describe '.commentaire_is_from_guest' do
+    let(:dossier) { create(:dossier) }
+    let!(:guest) { create(:invite_user, dossier: dossier) }
+
+    subject { commentaire_is_from_guest(commentaire) }
+
+    context 'when the commentaire sender is not a guest' do
+      let(:commentaire) { create(:commentaire, dossier: dossier, email: "michel@pref.fr") }
+      it { is_expected.to be false }
+    end
+
+    context 'when the commentaire sender is a guest on this dossier' do
+      let(:commentaire) { create(:commentaire, dossier: dossier, email: guest.email) }
+      it { is_expected.to be true }
+    end
+  end
+
   describe '.commentaire_date' do
     let(:present_date) { Time.local(2018, 9, 2, 10, 5, 0) }
     let(:creation_date) { present_date }


### PR DESCRIPTION
Dans le cadre de #1818, quelques améliorations à la messagerie.

Dans la plupart des cas ces améliorations concernent autant les Usagers (quand la fonctionnalité sera activée) que les Instructeurs (qui utilisent déjà la nouvelle messagerie).

- Amélioration du formatage des dates et de l'heure
- Amélioration du positionnement du bouton "Envoyer"
- Le bouton "Envoyer" est un bouton primaire (en bleu)
- Usager: clarification du message de succès après l'envoi
- Usager: Correction du label "Invité" qui s'affichait pour les messages venant des Instructeurs
- Usager: ne plus jamais afficher l'email complet (ni des Instructeurs, ni des autres)

### Avant

![avant](https://user-images.githubusercontent.com/179923/45163817-79976600-b1f1-11e8-8644-0d6483f49722.png)

### Après

![apres](https://user-images.githubusercontent.com/179923/45163824-7c925680-b1f1-11e8-902a-868f2b959ae6.png)
