### PR TITLE
[WIP] javascript: fix event bubbling on Mobile Safari

### DIFF
--- a/app/javascript/packs/application-old.js
+++ b/app/javascript/packs/application-old.js
@@ -11,6 +11,7 @@ import 'babel-polyfill';
 import '../shared/sentry';
 import '../shared/rails-ujs-fix';
 import '../shared/safari-11-file-xhr-workaround';
+import '../shared/safari-events-bubbling';
 import '../shared/autocomplete';
 import '../shared/remote-input';
 

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -13,6 +13,7 @@ import 'babel-polyfill';
 import '../shared/sentry';
 import '../shared/rails-ujs-fix';
 import '../shared/safari-11-file-xhr-workaround';
+import '../shared/safari-events-bubbling';
 import '../shared/autocomplete';
 import '../shared/remote-input';
 

--- a/app/javascript/shared/safari-events-bubbling.js
+++ b/app/javascript/shared/safari-events-bubbling.js
@@ -1,0 +1,17 @@
+// Mobile Safari doesn't bubble mouse events by default, unless:
+//
+// - the target element of the event is a link or a form field.
+// - the target element, or any of its ancestors up to but not including the <body>, has an explicit event handler set for any of the mouse events. This event handler may be an empty function.
+// - the target element, or any of its ancestors up to and including the document has a cursor: pointer CSS declarations.
+//
+// (See https://www.quirksmode.org/blog/archives/2014/02/mouse_event_bub.html)
+//
+// This is a problem for us, because we bind a lot of click events as
+// `document.on('click', '.my-element', …)` – which requires proper bubbling.
+//
+// To fix this globally, add an empty event handler to a non-body parent element.
+// This will force all mouse events to bubble on Mobile Safari.
+
+addEventListener('turbolinks:load', () => {
+  document.querySelector('.page-wrapper').addEventListener('click', () => {});
+});

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -21,29 +21,30 @@
         sentry: #{raw(sentry_config)}
       }];
   %body
-    = render partial: 'layouts/outdated_browser_banner'
-    = render partial: 'layouts/pre_maintenance'
-    - if staging?
-      #beta
-        Env Test
+    .page-wrapper
+      = render partial: 'layouts/outdated_browser_banner'
+      = render partial: 'layouts/pre_maintenance'
+      - if staging?
+        #beta
+          Env Test
 
-    #wrap
-      .row
-        #header.navbar
-          = render partial: "layouts/navbar"
-      .row.no-margin
-        - if RenderPartialService.left_panel_exist? @left_pannel_url
-          .col-xs-2#left-panel
-            = render partial: @left_pannel_url
-            - main_container_size = 10
-        - else
-          - main_container_size = 12
+      #wrap
+        .row
+          #header.navbar
+            = render partial: "layouts/navbar"
+        .row.no-margin
+          - if RenderPartialService.left_panel_exist? @left_pannel_url
+            .col-xs-2#left-panel
+              = render partial: @left_pannel_url
+              - main_container_size = 10
+          - else
+            - main_container_size = 12
 
-        = render partial: 'layouts/main_container', locals: { main_container_size: main_container_size }
-    #mask-search
-      %h1
-        %i.fa.fa-times{ style: 'position: fixed; top: 10; right: 30; color: white;' }
+          = render partial: 'layouts/main_container', locals: { main_container_size: main_container_size }
+      #mask-search
+        %h1
+          %i.fa.fa-times{ style: 'position: fixed; top: 10; right: 30; color: white;' }
 
-    = render partial: 'layouts/switch_devise_profile_module'
+      = render partial: 'layouts/switch_devise_profile_module'
 
-    = render partial: 'layouts/footer', locals: { main_container_size: main_container_size }
+      = render partial: 'layouts/footer', locals: { main_container_size: main_container_size }


### PR DESCRIPTION
This fixes the dropdown menus not being activated on Mobile Safari (Fix #2448)

**Rationale**

On a plusieurs solutions pour corriger le problème :

- Transformer le dropdown en vrai élément `button`
- Ajouter une classe `cursor`
- Binder le event-handler sur un élément enfant (plutôt que sur `body`)
- Ajouter un event-handler vide global

J'ai audité le code, et on a beaucoup d'endroits où on fait `document.on('click', …, …)`. J'ai peur que ce quirk revienne nous manger assez vite, surtout vu qu'on teste assez peu Mobile Safari.

Du coup je suis parti sur la solution globale. Mais je veux bien vos avis.