### PR TITLE
Dossier : amélioration des états terminés

### DIFF
--- a/app/assets/images/icons/download-white.svg
+++ b/app/assets/images/icons/download-white.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="20" viewBox="0 0 16 20"><g fill="none" fill-rule="evenodd"><path d="M11.5 8H15l-7 7-7-7h3.5V1h7zM1 19h14" stroke="#FFF" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/><path d="M-4-2h24v24H-4z"/></g></svg>

--- a/app/assets/stylesheets/new_design/icons.scss
+++ b/app/assets/stylesheets/new_design/icons.scss
@@ -53,6 +53,10 @@
     background-image: image-url("icons/attachment.svg");
   }
 
+  &.download {
+    background-image: image-url("icons/download-white.svg");
+  }
+
   &.lock {
     background-image: image-url("icons/lock.svg");
   }

--- a/app/assets/stylesheets/new_design/patron.scss
+++ b/app/assets/stylesheets/new_design/patron.scss
@@ -1,7 +1,12 @@
-@import "placeholders";
+@import "colors";
 
 .patron {
   p {
     margin-bottom: 20px;
+  }
+
+  .icon.download {
+    background-color: $blue;
+    box-shadow: 0px 0px 1px 2px $blue;
   }
 }

--- a/app/assets/stylesheets/new_design/status_overview.scss
+++ b/app/assets/stylesheets/new_design/status_overview.scss
@@ -55,18 +55,28 @@
     margin: auto;
   }
 
-  h3 {
-    font-size: 1.1em;
-    font-weight: bold;
-    margin-bottom: $default-spacer;
-  }
-
   p {
     margin-bottom: $default-padding;
   }
 
+  .decision {
+    font-size: 1.2em;
+    margin-top: $default-padding * 3;
+    margin-bottom: $default-padding * 3;
+  }
+
+  .icon {
+    margin-right: $default-spacer;
+  }
+
+  h3 {
+    font-weight: bold;
+    margin-bottom: $default-spacer;
+  }
+
   blockquote {
     quotes: "« " " »" "‘" "’";
+    margin-bottom: $default-padding * 3;
   }
 
   blockquote::before {
@@ -77,7 +87,7 @@
     content: close-quote;
   }
 
-  .icon {
-    margin-right: $default-spacer;
+  .action {
+    margin-bottom: $default-padding * 3;
   }
 }

--- a/app/views/new_user/dossiers/show.html.haml
+++ b/app/views/new_user/dossiers/show.html.haml
@@ -9,12 +9,5 @@
   .container
     = render partial: 'new_user/dossiers/show/status_overview', locals: { dossier: @dossier }
 
-    - latest_message = @dossier.commentaires.last
-    - if latest_message.present?
-      .latest-message-section
-        %h3.tab-title Dernier message
-
-        .message.inverted-background
-          = render partial: "shared/dossiers/messages/message", locals: { commentaire: latest_message, connected_user: current_user, messagerie_seen_at: nil }
-
-        = link_to commentaire_answer_action(latest_message, current_user), messagerie_dossier_url(@dossier, anchor: 'new_commentaire'), class: 'button send'
+    - if !@dossier.termine?
+      = render partial: 'new_user/dossiers/show/latest_message', locals: { dossier: @dossier }

--- a/app/views/new_user/dossiers/show/_latest_message.html.haml
+++ b/app/views/new_user/dossiers/show/_latest_message.html.haml
@@ -1,0 +1,9 @@
+- latest_message = dossier.commentaires.last
+- if latest_message.present?
+  .latest-message-section
+    %h3.tab-title Dernier message
+
+    .message.inverted-background
+      = render partial: "shared/dossiers/messages/message", locals: { commentaire: latest_message, connected_user: current_user, messagerie_seen_at: nil }
+
+    = link_to commentaire_answer_action(latest_message, current_user), messagerie_dossier_url(dossier, anchor: 'new_commentaire'), class: 'button send'

--- a/app/views/new_user/dossiers/show/_status_overview.html.haml
+++ b/app/views/new_user/dossiers/show/_status_overview.html.haml
@@ -39,7 +39,10 @@
             %blockquote= dossier.motivation
 
           - if dossier.attestation.present?
-            = link_to 'Télécharger l’attestation', attestation_dossier_path(dossier), target: '_blank', class: 'button primary'
+            .action
+              = link_to attestation_dossier_path(dossier), target: '_blank', class: 'button primary' do
+                %span.icon.download
+                Télécharger l’attestation
 
     - elsif dossier.refuse?
       .refuse

--- a/app/views/new_user/dossiers/show/_status_overview.html.haml
+++ b/app/views/new_user/dossiers/show/_status_overview.html.haml
@@ -38,6 +38,9 @@
             %h3 Motif de l’acceptation
             %blockquote= dossier.motivation
 
+          - if dossier.attestation.present?
+            = link_to 'Télécharger l’attestation', attestation_dossier_path(dossier), target: '_blank', class: 'button primary'
+
     - elsif dossier.refuse?
       .refuse
         %p

--- a/app/views/new_user/dossiers/show/_status_overview.html.haml
+++ b/app/views/new_user/dossiers/show/_status_overview.html.haml
@@ -28,25 +28,25 @@
 
     - elsif dossier.accepte?
       .accepte
-        %p
+        %p.decision
           %span.icon.accept
           Votre dossier a été
           = succeed '.' do
             %strong accepté
 
-          - if dossier.motivation.present?
-            %h3 Motif de l’acceptation
-            %blockquote= dossier.motivation
+        - if dossier.motivation.present?
+          %h3 Motif de l’acceptation
+          %blockquote= dossier.motivation
 
-          - if dossier.attestation.present?
-            .action
-              = link_to attestation_dossier_path(dossier), target: '_blank', class: 'button primary' do
-                %span.icon.download
-                Télécharger l’attestation
+        - if dossier.attestation.present?
+          .action
+            = link_to attestation_dossier_path(dossier), target: '_blank', class: 'button primary' do
+              %span.icon.download
+              Télécharger l’attestation
 
     - elsif dossier.refuse?
       .refuse
-        %p
+        %p.decision
           %span.icon.refuse
           Nous sommes désolés, votre dossier a malheureusement été
           = succeed '.' do
@@ -56,16 +56,17 @@
           %h3 Motif du refus
           %blockquote= dossier.motivation
 
-        = link_to 'Envoyer un message à l’administration', messagerie_dossier_url(dossier, anchor: 'new_commentaire'), class: 'button'
+        .action
+          = link_to 'Envoyer un message à l’administration', messagerie_dossier_url(dossier, anchor: 'new_commentaire'), class: 'button'
 
     - elsif dossier.sans_suite?
       .sans-suite
-        %p
+        %p.decision
           %span.icon.without-continuation
           Votre dossier a été classé
           = succeed '.' do
             %strong sans suite
 
-          - if dossier.motivation.present?
-            %h3 Motif du classement sans suite
-            %blockquote= dossier.motivation
+        - if dossier.motivation.present?
+          %h3 Motif du classement sans suite
+          %blockquote= dossier.motivation

--- a/app/views/new_user/dossiers/show/_status_overview.html.haml
+++ b/app/views/new_user/dossiers/show/_status_overview.html.haml
@@ -50,6 +50,8 @@
           %h3 Motif du refus
           %blockquote= dossier.motivation
 
+        = link_to 'Envoyer un message à l’administration', messagerie_dossier_url(dossier, anchor: 'new_commentaire'), class: 'button'
+
     - elsif dossier.sans_suite?
       .sans-suite
         %p

--- a/app/views/root/patron.html.haml
+++ b/app/views/root/patron.html.haml
@@ -23,6 +23,7 @@
     %span.icon.search
     %span.icon.sign-out
     %span.icon.info
+    %span.icon.download
     %span.icon.frown
     %span.icon.meh
     %span.icon.smile

--- a/spec/factories/dossier.rb
+++ b/spec/factories/dossier.rb
@@ -136,5 +136,14 @@ FactoryBot.define do
         end
       end
     end
+
+    trait :with_attestation do
+      after(:create) do |dossier, _evaluator|
+        if dossier.procedure.attestation_template.blank?
+          dossier.procedure.attestation_template = create(:attestation_template)
+        end
+        dossier.attestation = dossier.build_attestation
+      end
+    end
   end
 end

--- a/spec/views/new_user/dossiers/show/_status_overview.html.haml_spec.rb
+++ b/spec/views/new_user/dossiers/show/_status_overview.html.haml_spec.rb
@@ -67,6 +67,11 @@ describe 'new_user/dossiers/show/_status_overview.html.haml', type: :view do
     it { is_expected.not_to have_selector('.status-timeline') }
     it { is_expected.to have_selector('.status-explanation .accepte') }
     it { is_expected.to have_text(dossier.motivation) }
+
+    context 'with attestation' do
+      let(:dossier) { create :dossier, :accepte, :with_attestation }
+      it { is_expected.to have_link(nil, href: attestation_dossier_path(dossier)) }
+    end
   end
 
   context 'when refusé' do

--- a/spec/views/new_user/dossiers/show/_status_overview.html.haml_spec.rb
+++ b/spec/views/new_user/dossiers/show/_status_overview.html.haml_spec.rb
@@ -75,6 +75,7 @@ describe 'new_user/dossiers/show/_status_overview.html.haml', type: :view do
     it { is_expected.not_to have_selector('.status-timeline') }
     it { is_expected.to have_selector('.status-explanation .refuse') }
     it { is_expected.to have_text(dossier.motivation) }
+    it { is_expected.to have_link(nil, href: messagerie_dossier_url(dossier, anchor: 'new_commentaire')) }
   end
 
   context 'when classé sans suite' do


### PR DESCRIPTION
Dans le cadre de #1818, cette PR améliore les infos affichées dans les états "Accepté", "Refusé" et "Sans suite".

Elle permet notamment de :

- Télécharger l'attestation (en cas d'acceptation)
- Contacter l'administration (en cas de rejet)

## Accepté

![screenshot_2018-09-17 resume dossier n 133522 demande de subvention au titre de l 39 amenagement du territoire dema](https://user-images.githubusercontent.com/179923/45625056-432cd700-ba8c-11e8-8847-41740de7786f.png)

## Refusé

![screenshot_2018-09-17 resume dossier n 133522 demande de subvention au titre de l 39 amenagement du territoire dema 1](https://user-images.githubusercontent.com/179923/45625063-46c05e00-ba8c-11e8-8417-ea732ba8d21f.png)

## Sans suite

![screenshot_2018-09-17 resume dossier n 133522 demande de subvention au titre de l 39 amenagement du territoire dema 2](https://user-images.githubusercontent.com/179923/45625075-4a53e500-ba8c-11e8-924e-1303d83d1b5b.png)
