### PR TITLE
Dossier : amélioration des textes décrivant les différents statuts

### DIFF
--- a/app/views/new_user/dossiers/show/_status_overview.html.haml
+++ b/app/views/new_user/dossiers/show/_status_overview.html.haml
@@ -19,8 +19,12 @@
 
     - elsif dossier.en_construction?
       .en-construction
-        %p Un accompagnant de l’administration est en train de vérifier que votre dossier est bien complet.
-        %p Si des modifications sont nécessaires, vous recevrez un email avec les modifications à effectuer. Et sinon, dès que votre dossier sera complet, il passera automatiquement en instruction.
+        %p Un instructeur de l’administration est en train de vérifier que votre dossier est bien complet. Si des modifications sont nécessaires, vous recevrez un message avec les modifications à effectuer.
+
+        %p
+          Sinon,
+          = succeed '.' do
+            %strong votre dossier passera directement en instruction
 
     - elsif dossier.en_instruction?
       .en-instruction

--- a/app/views/new_user/dossiers/show/_status_overview.html.haml
+++ b/app/views/new_user/dossiers/show/_status_overview.html.haml
@@ -1,8 +1,9 @@
 .status-overview
   - if !dossier.termine?
     %ul.status-timeline
-      %li.brouillon{ class: dossier.brouillon? ? 'active' : nil }
-        brouillon
+      - if dossier.brouillon?
+        %li.brouillon{ class: dossier.brouillon? ? 'active' : nil }
+          brouillon
       %li.en-construction{ class: dossier.en_construction? ? 'active' : nil }
         en construction
       %li.en-instruction{ class: dossier.en_instruction? ? 'active' : nil }

--- a/app/views/new_user/dossiers/show/_status_overview.html.haml
+++ b/app/views/new_user/dossiers/show/_status_overview.html.haml
@@ -28,8 +28,12 @@
 
     - elsif dossier.en_instruction?
       .en-instruction
-        %p Votre dossier est complet. Il est en cours d’examen par les agent·e·s de l’administration.
-        %p Dès que l’administration aura statué sur votre dossier, vous recevrez un email avec le résultat.
+        %p Votre dossier est complet. Il est en cours d’examen par les instructeur de l’administration.
+        %p
+          Dès que l’administration aura statué sur votre dossier,
+          %strong
+            vous recevrez un email
+          avec le résultat.
 
     - elsif dossier.accepte?
       .accepte

--- a/spec/views/new_user/dossiers/show/_status_overview.html.haml_spec.rb
+++ b/spec/views/new_user/dossiers/show/_status_overview.html.haml_spec.rb
@@ -39,7 +39,7 @@ describe 'new_user/dossiers/show/_status_overview.html.haml', type: :view do
     let(:dossier) { create :dossier, :en_construction }
 
     it 'renders the timeline (without the final states)' do
-      expect(rendered).to have_timeline_item('.brouillon').inactive
+      expect(rendered).not_to have_timeline_item('.brouillon')
       expect(rendered).to have_timeline_item('.en-construction').active
       expect(rendered).to have_timeline_item('.en-instruction').inactive
       expect(rendered).to have_timeline_item('.termine').inactive
@@ -52,7 +52,7 @@ describe 'new_user/dossiers/show/_status_overview.html.haml', type: :view do
     let(:dossier) { create :dossier, :en_instruction }
 
     it 'renders the timeline (without the final states)' do
-      expect(rendered).to have_timeline_item('.brouillon').inactive
+      expect(rendered).not_to have_timeline_item('.brouillon')
       expect(rendered).to have_timeline_item('.en-construction').inactive
       expect(rendered).to have_timeline_item('.en-instruction').active
       expect(rendered).to have_timeline_item('.termine').inactive


### PR DESCRIPTION
Cette PR améliore la formulation des messages qui décrivent les différents statuts et la marche à suivre. (cf. #1818)

- **On évite d'afficher l'étape "Brouillon" dans la timeline**. Brouillon, c'est un état transcient qu'on aimerait automatiser et rendre le plus transparent possible, pas une vraie étape d'instruction du dossier.
- Amélioration du texte `en construction`.
- Amélioration du texte `en instruction`.

## En construction

<img width="858" alt="capture d ecran 2018-09-18 a 10 30 38" src="https://user-images.githubusercontent.com/179923/45674899-53958e00-bb2e-11e8-8ba8-731c615405e0.png">

## En instruction

![screenshot_2018-09-17 resume dossier n 133522 demande de subvention au titre de l 39 amenagement du territoire dema](https://user-images.githubusercontent.com/179923/45625907-4de86b80-ba8e-11e8-9378-a05779e0000b.png)
