### PR TITLE
dossier: finish feature-switch for enabled new dossier details

### DIFF
--- a/app/controllers/support_controller.rb
+++ b/app/controllers/support_controller.rb
@@ -9,7 +9,7 @@ class SupportController < ApplicationController
     if direct_message? && create_commentaire
       flash.notice = "Votre message a été envoyé sur la messagerie de votre dossier."
 
-      redirect_to users_dossier_recapitulatif_path(dossier)
+      redirect_to helpers.url_for_dossier(dossier)
     elsif create_conversation
       flash.notice = "Votre message a été envoyé."
 

--- a/app/controllers/users/recapitulatif_controller.rb
+++ b/app/controllers/users/recapitulatif_controller.rb
@@ -4,7 +4,11 @@ class Users::RecapitulatifController < UsersController
   end
 
   def show
-    create_dossier_facade
+    if Flipflop.new_dossier_details?
+      redirect_to dossier_url(current_user_dossier)
+    else
+      create_dossier_facade
+    end
   end
 
   def initiate

--- a/app/helpers/dossier_helper.rb
+++ b/app/helpers/dossier_helper.rb
@@ -18,6 +18,8 @@ module DossierHelper
   def url_for_dossier(dossier)
     if dossier.brouillon?
       brouillon_dossier_path(dossier)
+    elsif Flipflop.new_dossier_details?
+      dossier_path(dossier)
     else
       users_dossier_recapitulatif_path(dossier)
     end

--- a/app/views/new_user/dossiers/_dossier_footer.html.haml
+++ b/app/views/new_user/dossiers/_dossier_footer.html.haml
@@ -20,7 +20,11 @@
               = link_to service.email, "mailto:#{service.email}"
             - else
               Directement
-              = link_to "par la messagerie", users_dossier_recapitulatif_path(dossier)
+              - if Flipflop.new_dossier_details?
+                = link_to "par la messagerie", messagerie_dossier_path(dossier)
+              - else
+                = link_to "par la messagerie", users_dossier_recapitulatif_path(dossier)
+
           %p
             Par téléphone :
             %a{ href: "tel:#{service.telephone}" }= service.telephone

--- a/app/views/new_user/dossiers/merci.html.haml
+++ b/app/views/new_user/dossiers/merci.html.haml
@@ -18,4 +18,7 @@
       %b échanger avec un instructeur
       lors de sa construction et de son instruction
 
-    = link_to 'Accéder à votre dossier', users_dossier_recapitulatif_path(@dossier), class: 'button large primary'
+    - if Flipflop.new_dossier_details?
+      = link_to 'Accéder à votre dossier', dossier_path(@dossier), class: 'button large primary'
+    - else
+      = link_to 'Accéder à votre dossier', users_dossier_recapitulatif_path(@dossier), class: 'button large primary'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -143,9 +143,9 @@ Rails.application.routes.draw do
 
       patch 'pieces_justificatives' => 'description#pieces_justificatives'
 
+      # TODO: once these pages will be migrated to the new user design, replace these routes by a redirection
       get '/recapitulatif' => 'recapitulatif#show'
       post '/recapitulatif/initiate' => 'recapitulatif#initiate'
-
       post '/commentaire' => 'commentaires#create'
 
       get '/carte/position' => 'carte#get_position'


### PR DESCRIPTION
Cette PR rend le feature-switch pour activer les nouveaux détails d'un dossier complet.

Activer le feature-switch :

- émet des liens vers les nouvelles pages plutôt que l'ancienne (`/users/dossiers/1234/recapitulatif` -> `/dossiers/1234`)
- active les redirections des anciennes URL vers les nouvelles

Ça permettra d'activer les nouveaux détails d'un dossier en douceur dès que la checklist de https://github.com/betagouv/tps/issues/1818#issue-312522619 sera complète.