### PR TITLE
Gemfile: add default ActiveRecord translations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,6 +49,9 @@ gem 'devise-async'
 gem 'openid_connect'
 gem 'omniauth-github'
 
+# Locales par défaut
+gem 'rails-i18n'
+
 gem 'rest-client'
 gem 'typhoeus'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -599,6 +599,9 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.0.4)
       loofah (~> 2.2, >= 2.2.2)
+    rails-i18n (5.1.1)
+      i18n (>= 0.7, < 2)
+      railties (>= 5.0, < 6)
     railties (5.2.1)
       actionpack (= 5.2.1)
       activesupport (= 5.2.1)
@@ -874,6 +877,7 @@ DEPENDENCIES
   rack-mini-profiler
   rails
   rails-controller-testing
+  rails-i18n
   rbnacl-libsodium
   rest-client
   rgeo-geojson
@@ -908,4 +912,4 @@ DEPENDENCIES
   xray-rails
 
 BUNDLED WITH
-   1.16.3
+   1.16.4


### PR DESCRIPTION
Before:

```ruby
> Commentaire.create!
ActiveRecord::RecordInvalid (translation missing: fr.activerecord.errors.messages.record_invalid)
```

After:

```ruby
> Commentaire.create!
ActiveRecord::RecordInvalid (La validation a échoué : Body Votre message ne peut être vide)
```

Fix #2096