### PR TITLE
update: maintain .env up-to-date

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ doc/*.svg
 uploads/*
 .byebug_history
 .env
+.env.local
 Procfile.dev
 storage/
 /public/packs

--- a/bin/setup
+++ b/bin/setup
@@ -21,11 +21,18 @@ chdir APP_ROOT do
   system('bundle check') || system!('bundle install')
   system! 'bin/yarn install'
 
-
   puts "\n== Copying sample files =="
-  unless File.exist?('.env')
-    cp 'config/env.example', '.env'
-  end
+  env_file = IO.read 'config/env.example'
+  disclaimer = <<~NOTICE
+    # This file is generated automatically from `config/env.sample`,
+    # and will be overwritten when running `bin/update`.
+    #
+    # To override some environment variables locally, create a `.env.local` file,
+    # and add your custom overrides in it.
+
+  NOTICE
+  env_file = IO.read 'config/env.example'
+  IO.write '.env', disclaimer + env_file
 
   # Create the database, load the schema, and initialize it with the seed data
   puts "\n== Preparing database =="

--- a/bin/update
+++ b/bin/update
@@ -18,6 +18,19 @@ chdir APP_ROOT do
   system('bundle check') || system!('bundle install')
   system! 'bin/yarn install'
 
+  puts "\n== Updating configuration files =="
+  env_file = IO.read 'config/env.example'
+  disclaimer = <<~NOTICE
+    # This file is generated automatically from `config/env.sample`,
+    # and will be overwritten when running `bin/update`.
+    #
+    # To override some environment variables locally, create a `.env.local` file,
+    # and add your custom overrides in it.
+
+  NOTICE
+  env_file = IO.read 'config/env.example'
+  IO.write '.env', disclaimer + env_file
+
   puts "\n== Updating database =="
   system! 'bin/rails db:migrate'
 


### PR DESCRIPTION
Un truc un peu pénible aujourd'hui avec le fichier `.env` : en local, quand quelqu'un rajoute une variable d'env à `config/env.example`, tous les développeurs doivent manuellement la rajouter à leur fichier `.env`.

Cette PR propose un mode de fonctionnement qui rend ça automatique :

- Le fichier `.env` est toujours supposé être le même que le fichier de référence (`config/env.example`)
- Le fichier `.env` est maintenu automatiquement à jour par `bin/update`
- Les overrides locaux des variables d’environnement vont dans un fichier `.env.local` sur le poste de chaque développeur (qui n'est bien sûr pas commité).

### Alternatives

Pour résoudre cette petite douleur, on peut aussi simplement symlinker le fichier `config/env.example` vers `.env` (plutôt que de le copier)


Vous en pensez quoi ?