### PR TITLE
[Dossier] Corrige les accès invités

### DIFF
--- a/app/assets/stylesheets/new_design/dossier_show.scss
+++ b/app/assets/stylesheets/new_design/dossier_show.scss
@@ -11,7 +11,7 @@
     }
 
     .title-container {
-      margin-bottom: $default-padding * 2;
+      margin-bottom: $default-spacer;
       padding-left: 32px;
 
       .icon.folder {
@@ -30,6 +30,11 @@
     h2 {
       color: $grey;
       font-weight: bold;
+    }
+
+    .header-actions {
+      margin-bottom: $default-spacer;
+      text-align: right;
     }
   }
 

--- a/app/controllers/new_user/dossiers_controller.rb
+++ b/app/controllers/new_user/dossiers_controller.rb
@@ -122,14 +122,14 @@ module NewUser
         flash.now.alert = errors
         render :modifier
       else
-        if current_user.owns?(dossier)
-          if Flipflop.new_dossier_details?
-            redirect_to demande_dossier_path(@dossier)
-          else
-            redirect_to users_dossier_recapitulatif_path(@dossier)
-          end
+        if Flipflop.new_dossier_details?
+          redirect_to demande_dossier_path(@dossier)
         else
-          redirect_to users_dossiers_invite_path(@dossier.invite_for_user(current_user))
+          if current_user.owns?(dossier)
+            redirect_to users_dossier_recapitulatif_path(@dossier)
+          else
+            redirect_to users_dossiers_invite_path(@dossier.invite_for_user(current_user))
+          end
         end
       end
     end

--- a/app/controllers/new_user/dossiers_controller.rb
+++ b/app/controllers/new_user/dossiers_controller.rb
@@ -2,8 +2,11 @@ module NewUser
   class DossiersController < UserController
     include DossierHelper
 
-    before_action :ensure_ownership!, except: [:index, :show, :demande, :messagerie, :brouillon, :update_brouillon, :modifier, :update, :recherche]
-    before_action :ensure_ownership_or_invitation!, only: [:show, :demande, :messagerie, :brouillon, :update_brouillon, :modifier, :update, :create_commentaire]
+    ACTIONS_ALLOWED_TO_ANY_USER = [:index, :recherche]
+    ACTIONS_ALLOWED_TO_OWNER_OR_INVITE = [:show, :demande, :messagerie, :brouillon, :update_brouillon, :modifier, :update, :create_commentaire]
+
+    before_action :ensure_ownership!, except: ACTIONS_ALLOWED_TO_ANY_USER + ACTIONS_ALLOWED_TO_OWNER_OR_INVITE
+    before_action :ensure_ownership_or_invitation!, only: ACTIONS_ALLOWED_TO_OWNER_OR_INVITE
     before_action :ensure_dossier_can_be_updated, only: [:update_identite, :update_brouillon, :modifier, :update]
     before_action :forbid_invite_submission!, only: [:update_brouillon]
     before_action :forbid_closed_submission!, only: [:update_brouillon]

--- a/app/controllers/users/dossiers/invites_controller.rb
+++ b/app/controllers/users/dossiers/invites_controller.rb
@@ -12,6 +12,10 @@ class Users::Dossiers::InvitesController < UsersController
   def show
     @facade = InviteDossierFacades.new params[:id].to_i, current_user.email
 
+    if Flipflop.new_dossier_details?
+      return redirect_to dossier_path(@facade.dossier)
+    end
+
     if @facade.dossier.brouillon?
       redirect_to brouillon_dossier_path(@facade.dossier)
     else

--- a/app/views/invites/_dropdown.html.haml
+++ b/app/views/invites/_dropdown.html.haml
@@ -1,0 +1,10 @@
+%span.button.dropdown.invite-user-action
+  %span.icon.person
+  - if dossier.invites.count > 0
+    Voir les personnes invitées
+    %span.badge= dossier.invites.count
+  - else
+    Inviter une personne à modifier ce dossier
+
+  .dropdown-content.fade-in-down
+    = render partial: "invites/form", locals: { dossier: dossier }

--- a/app/views/new_user/dossiers/show/_header.html.haml
+++ b/app/views/new_user/dossiers/show/_header.html.haml
@@ -7,6 +7,10 @@
       %h1= dossier.procedure.libelle
       %h2 Dossier nº #{dossier.id}
 
+    - if current_user.owns?(dossier)
+      .header-actions
+        = render partial: 'invites/dropdown', locals: { dossier: dossier }
+
     %ul.tabs
       = dynamic_tab_item('Résumé', dossier_path(dossier))
       = dynamic_tab_item('Demande', [demande_dossier_path(dossier), modifier_dossier_path(dossier)])

--- a/app/views/shared/dossiers/_header.html.haml
+++ b/app/views/shared/dossiers/_header.html.haml
@@ -4,13 +4,4 @@
 
 .dossier-form-actions
   - if current_user.owns?(dossier)
-    %span.button.dropdown.invite-user-action
-      %span.icon.person
-      - if dossier.invites.count > 0
-        Voir les personnes invitées
-        %span.badge= dossier.invites.count
-      - else
-        Inviter une personne à modifier ce dossier
-
-      .dropdown-content.fade-in-down
-        = render partial: "invites/form", locals: { dossier: dossier }
+    = render partial: 'invites/dropdown', locals: { dossier: dossier }

--- a/spec/views/new_user/dossiers/demande.html.haml_spec.rb
+++ b/spec/views/new_user/dossiers/demande.html.haml_spec.rb
@@ -5,6 +5,7 @@ describe 'new_user/dossiers/demande.html.haml', type: :view do
   let(:dossier) { create(:dossier, :en_construction, :with_entreprise, procedure: procedure) }
 
   before do
+    sign_in dossier.user
     assign(:dossier, dossier)
   end
 

--- a/spec/views/new_user/dossiers/show/_header.html.haml_spec.rb
+++ b/spec/views/new_user/dossiers/show/_header.html.haml_spec.rb
@@ -5,7 +5,7 @@ describe 'new_user/dossiers/show/header.html.haml', type: :view do
     sign_in dossier.user
   end
 
-  subject! { render 'new_user/dossiers/show/header.html.haml', dossier: dossier, is_dossier_owner: true }
+  subject! { render 'new_user/dossiers/show/header.html.haml', dossier: dossier }
 
   it 'affiche les informations du dossier' do
     expect(rendered).to have_text(dossier.procedure.libelle)

--- a/spec/views/new_user/dossiers/show/_header.html.haml_spec.rb
+++ b/spec/views/new_user/dossiers/show/_header.html.haml_spec.rb
@@ -1,7 +1,11 @@
 describe 'new_user/dossiers/show/header.html.haml', type: :view do
   let(:dossier) { create(:dossier, :en_construction, procedure: create(:procedure)) }
 
-  subject! { render 'new_user/dossiers/show/header.html.haml', dossier: dossier }
+  before do
+    sign_in dossier.user
+  end
+
+  subject! { render 'new_user/dossiers/show/header.html.haml', dossier: dossier, is_dossier_owner: true }
 
   it 'affiche les informations du dossier' do
     expect(rendered).to have_text(dossier.procedure.libelle)


### PR DESCRIPTION
Dans le cadre de la nouvelle présentation des dossiers (#1818), cette PR corrige les fonctionnalités liées aux Invités :

- L'Usager peut voir et inviter des intervenants tierces même après avoir soumis le dossier ;
- ETQ Invité, correction des redirections après avoir cliqué sur le lien dans le mail d'invitation ;
- ETQ Invité, correction de l'envoi des messages.

<img width="1125" alt="capture d ecran 2018-09-20 a 17 57 50" src="https://user-images.githubusercontent.com/179923/45831094-c8b7bd80-bcfe-11e8-85fc-2194ac8ae658.png">


**TODO:**

- [x] Améliorer le layout du bouton "Inviter"