### PR TITLE
Move the dossier-edit class directly to the _edit.html.haml template

### DIFF
--- a/app/views/new_user/dossiers/brouillon.html.haml
+++ b/app/views/new_user/dossiers/brouillon.html.haml
@@ -3,9 +3,8 @@
 - content_for :footer do
   = render partial: "new_user/dossiers/dossier_footer", locals: { dossier: @dossier }
 
-.dossier-edit
-  .dossier-header.sub-header
-    .container
-      = render partial: "shared/dossiers/header", locals: { dossier: @dossier, apercu: false }
+.dossier-header.sub-header
+  .container
+    = render partial: "shared/dossiers/header", locals: { dossier: @dossier, apercu: false }
 
-  = render partial: "shared/dossiers/edit", locals: { dossier: @dossier, apercu: false }
+= render partial: "shared/dossiers/edit", locals: { dossier: @dossier, apercu: false }

--- a/app/views/shared/dossiers/_edit.html.haml
+++ b/app/views/shared/dossiers/_edit.html.haml
@@ -1,4 +1,4 @@
-.container
+.dossier-edit.container
   = render partial: "shared/dossiers/submit_is_over", locals: { dossier: dossier }
 
   - if apercu


### PR DESCRIPTION
Revue conseillée avec `?w=1`

So that when the partial included in
modifier.html.haml can also benefit from its
styling rules

Avant :

![screenshot_2018-09-21 modifier dossier n 130833 test notice demarches-simplifiees fr 1](https://user-images.githubusercontent.com/1333173/45867122-fd6d5880-bd82-11e8-8679-63997b7d9c13.png)

Après :

![screenshot_2018-09-21 modifier dossier n 130833 test notice demarches-simplifiees fr](https://user-images.githubusercontent.com/1333173/45867130-052cfd00-bd83-11e8-92aa-64f86564e20b.png)
