### PR TITLE
Remove a warning in the console task

### DIFF
--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -27,6 +27,6 @@ namespace :dev do
   end
 
   task :console do
-    exec("ssh tps@sgmap_production1 -t 'source /etc/profile && cd current && bundle exec rails c production'")
+    exec("ssh tps@sgmap_production1 -t 'source /etc/profile && cd current && bundle exec rails c -e production'")
   end
 end


### PR DESCRIPTION
Passing the environment's name as a regular
argument is deprecated and will be removed in the
next Rails version. Please, use the -e option
instead.