### PR TITLE
[Fix #2309] Remove therubyracer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,9 +9,6 @@ gem 'sass-rails'
 # Use Uglifier as compressor for JavaScript assets
 gem 'uglifier'
 
-# See https://github.com/sstephenson/execjs#readme for more supported runtimes
-gem 'therubyracer', platforms: :ruby
-
 # Use jquery as the JavaScript library
 gem 'jquery-rails'
 # Turbolinks makes following links in your web application faster. Read more: https://github.com/rails/turbolinks

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -459,7 +459,6 @@ GEM
     leaflet-markercluster-rails (0.7.0)
       railties (>= 3.1)
     leaflet-rails (0.7.7)
-    libv8 (3.16.14.19)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -626,7 +625,6 @@ GEM
       json (>= 1.8)
       nokogiri (~> 1.5)
       trollop (~> 2.1)
-    ref (2.0.0)
     request_store (1.4.1)
       rack (>= 1.4)
     responders (2.4.0)
@@ -750,9 +748,6 @@ GEM
       httpclient (>= 2.4)
     sysexits (1.2.0)
     temple (0.8.0)
-    therubyracer (0.12.3)
-      libv8 (~> 3.16.14.15)
-      ref
     thor (0.20.0)
     thread_safe (0.3.6)
     tilt (2.0.8)
@@ -898,7 +893,6 @@ DEPENDENCIES
   spreadsheet_architect
   spring
   spring-commands-rspec
-  therubyracer
   timecop
   turbolinks
   typhoeus


### PR DESCRIPTION
Il me semble que comme on a node sur Circle et sur nos serveurs (requis dans ces 2 cas), on peut se passer du gem `therubyracer`