### PR TITLE
[Dossier] Teste le système d'invitations sur la nouvelle UI de dossiers

### DIFF
--- a/spec/factories/procedure.rb
+++ b/spec/factories/procedure.rb
@@ -22,6 +22,14 @@ FactoryBot.define do
       end
     end
 
+    factory :simple_procedure do
+      after(:build) do |procedure, _evaluator|
+        procedure.for_individual = true
+        procedure.types_de_champ << create(:type_de_champ, libelle: 'Texte obligatoire', mandatory: true)
+        procedure.publish!(generate(:published_path))
+      end
+    end
+
     after(:build) do |procedure, _evaluator|
       if procedure.module_api_carto.nil?
         module_api_carto = create(:module_api_carto)

--- a/spec/features/new_user/dossier_details_spec.rb
+++ b/spec/features/new_user/dossier_details_spec.rb
@@ -1,10 +1,7 @@
 describe 'Dossier details:' do
   let(:user) { create(:user) }
-  let(:simple_procedure) do
-    tdcs = [create(:type_de_champ, libelle: 'texte obligatoire')]
-    create(:procedure, :published, :for_individual, types_de_champ: tdcs)
-  end
-  let(:dossier) { create(:dossier, :en_construction, :for_individual, :with_commentaires, user: user, procedure: simple_procedure) }
+  let(:procedure) { create(:simple_procedure) }
+  let(:dossier) { create(:dossier, :en_construction, :for_individual, :with_commentaires, user: user, procedure: procedure) }
 
   before do
     Flipflop::FeatureSet.current.test!.switch!(:new_dossier_details, true)
@@ -21,7 +18,7 @@ describe 'Dossier details:' do
   describe "the user can see the mean time they are expected to wait" do
     context "when the dossier is in construction" do
       before do
-        other_dossier = create(:dossier, :accepte, :for_individual, procedure: simple_procedure, en_construction_at: 10.days.ago, en_instruction_at: Time.now)
+        other_dossier = create(:dossier, :accepte, :for_individual, procedure: procedure, en_construction_at: 10.days.ago, en_instruction_at: Time.now)
         visit dossier_path(dossier)
       end
 
@@ -29,10 +26,10 @@ describe 'Dossier details:' do
     end
 
     context "when the dossier is in instruction" do
-      let(:dossier) { create(:dossier, :en_instruction, :for_individual, :with_commentaires, user: user, procedure: simple_procedure) }
+      let(:dossier) { create(:dossier, :en_instruction, :for_individual, :with_commentaires, user: user, procedure: procedure) }
 
       before do
-        other_dossier = create(:dossier, :accepte, :for_individual, procedure: simple_procedure, en_instruction_at: 2.months.ago, processed_at: Time.now)
+        other_dossier = create(:dossier, :accepte, :for_individual, procedure: procedure, en_instruction_at: 2.months.ago, processed_at: Time.now)
         visit dossier_path(dossier)
       end
 

--- a/spec/features/new_user/dossier_details_spec.rb
+++ b/spec/features/new_user/dossier_details_spec.rb
@@ -8,11 +8,10 @@ describe 'Dossier details:' do
 
   before do
     Flipflop::FeatureSet.current.test!.switch!(:new_dossier_details, true)
+    visit_dossier dossier
   end
 
   scenario 'the user can see the summary of the dossier status' do
-    visit_dossier dossier
-
     expect(page).to have_current_path(dossier_path(dossier))
     expect(page).to have_content(dossier.id)
     expect(page).to have_selector('.status-explanation')
@@ -20,30 +19,24 @@ describe 'Dossier details:' do
   end
 
   describe "the user can see the mean time they are expected to wait" do
-    context "the dossier is in construction" do
+    context "when the dossier is in construction" do
       before do
         other_dossier = create(:dossier, :accepte, :for_individual, procedure: simple_procedure, en_construction_at: 10.days.ago, en_instruction_at: Time.now)
+        visit dossier_path(dossier)
       end
 
-      it "show the proper wait time" do
-        visit_dossier dossier
-
-        expect(page).to have_text("Le temps moyen de vérification pour cette démarche est de 10 jours.")
-      end
+      it { expect(page).to have_text("Le temps moyen de vérification pour cette démarche est de 10 jours.") }
     end
 
-    context "the dossier is in instruction" do
+    context "when the dossier is in instruction" do
       let(:dossier) { create(:dossier, :en_instruction, :for_individual, :with_commentaires, user: user, procedure: simple_procedure) }
 
       before do
         other_dossier = create(:dossier, :accepte, :for_individual, procedure: simple_procedure, en_instruction_at: 2.months.ago, processed_at: Time.now)
+        visit dossier_path(dossier)
       end
 
-      it "show the proper wait time" do
-        visit_dossier dossier
-
-        expect(page).to have_text("Le temps moyen d’instruction pour cette démarche est de 2 mois.")
-      end
+      it { expect(page).to have_text("Le temps moyen d’instruction pour cette démarche est de 2 mois.") }
     end
   end
 

--- a/spec/features/new_user/dossier_details_spec.rb
+++ b/spec/features/new_user/dossier_details_spec.rb
@@ -1,3 +1,5 @@
+require 'features/new_user/dossier_shared_examples.rb'
+
 describe 'Dossier details:' do
   let(:user) { create(:user) }
   let(:procedure) { create(:simple_procedure) }
@@ -37,41 +39,8 @@ describe 'Dossier details:' do
     end
   end
 
-  scenario 'the user can see and edit dossier before instruction' do
-    visit_dossier dossier
-    click_on 'Demande'
-
-    expect(page).to have_current_path(demande_dossier_path(dossier))
-    click_on 'Modifier le dossier'
-
-    expect(page).to have_current_path(modifier_dossier_path(dossier))
-    fill_in('texte obligatoire', with: 'Nouveau texte')
-    click_on 'Enregistrer les modifications du dossier'
-
-    expect(page).to have_current_path(demande_dossier_path(dossier))
-    expect(page).to have_content('Nouveau texte')
-  end
-
-  context 'with messages' do
-    let!(:commentaire) { create(:commentaire, dossier: dossier, email: 'instructeur@exemple.fr', body: 'Message envoyé à l’usager') }
-    let(:message_body) { 'Message envoyé à l’instructeur' }
-
-    scenario 'the user can send a message' do
-      visit_dossier dossier
-      click_on 'Messagerie'
-
-      expect(page).to have_current_path(messagerie_dossier_path(dossier))
-      expect(page).to have_content(commentaire.body)
-
-      fill_in 'commentaire_body', with: message_body
-      click_on 'Envoyer'
-
-      expect(page).to have_current_path(messagerie_dossier_path(dossier))
-      expect(page).to have_content('Message envoyé')
-      expect(page).to have_content(commentaire.body)
-      expect(page).to have_content(message_body)
-    end
-  end
+  it_behaves_like 'the user can edit the submitted demande'
+  it_behaves_like 'the user can send messages to the instructeur'
 
   private
 

--- a/spec/features/new_user/dossier_shared_examples.rb
+++ b/spec/features/new_user/dossier_shared_examples.rb
@@ -1,0 +1,41 @@
+RSpec.shared_examples 'the user can edit the submitted demande' do
+  scenario js: true do
+    visit dossier_path(dossier)
+
+    expect(page).to have_current_path(dossier_path(dossier))
+    click_on 'Demande'
+
+    expect(page).to have_current_path(demande_dossier_path(dossier))
+    click_on 'Modifier le dossier'
+
+    expect(page).to have_current_path(modifier_dossier_path(dossier))
+    fill_in('Texte obligatoire', with: 'Nouveau texte')
+    click_on 'Enregistrer les modifications du dossier'
+
+    expect(page).to have_current_path(demande_dossier_path(dossier))
+    expect(page).to have_content('Nouveau texte')
+  end
+end
+
+RSpec.shared_examples 'the user can send messages to the instructeur' do
+  let!(:commentaire) { create(:commentaire, dossier: dossier, email: 'instructeur@exemple.fr', body: 'Message envoyé à l’usager') }
+  let(:message_body) { 'Message envoyé à l’instructeur' }
+
+  scenario js: true do
+    visit dossier_path(dossier)
+
+    expect(page).to have_current_path(dossier_path(dossier))
+    click_on 'Messagerie'
+
+    expect(page).to have_current_path(messagerie_dossier_path(dossier))
+    expect(page).to have_content(commentaire.body)
+
+    fill_in 'commentaire_body', with: message_body
+    click_on 'Envoyer'
+
+    expect(page).to have_current_path(messagerie_dossier_path(dossier))
+    expect(page).to have_content('Message envoyé')
+    expect(page).to have_content(commentaire.body)
+    expect(page).to have_content(message_body)
+  end
+end

--- a/spec/features/new_user/invite_spec.rb
+++ b/spec/features/new_user/invite_spec.rb
@@ -76,7 +76,7 @@ feature 'Invitations' do
     end
   end
 
-  context 'when the dossier is en_construction' do
+  context 'when the dossier is en_construction (legacy UI)' do
     let!(:dossier) { create(:dossier, :for_individual, :en_construction, user: user, procedure: procedure) }
 
     scenario 'on dossier details, a user can invite another user to collaborate on the dossier', js: true do

--- a/spec/features/new_user/invite_spec.rb
+++ b/spec/features/new_user/invite_spec.rb
@@ -51,11 +51,9 @@ feature 'Invitations' do
     end
 
     scenario 'an invited user can see and edit the draft', js: true do
-      visit users_dossiers_invite_path(invite)
-      expect(page).to have_current_path(new_user_session_path)
-
-      submit_login_form(invited_user.email, invited_user.password)
+      navigate_to_invited_dossier(invite)
       expect(page).to have_current_path(brouillon_dossier_path(dossier))
+
       expect(page).to have_no_selector('.button.invite-user-action')
 
       fill_in 'Texte obligatoire', with: 'Some edited value'
@@ -65,10 +63,7 @@ feature 'Invitations' do
     end
 
     scenario 'an invited user cannot submit the draft' do
-      visit users_dossiers_invite_path(invite)
-      expect(page).to have_current_path(new_user_session_path)
-
-      submit_login_form(invited_user.email, invited_user.password)
+      navigate_to_invited_dossier(invite)
       expect(page).to have_current_path(brouillon_dossier_path(dossier))
 
       expect(page).to have_button('Soumettre le dossier', disabled: true)
@@ -132,6 +127,12 @@ feature 'Invitations' do
     expect(page).to have_current_path(dossiers_path)
     click_on(dossier.id)
     expect(page).to have_current_path(brouillon_dossier_path(dossier))
+  end
+
+  def navigate_to_invited_dossier(invite)
+    visit users_dossiers_invite_path(invite)
+    expect(page).to have_current_path(new_user_session_path)
+    submit_login_form(invited_user.email, invited_user.password)
   end
 
   def navigate_to_recapitulatif(dossier)

--- a/spec/features/new_user/invite_spec.rb
+++ b/spec/features/new_user/invite_spec.rb
@@ -1,16 +1,16 @@
 require 'spec_helper'
 
 feature 'Invitations' do
-  let(:user) { create(:user) }
+  let(:owner) { create(:user) }
   let(:invited_user) { create(:user, email: 'user_invite@exemple.fr') }
   let(:procedure) { create(:simple_procedure) }
   let(:invite) { create(:invite_user, user: invited_user, dossier: dossier) }
 
   context 'when the dossier is a brouillon' do
-    let!(:dossier) { create(:dossier, :for_individual, state: Dossier.states.fetch(:brouillon), user: user, procedure: procedure) }
+    let!(:dossier) { create(:dossier, :for_individual, state: Dossier.states.fetch(:brouillon), user: owner, procedure: procedure) }
 
-    scenario 'on the form, a user can invite another user to collaborate on the dossier', js: true do
-      log_in(user)
+    scenario 'on the form, the owner of a dossier can invite another user to collaborate on the dossier', js: true do
+      log_in(owner)
       navigate_to_brouillon(dossier)
 
       fill_in 'Texte obligatoire', with: 'Some edited value'
@@ -77,10 +77,10 @@ feature 'Invitations' do
   end
 
   context 'when the dossier is en_construction (legacy UI)' do
-    let!(:dossier) { create(:dossier, :for_individual, :en_construction, user: user, procedure: procedure) }
+    let!(:dossier) { create(:dossier, :for_individual, :en_construction, user: owner, procedure: procedure) }
 
     scenario 'on dossier details, a user can invite another user to collaborate on the dossier', js: true do
-      log_in(user)
+      log_in(owner)
       navigate_to_recapitulatif(dossier)
 
       legacy_send_invite_to "user_invite@exemple.fr"

--- a/spec/features/new_user/invite_spec.rb
+++ b/spec/features/new_user/invite_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 feature 'Invitations' do
   let(:user) { create(:user) }
   let(:invited_user) { create(:user, email: 'user_invite@exemple.fr') }
-  let(:procedure) { create(:procedure, :published, :with_type_de_champ) }
+  let(:procedure) { create(:simple_procedure) }
   let(:invite) { create(:invite_user, user: invited_user, dossier: dossier) }
 
   context 'when the dossier is a brouillon' do
@@ -13,7 +13,7 @@ feature 'Invitations' do
       log_in(user)
       navigate_to_brouillon(dossier)
 
-      fill_in 'Libelle du champ', with: 'Some edited value'
+      fill_in 'Texte obligatoire', with: 'Some edited value'
       send_invite_to "user_invite@exemple.fr"
 
       expect(page).to have_current_path(brouillon_dossier_path(dossier))
@@ -21,7 +21,7 @@ feature 'Invitations' do
       expect(page).to have_text("user_invite@exemple.fr")
 
       # Ensure unsaved edits to the form are not lost
-      expect(page).to have_field('Libelle du champ', with: 'Some edited value')
+      expect(page).to have_field('Texte obligatoire', with: 'Some edited value')
     end
 
     context 'when inviting someone without an existing account' do
@@ -58,10 +58,10 @@ feature 'Invitations' do
       expect(page).to have_current_path(brouillon_dossier_path(dossier))
       expect(page).to have_no_selector('.button.invite-user-action')
 
-      fill_in 'Libelle du champ', with: 'Some edited value'
+      fill_in 'Texte obligatoire', with: 'Some edited value'
       click_button 'Enregistrer le brouillon'
       expect(page).to have_text('Votre brouillon a bien été sauvegardé')
-      expect(page).to have_field('Libelle du champ', with: 'Some edited value')
+      expect(page).to have_field('Texte obligatoire', with: 'Some edited value')
     end
 
     scenario 'an invited user cannot submit the draft' do
@@ -105,7 +105,7 @@ feature 'Invitations' do
       visit brouillon_dossier_path(dossier)
 
       expect(page).to have_current_path(brouillon_dossier_path(dossier))
-      fill_in "Libelle du champ", with: "Some edited value"
+      fill_in "Texte obligatoire", with: "Some edited value"
       click_button "Enregistrer les modifications du dossier"
 
       expect(page).to have_current_path(users_dossiers_invite_path(invite))


### PR DESCRIPTION
Cette PR teste le système d'invitations sur la nouvelle UI de dossiers.

Pour cela, la majorité du boulot est de préparer la factorisation de scénarios comme _"Éditer un dossier en construction"_ ou _"Envoyer un message à l'instructeur"_.

Une fois cette factorisation faite, le commit qui utilise ces scénarios partagés pour vérifier que ça fonctionne autant pour le propriétaire du dossier que pour un invité est assez simple.

**Dépend de :**

- [x] #2643