### PR TITLE
[Dossier] Ajout des champs SIRET et carto

### DIFF
--- a/spec/views/new_gestionnaire/dossiers/show.html.haml_spec.rb
+++ b/spec/views/new_gestionnaire/dossiers/show.html.haml_spec.rb
@@ -1,39 +1,21 @@
 describe 'new_gestionnaire/dossiers/show.html.haml', type: :view do
-  before { view.extend DossierHelper }
-
   let(:current_gestionnaire) { create(:gestionnaire) }
-  let(:individual) { nil }
-  let(:etablissement) { nil }
-  let(:dossier) { create(:dossier, :en_construction, etablissement: etablissement, individual: individual) }
+  let(:dossier) { create(:dossier, :en_construction) }
 
   before do
+    sign_in current_gestionnaire
     assign(:dossier, dossier)
-    allow(view).to receive(:current_gestionnaire).and_return(current_gestionnaire)
-    render
   end
 
-  context "when dossier was created by an etablissement" do
-    let(:etablissement) { create(:etablissement) }
+  subject! { render }
 
-    it { expect(rendered).to include(etablissement.entreprise_raison_sociale) }
-    it { expect(rendered).to include(etablissement.entreprise_siret_siege_social) }
-    it { expect(rendered).to include(etablissement.entreprise_forme_juridique) }
-
-    context "and entreprise is an association" do
-      let(:etablissement) { create(:etablissement, :is_association) }
-
-      it { expect(rendered).to include(etablissement.association_rna) }
-      it { expect(rendered).to include(etablissement.association_titre) }
-      it { expect(rendered).to include(etablissement.association_objet) }
-    end
+  it 'renders the header' do
+    expect(rendered).to have_text("Dossier nº #{dossier.id}")
   end
 
-  context "when dossier was created by an individual" do
-    let(:individual) { create(:individual) }
-
-    it { expect(rendered).to include(individual.gender) }
-    it { expect(rendered).to include(individual.nom) }
-    it { expect(rendered).to include(individual.prenom) }
-    it { expect(rendered).to include(individual.birthdate.strftime("%d/%m/%Y")) }
+  it 'renders the dossier infos' do
+    expect(rendered).to have_text('Identité')
+    expect(rendered).to have_text('Demande')
+    expect(rendered).to have_text('Pièces jointes')
   end
 end

--- a/spec/views/shared/dossiers/_demande.html.haml_spec.rb
+++ b/spec/views/shared/dossiers/_demande.html.haml_spec.rb
@@ -1,0 +1,44 @@
+describe 'shared/dossiers/demande.html.haml', type: :view do
+  let(:current_gestionnaire) { create(:gestionnaire) }
+  let(:individual) { nil }
+  let(:etablissement) { nil }
+  let(:procedure) { create(:procedure, :published) }
+  let(:dossier) { create(:dossier, :en_construction, procedure: procedure, etablissement: etablissement, individual: individual) }
+
+  before do
+    sign_in current_gestionnaire
+  end
+
+  subject! { render 'shared/dossiers/demande.html.haml', dossier: dossier, demande_seen_at: nil }
+
+  context 'when dossier was created by an etablissement' do
+    let(:etablissement) { create(:etablissement) }
+
+    it 'renders the etablissement infos' do
+      expect(rendered).to include(etablissement.entreprise_raison_sociale)
+      expect(rendered).to include(etablissement.entreprise_siret_siege_social)
+      expect(rendered).to include(etablissement.entreprise_forme_juridique)
+    end
+
+    context 'and entreprise is an association' do
+      let(:etablissement) { create(:etablissement, :is_association) }
+
+      it 'renders the association infos' do
+        expect(rendered).to include(etablissement.association_rna)
+        expect(rendered).to include(etablissement.association_titre)
+        expect(rendered).to include(etablissement.association_objet)
+      end
+    end
+  end
+
+  context 'when dossier was created by an individual' do
+    let(:individual) { create(:individual) }
+
+    it 'renders the individual identity infos' do
+      expect(rendered).to include(individual.gender)
+      expect(rendered).to include(individual.nom)
+      expect(rendered).to include(individual.prenom)
+      expect(rendered).to include(individual.birthdate.strftime("%d/%m/%Y"))
+    end
+  end
+end

--- a/spec/views/shared/dossiers/_demande.html.haml_spec.rb
+++ b/spec/views/shared/dossiers/_demande.html.haml_spec.rb
@@ -41,4 +41,30 @@ describe 'shared/dossiers/demande.html.haml', type: :view do
       expect(rendered).to include(individual.birthdate.strftime("%d/%m/%Y"))
     end
   end
+
+  context 'when the dossier has champs' do
+    let(:procedure) { create(:procedure, :published, :with_type_de_champ) }
+
+    it 'renders the champs' do
+      dossier.champs.each do |champ|
+        expect(rendered).to include(champ.libelle)
+      end
+    end
+  end
+
+  context 'when the dossier has pièces justificatives' do
+    let(:procedure) { create(:procedure, :published, :with_two_type_de_piece_justificative) }
+
+    it 'renders the pièces justificatives' do
+      expect(rendered).to have_text('Pièces jointes')
+    end
+  end
+
+  context 'when the dossier uses maps' do
+    let(:procedure) { create(:procedure, :published, :with_api_carto) }
+
+    it 'renders the maps infos' do
+      expect(rendered).to have_text('Cartographie')
+    end
+  end
 end


### PR DESCRIPTION
Dans le cadre de #1818, on permet aux Usagers d'afficher les infos de leur dossier liées à l'identification SIRET et à la carto.

Plot-twist : c'était déjà implémenté ! 🙀 Le code est partagé avec la partie Instructeur, qui l'implémentait déjà.

En revanche cette PR généralise et augmente les tests de vue de la partie Instructeur, pour qu'ils s'appliquent aussi à la partie Usager.

