### PR TITLE
Use uglifier with no mangle option in order to fix leaflet in production

### DIFF
--- a/app/assets/javascripts/old_design/carte/carte.js
+++ b/app/assets/javascripts/old_design/carte/carte.js
@@ -2,7 +2,7 @@ var LON = '2.428462';
 var LAT = '46.538192';
 
 function initCarto() {
-  OSM = L.tileLayer("http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
+  OSM = L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
     attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>'
   });
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -28,7 +28,7 @@ Rails.application.configure do
   config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
   # Compress JavaScripts and CSS.
-  config.assets.js_compressor = :uglifier
+  config.assets.js_compressor = Uglifier.new(mangle: false)
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.


### PR DESCRIPTION
Nous avons du js compilé par asset pipeline qui plant en prod.
Donc pas de rapport avec webpacker.
Si je remplace par `config.assets.js_compressor = Uglifier.new(mangle: false)` ça marche.

Fixes #2684