### PR TITLE
Use letter opener

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -164,6 +164,7 @@ group :development do
   gem 'rubocop-rspec-focused', require: false
   gem 'haml-lint'
   gem 'scss_lint', require: false
+  gem 'letter_opener_web'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -459,6 +459,12 @@ GEM
     leaflet-markercluster-rails (0.7.0)
       railties (>= 3.1)
     leaflet-rails (0.7.7)
+    letter_opener (1.6.0)
+      launchy (~> 2.2)
+    letter_opener_web (1.3.4)
+      actionmailer (>= 3.2)
+      letter_opener (~> 1.0)
+      railties (>= 3.2)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -855,6 +861,7 @@ DEPENDENCIES
   leaflet-draw-rails
   leaflet-markercluster-rails (~> 0.7.0)
   leaflet-rails
+  letter_opener_web
   lograge
   logstash-event
   mailjet
@@ -906,4 +913,4 @@ DEPENDENCIES
   zxcvbn-ruby
 
 BUNDLED WITH
-   1.16.4
+   1.16.5

--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,2 @@
 server: bin/rails server
 jobs: bin/delayed_job run
-mails: mailcatcher -f

--- a/bin/setup
+++ b/bin/setup
@@ -13,9 +13,6 @@ chdir APP_ROOT do
   # This script is a starting point to setup your application.
   # Add necessary setup steps to this file.
 
-  puts '== Installing global tools =='
-  system! 'gem install mailcatcher --conservative'
-
   puts "\n== Installing dependencies =="
   system! 'gem install bundler --conservative'
   system('bundle check') || system!('bundle install')

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -45,17 +45,11 @@ Rails.application.configure do
   config.assets.raise_runtime_errors = true
 
   # Action Mailer settings
-  config.action_mailer.delivery_method = :smtp
-  config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
-  # Config for mailcatcher https://mailcatcher.me/
-  config.action_mailer.smtp_settings = {
-    address: 'localhost',
-    port: 1025,
-    locale: 'fr'
-  }
+  config.action_mailer.delivery_method = :letter_opener_web
 
   Rails.application.routes.default_url_options = {
-    host: 'localhost:3000'
+    host: 'localhost',
+    port: 3000
   }
 
   # Raises error for missing translations

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -46,6 +46,14 @@ Rails.application.routes.draw do
   end
 
   #
+  # Letter Opener
+  #
+
+  if Rails.env.development?
+    mount LetterOpenerWeb::Engine, at: "/letter_opener"
+  end
+
+  #
   # Monitoring
   #
 


### PR DESCRIPTION
Ce-si remplace `mailcatcher` avec une solution qui tourne dans le même process que rails en dev. Je trouve ça mieux, car ça évite un setup plus complique et en plus catch les email même si quelqu'un run `rails server`.

Vous avez des avis ?

cc @gregoirenovel @kemenaran @LeSim @mmagn @fredZen 