### PR TITLE
Remove ssl_verifypeer option in ApiEntreprise::API.call

### DIFF
--- a/app/lib/api_entreprise/api.rb
+++ b/app/lib/api_entreprise/api.rb
@@ -27,7 +27,6 @@ class ApiEntreprise::API
     params = params(siret_or_siren, procedure_id)
 
     response = Typhoeus.get(url,
-      ssl_verifypeer: false,
       params: params,
       timeout: TIMEOUT)
 


### PR DESCRIPTION
SSL seems OK for https://entreprise.api.gouv.fr/