### PR TITLE
deploy: fix after_party deployment

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -104,6 +104,16 @@ namespace :yarn do
   end
 end
 
+namespace :after_party do
+  desc "Run after_party tasks."
+  task :run do
+    queue %{
+      echo "-----> Running deploy tasks"
+      #{echo_cmd %[#{rake} after_party:run]}
+    }
+  end
+end
+
 desc "Deploys the current version to the server."
 task :deploy => :environment do
   queue 'export PATH=$PATH:/usr/local/rbenv/bin:/usr/local/rbenv/shims'
@@ -116,7 +126,7 @@ task :deploy => :environment do
     invoke :'bundle:install'
     invoke :'yarn:install'
     invoke :'rails:db_migrate'
-    invoke :'rake[after_party:run]'
+    invoke :'after_party:run'
     invoke :'rails:assets_precompile:force'
 
     to :launch do


### PR DESCRIPTION
- Modification de la manière dont la tâche after_party est exécutée
- Ajout d'une ligne de debug dans la console lors de l'exécution de la tâche

Testé en local avec

```shell
bundle exec mina deploy domain="test.domain" to=production --simulate
```

### Avant

```shell
  (

    cd "/var/www/tps/current" && RAILS_ENV="production" bundle exec rake after_party:run

  ) && (

    echo "-----> Precompiling asset files"
    RAILS_ENV="production" bundle exec rake assets:precompile RAILS_GROUPS=assets

  )
```

### Après

```shell
  (

    echo "-----> Running deploy tasks"
    RAILS_ENV="production" bundle exec rake after_party:run

  ) && (

    echo "-----> Precompiling asset files"
    RAILS_ENV="production" bundle exec rake assets:precompile RAILS_GROUPS=assets

  )
```

Je ne sais pas exactement ce qui peut coincer, mais ce qui est sûr c'est qu'on exécute la tâche rake exactement comme les autres tâches de Mina. Ça doit fonctionner 🤞 