### PR TITLE
README: document letter_opener usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ L'application tourne à l'adresse `http://localhost:3000`. Un utilisateur de tes
     Administrateurs::ActivateBeforeExpirationJob.set(cron: "0 8 * * *").perform_later
     WarnExpiringDossiersJob.set(cron: "0 0 1 * *").perform_later
 
+## Voir les emails envoyés en local
+
+http://localhost:3000/letter_opener
+
 ## Mise à jour de l'application
 
 Pour mettre à jour votre environnement de développement, installer les nouvelles dépendances et faire jouer les migrations, exécutez :


### PR DESCRIPTION
Ajout d'une ligne pour indiquer comment lire les emails envoyés en local.