### PR TITLE
Allow to override active_job adapter

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -61,4 +61,9 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+  # This is useful to run rails in development with :async queue adapter
+  if ENV['RAILS_QUEUE_ADAPTER']
+    config.active_job.queue_adapter = ENV['RAILS_QUEUE_ADAPTER'].to_sym
+  end
 end


### PR DESCRIPTION
Follow up to https://github.com/betagouv/tps/pull/2872

Avec ce changement on peut set `RAILS_QUEUE_ADAPTER=async` et lancer `rails s` avec les jobs. Ce n’est pas ISO prod mais je pense que ça fera l'affaire pour 90% du temps en dev. Je ne propose pas de le mettre par défaut pour l’instant, mais cette PR le rend facile à activer.

