### PR TITLE
Conf: storage.apientreprise.fr -> static.demarches-simplifiees.fr

### DIFF
--- a/config/initializers/urls.rb
+++ b/config/initializers/urls.rb
@@ -8,7 +8,7 @@ HELPSCOUT_API_URL = "https://api.helpscout.net/v2"
 PIPEDRIVE_API_URL = "https://api.pipedrive.com/v1"
 
 # Internal URLs
-FOG_BASE_URL = "https://storage.apientreprise.fr"
+FOG_BASE_URL = "https://static.demarches-simplifiees.fr"
 
 # External services URLs
 DOC_URL = "https://doc.demarches-simplifiees.fr"

--- a/spec/uploaders/remote_downloader_spec.rb
+++ b/spec/uploaders/remote_downloader_spec.rb
@@ -6,6 +6,6 @@ describe RemoteDownloader do
   subject { described_class.new filename }
 
   describe '#url' do
-    it { expect(subject.url).to eq 'https://storage.apientreprise.fr/tps_dev/file_name.pdf' }
+    it { expect(subject.url).to eq 'https://static.demarches-simplifiees.fr/tps_dev/file_name.pdf' }
   end
 end


### PR DESCRIPTION
C'était le seul ndd dispo sur notre certificat qui collait un peu à l'upload de fichier.