### PR TITLE
Force port to 3000 when running on overmind

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-server: bin/rails server
+server: bin/rails server -p 3000
 jobs: bin/delayed_job run


### PR DESCRIPTION
On development machines

- overmind + unicorn defaulted to port 3000
- overmind + puma defaults to port 5000

Forcing port 3000 rather than changing the readme and configuration