### PR TITLE
[Fix #2815] Ne pas parler de plusieurs PJs quand il n'y en a qu'une

### DIFF
--- a/app/views/shared/dossiers/_edit.html.haml
+++ b/app/views/shared/dossiers/_edit.html.haml
@@ -35,9 +35,12 @@
           Pièces jointes
 
         .warning
-          Pour éviter toute erreur, nous vous conseillons de limiter la taille de chaque pièce jointe à 20 Mo, et de les ajouter une par une, en enregistrant votre
-          = dossier.brouillon? ? "brouillon" : "dossier"
-          après chaque ajout.
+          - if tpjs.many?
+            Pour éviter toute erreur, nous vous conseillons de limiter la taille de chaque pièce jointe à 20 Mo, et de les ajouter une par une, en enregistrant votre
+            = dossier.brouillon? ? "brouillon" : "dossier"
+            après chaque ajout.
+          - else
+            Pour éviter toute erreur, nous vous conseillons de limiter la taille de votre pièce jointe à 20 Mo.
 
         - tpjs.each do |tpj|
           .pj-input


### PR DESCRIPTION
Avec une seule PJ : 
![screenshot from 2018-10-30 10-24-16](https://user-images.githubusercontent.com/356570/47708538-9028cf00-dc2e-11e8-9704-1557f419f4b6.png)

Avec plusieurs PJ (inchangé) : 
![screenshot from 2018-10-30 10-24-29](https://user-images.githubusercontent.com/356570/47708548-961eb000-dc2e-11e8-92a4-b578f7f02e5c.png)
