### PR TITLE
Fix test that doesn't work just after daylight saving time changes

### DIFF
--- a/spec/controllers/stats_controller_spec.rb
+++ b/spec/controllers/stats_controller_spec.rb
@@ -244,7 +244,7 @@ describe StatsController, type: :controller do
 
   describe "#avis_average_answer_time" do
     before do
-      Timecop.freeze(Time.zone.now)
+      Timecop.freeze(Time.zone.local(2016, 10, 2))
 
       # 1 week ago
       create(:avis, answer: "voila ma réponse", created_at: 1.week.ago + 1.day, updated_at: 1.week.ago + 2.days) # 1 day


### PR DESCRIPTION
If I submit a request on Friday at 8am, and get a response on Monday at 8am, the response time is 72h...

except if there was a daylight saving time change on Sunday, in which case the response time is either 71h or 73h, making the test fail