### PR TITLE
Ask multiple experts for an avis in one click

### DIFF
--- a/app/controllers/concerns/create_avis_concern.rb
+++ b/app/controllers/concerns/create_avis_concern.rb
@@ -5,22 +5,39 @@ module CreateAvisConcern
 
   def create_avis_from_params(dossier, confidentiel = false)
     confidentiel ||= create_avis_params[:confidentiel]
-    avis = Avis.new(create_avis_params.merge(claimant: current_gestionnaire, dossier: dossier, confidentiel: confidentiel))
+    emails = create_avis_params[:emails].split(',').map(&:strip)
 
-    if avis.save
-      flash.notice = "Une demande d'avis a été envoyée à #{avis.email_to_display}"
+    create_results = Avis.create(
+      emails.map do |email|
+        {
+          email: email,
+          introduction: create_avis_params[:introduction],
+          claimant: current_gestionnaire,
+          dossier: dossier,
+          confidentiel: confidentiel
+        }
+      end
+    )
+
+    if create_results.all?(&:persisted?)
+      sent_emails_addresses = create_results.map(&:email_to_display).join(", ")
+      flash.notice = "Une demande d'avis a été envoyée à #{sent_emails_addresses}"
 
       nil
     else
-      flash.now.alert = @avis.errors.full_messages
+      flash.now.alert = create_results
+        .map(&:errors)
+        .reject(&:empty?)
+        .map(&:full_messages)
+        .flatten
 
       # When an error occurs, return the avis back to the controller
       # to give the user a chance to correct and resubmit
-      avis
+      Avis.new(create_avis_params)
     end
   end
 
   def create_avis_params
-    params.require(:avis).permit(:email, :introduction, :confidentiel)
+    params.require(:avis).permit(:emails, :introduction, :confidentiel)
   end
 end

--- a/app/controllers/concerns/create_avis_concern.rb
+++ b/app/controllers/concerns/create_avis_concern.rb
@@ -1,0 +1,26 @@
+module CreateAvisConcern
+  extend ActiveSupport::Concern
+
+  private
+
+  def create_avis_from_params(dossier, confidentiel = false)
+    confidentiel ||= create_avis_params[:confidentiel]
+    avis = Avis.new(create_avis_params.merge(claimant: current_gestionnaire, dossier: dossier, confidentiel: confidentiel))
+
+    if avis.save
+      flash.notice = "Une demande d'avis a été envoyée à #{avis.email_to_display}"
+
+      nil
+    else
+      flash.now.alert = @avis.errors.full_messages
+
+      # When an error occurs, return the avis back to the controller
+      # to give the user a chance to correct and resubmit
+      avis
+    end
+  end
+
+  def create_avis_params
+    params.require(:avis).permit(:email, :introduction, :confidentiel)
+  end
+end

--- a/app/controllers/concerns/create_avis_concern.rb
+++ b/app/controllers/concerns/create_avis_concern.rb
@@ -5,7 +5,12 @@ module CreateAvisConcern
 
   def create_avis_from_params(dossier, confidentiel = false)
     confidentiel ||= create_avis_params[:confidentiel]
-    emails = create_avis_params[:emails].split(',').map(&:strip)
+
+    # Because of a limitation of the email_field rails helper,
+    # the :emails parameter is a 1-element array.
+    # Hence the call to first
+    # https://github.com/rails/rails/issues/17225
+    emails = create_avis_params[:emails].first.split(',').map(&:strip)
 
     create_results = Avis.create(
       emails.map do |email|
@@ -38,6 +43,6 @@ module CreateAvisConcern
   end
 
   def create_avis_params
-    params.require(:avis).permit(:emails, :introduction, :confidentiel)
+    params.require(:avis).permit(:introduction, :confidentiel, emails: [])
   end
 end

--- a/app/controllers/concerns/create_avis_concern.rb
+++ b/app/controllers/concerns/create_avis_concern.rb
@@ -24,21 +24,23 @@ module CreateAvisConcern
       end
     )
 
-    if create_results.all?(&:persisted?)
-      sent_emails_addresses = create_results.map(&:email_to_display).join(", ")
-      flash.notice = "Une demande d'avis a été envoyée à #{sent_emails_addresses}"
+    persisted, failed = create_results.partition(&:persisted?)
 
-      nil
-    else
-      flash.now.alert = create_results
-        .map(&:errors)
-        .reject(&:empty?)
-        .map(&:full_messages)
-        .flatten
+    if persisted.any?
+      sent_emails_addresses = persisted.map(&:email_to_display).join(", ")
+      flash.notice = "Une demande d'avis a été envoyée à #{sent_emails_addresses}"
+    end
+
+    if failed.any?
+      flash.now.alert = failed
+        .select { |avis| avis.errors.present? }
+        .map { |avis| "#{avis.email} : #{avis.errors.full_messages.join(', ')}" }
 
       # When an error occurs, return the avis back to the controller
       # to give the user a chance to correct and resubmit
-      Avis.new(create_avis_params)
+      Avis.new(create_avis_params.merge(emails: [failed.map(&:email).join(", ")]))
+    else
+      nil
     end
   end
 

--- a/app/controllers/new_gestionnaire/avis_controller.rb
+++ b/app/controllers/new_gestionnaire/avis_controller.rb
@@ -60,7 +60,7 @@ module NewGestionnaire
     end
 
     def create_avis
-      confidentiel = avis.confidentiel || params[:avis][:confidentiel]
+      confidentiel = avis.confidentiel || create_avis_params[:confidentiel]
       @new_avis = Avis.new(create_avis_params.merge(claimant: current_gestionnaire, dossier: avis.dossier, confidentiel: confidentiel))
 
       if @new_avis.save
@@ -143,7 +143,7 @@ module NewGestionnaire
     end
 
     def create_avis_params
-      params.require(:avis).permit(:email, :introduction)
+      params.require(:avis).permit(:email, :introduction, :confidentiel)
     end
   end
 end

--- a/app/models/avis.rb
+++ b/app/models/avis.rb
@@ -6,6 +6,7 @@ class Avis < ApplicationRecord
   belongs_to :claimant, class_name: 'Gestionnaire'
 
   validates :email, format: { with: Devise.email_regexp, message: "n'est pas valide" }, allow_nil: true
+  validates :claimant, presence: true
 
   before_validation -> { sanitize_email(:email) }
   before_create :try_to_assign_gestionnaire

--- a/app/models/avis.rb
+++ b/app/models/avis.rb
@@ -19,6 +19,10 @@ class Avis < ApplicationRecord
   scope :by_latest, -> { order(updated_at: :desc) }
   scope :updated_since?, -> (date) { where('avis.updated_at > ?', date) }
 
+  # The form allows subtmitting avis requests to several emails at once,
+  # hence this virtual attribute.
+  attr_accessor :emails
+
   def email_to_display
     gestionnaire&.email || email
   end

--- a/app/views/new_gestionnaire/shared/avis/_form.html.haml
+++ b/app/views/new_gestionnaire/shared/avis/_form.html.haml
@@ -1,9 +1,9 @@
 %section.ask-avis
-  %h1.tab-title Inviter une personne à donner son avis
-  %p.avis-notice L'invité pourra consulter, donner un avis sur le dossier et contribuer au fil de messagerie, mais il ne pourra le modifier.
+  %h1.tab-title Inviter des personnes à donner leur avis
+  %p.avis-notice Les invités pourront consulter, donner un avis sur le dossier et contribuer au fil de messagerie, mais ils ne pourront pas le modifier.
 
   = form_for avis, url: url, html: { class: 'form' } do |f|
-    = f.email_field :email, placeholder: 'Adresse email', required: true
+    = f.text_field :emails, placeholder: 'Adresses email, séparées par des virgules', required: true
     = f.text_area :introduction, rows: 3, value: avis.introduction || 'Bonjour, merci de me donner votre avis sur ce dossier.', required: true
     .flex.justify-between.align-baseline
       - if must_be_confidentiel

--- a/app/views/new_gestionnaire/shared/avis/_form.html.haml
+++ b/app/views/new_gestionnaire/shared/avis/_form.html.haml
@@ -3,7 +3,7 @@
   %p.avis-notice Les invités pourront consulter, donner un avis sur le dossier et contribuer au fil de messagerie, mais ils ne pourront pas le modifier.
 
   = form_for avis, url: url, html: { class: 'form' } do |f|
-    = f.text_field :emails, placeholder: 'Adresses email, séparées par des virgules', required: true
+    = f.email_field :emails, placeholder: 'Adresses email, séparées par des virgules', required: true, multiple: true
     = f.text_area :introduction, rows: 3, value: avis.introduction || 'Bonjour, merci de me donner votre avis sur ce dossier.', required: true
     .flex.justify-between.align-baseline
       - if must_be_confidentiel

--- a/config/application.rb
+++ b/config/application.rb
@@ -25,6 +25,7 @@ module TPS
     config.i18n.available_locales = [:fr]
 
     config.paths.add "#{config.root}/lib", eager_load: true
+    config.paths.add "#{config.root}/app/controllers/concerns", eager_load: true
 
     config.assets.paths << Rails.root.join('app', 'assets', 'javascript')
     config.assets.paths << Rails.root.join('app', 'assets', 'fonts')

--- a/config/application.rb
+++ b/config/application.rb
@@ -24,7 +24,7 @@ module TPS
     config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}')]
     config.i18n.available_locales = [:fr]
 
-    config.autoload_paths += ["#{config.root}/lib", "#{config.root}/app/validators", "#{config.root}/app/facades"]
+    config.autoload_paths += ["#{config.root}/lib"]
     config.assets.paths << Rails.root.join('app', 'assets', 'javascript')
     config.assets.paths << Rails.root.join('app', 'assets', 'fonts')
     config.assets.precompile += ['.woff']

--- a/config/application.rb
+++ b/config/application.rb
@@ -24,7 +24,8 @@ module TPS
     config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}')]
     config.i18n.available_locales = [:fr]
 
-    config.autoload_paths += ["#{config.root}/lib"]
+    config.paths.add "#{config.root}/lib", eager_load: true
+
     config.assets.paths << Rails.root.join('app', 'assets', 'javascript')
     config.assets.paths << Rails.root.join('app', 'assets', 'fonts')
     config.assets.precompile += ['.woff']

--- a/spec/controllers/new_gestionnaire/avis_controller_spec.rb
+++ b/spec/controllers/new_gestionnaire/avis_controller_spec.rb
@@ -105,7 +105,7 @@ describe NewGestionnaire::AvisController, type: :controller do
       let(:created_avis) { Avis.last }
 
       before do
-        post :create_avis, params: { id: previous_avis.id, avis: { email: email, introduction: intro, confidentiel: asked_confidentiel } }
+        post :create_avis, params: { id: previous_avis.id, avis: { emails: email, introduction: intro, confidentiel: asked_confidentiel } }
       end
 
       context 'when an invalid email' do

--- a/spec/controllers/new_gestionnaire/avis_controller_spec.rb
+++ b/spec/controllers/new_gestionnaire/avis_controller_spec.rb
@@ -100,22 +100,35 @@ describe NewGestionnaire::AvisController, type: :controller do
 
     describe '#create_avis' do
       let!(:previous_avis) { Avis.create(dossier: dossier, claimant: claimant, gestionnaire: gestionnaire, confidentiel: previous_avis_confidentiel) }
-      let(:email) { 'a@b.com' }
+      let(:emails) { ['a@b.com'] }
       let(:intro) { 'introduction' }
       let(:created_avis) { Avis.last }
+      let!(:old_avis_count) { Avis.count }
 
       before do
-        post :create_avis, params: { id: previous_avis.id, avis: { emails: [email], introduction: intro, confidentiel: asked_confidentiel } }
+        post :create_avis, params: { id: previous_avis.id, avis: { emails: emails, introduction: intro, confidentiel: asked_confidentiel } }
       end
 
       context 'when an invalid email' do
         let(:previous_avis_confidentiel) { false }
         let(:asked_confidentiel) { false }
-        let(:email) { "toto.fr" }
+        let(:emails) { ["toto.fr"] }
 
         it { expect(response).to render_template :instruction }
-        it { expect(flash.alert).to eq(["Email n'est pas valide"]) }
+        it { expect(flash.alert).to eq(["toto.fr : Email n'est pas valide"]) }
         it { expect(Avis.last).to eq(previous_avis) }
+      end
+
+      context 'with multiple emails' do
+        let(:asked_confidentiel) { false }
+        let(:previous_avis_confidentiel) { false }
+        let(:emails) { ["toto.fr,titi@titimail.com"] }
+
+        it { expect(response).to render_template :instruction }
+        it { expect(flash.alert).to eq(["toto.fr : Email n'est pas valide"]) }
+        it { expect(flash.notice).to eq("Une demande d'avis a été envoyée à titi@titimail.com") }
+        it { expect(Avis.count).to eq(old_avis_count + 1) }
+        it { expect(created_avis.email).to eq("titi@titimail.com") }
       end
 
       context 'when the previous avis is public' do
@@ -125,7 +138,7 @@ describe NewGestionnaire::AvisController, type: :controller do
           let(:asked_confidentiel) { false }
 
           it { expect(created_avis.confidentiel).to be(false) }
-          it { expect(created_avis.email).to eq(email) }
+          it { expect(created_avis.email).to eq(emails.last) }
           it { expect(created_avis.introduction).to eq(intro) }
           it { expect(created_avis.dossier).to eq(previous_avis.dossier) }
           it { expect(created_avis.claimant).to eq(gestionnaire) }

--- a/spec/controllers/new_gestionnaire/avis_controller_spec.rb
+++ b/spec/controllers/new_gestionnaire/avis_controller_spec.rb
@@ -105,7 +105,7 @@ describe NewGestionnaire::AvisController, type: :controller do
       let(:created_avis) { Avis.last }
 
       before do
-        post :create_avis, params: { id: previous_avis.id, avis: { emails: email, introduction: intro, confidentiel: asked_confidentiel } }
+        post :create_avis, params: { id: previous_avis.id, avis: { emails: [email], introduction: intro, confidentiel: asked_confidentiel } }
       end
 
       context 'when an invalid email' do

--- a/spec/controllers/new_gestionnaire/dossiers_controller_spec.rb
+++ b/spec/controllers/new_gestionnaire/dossiers_controller_spec.rb
@@ -313,7 +313,7 @@ describe NewGestionnaire::DossiersController, type: :controller do
       post :create_avis, params: {
         procedure_id: procedure.id,
         dossier_id: dossier.id,
-        avis: { emails: email, introduction: 'intro', confidentiel: true }
+        avis: { emails: [email], introduction: 'intro', confidentiel: true }
       }
     end
 

--- a/spec/controllers/new_gestionnaire/dossiers_controller_spec.rb
+++ b/spec/controllers/new_gestionnaire/dossiers_controller_spec.rb
@@ -313,7 +313,7 @@ describe NewGestionnaire::DossiersController, type: :controller do
       post :create_avis, params: {
         procedure_id: procedure.id,
         dossier_id: dossier.id,
-        avis: { email: email, introduction: 'intro', confidentiel: true }
+        avis: { emails: email, introduction: 'intro', confidentiel: true }
       }
     end
 

--- a/spec/features/new_gestionnaire/gestionnaire_spec.rb
+++ b/spec/features/new_gestionnaire/gestionnaire_spec.rb
@@ -192,7 +192,7 @@ feature 'The gestionnaire part' do
   end
 
   def ask_confidential_avis(to, introduction)
-    fill_in 'avis_email', with: to
+    fill_in 'avis_emails', with: to
     fill_in 'avis_introduction', with: introduction
     select 'confidentiel', from: 'avis_confidentiel'
     click_on 'Demander un avis'


### PR DESCRIPTION
Fix #835 

Il y a trois assez gros points sur lesquels je m’attends à ce qu’il y ait de la discussion (dans le sens, j’ai trouvé une solution, je n’en suis pas ravi)

1. il commençait à y avoir pas mal de duplication entre le contrôleur des dossiers et celui des avis, du coup j’ai sorti un concern https://github.com/betagouv/tps/pull/2938/commits/36edb67500ea42e7147a5d10e73e532d532aa2c0
2. le form a des emails (au pluriel) alors que le model a un email (au singulier). Du coup j’ai rajouté un attribut virtuel mais je ne suis pas convaincu que le model devrait avoir à se soucier de ça https://github.com/betagouv/tps/pull/2938/commits/49f17a5aa442396f129b06dfc7d7b6a89bb077ab#diff-35b5815b190108c5722c67d05ffb7630R24
3. l’attribute html5 `multiple` (qui permet d’avoir un champ email avec plusieurs emails ET validation html5) clashe avec l’option `multiple` des field helpers de rails, ce qui fait que rails me rajoute un niveau d’emballage inutile dans un array, que je suis obligé de redétricoter à coup de `first` https://github.com/betagouv/tps/pull/2938/commits/d7a47b64ddef100a5e5ecef9b3c17a4cf21f4f0f