### PR TITLE
Matomo analytics

### DIFF
--- a/app/assets/stylesheets/new_design/suivi.scss
+++ b/app/assets/stylesheets/new_design/suivi.scss
@@ -1,0 +1,27 @@
+$default-space: 15px;
+$new-p-margin-bottom: 3 * $default-space;
+
+.suivi {
+  width: 1040px;
+  margin: 0 auto;
+  padding-top: $default-space * 2;
+  padding-bottom: $default-space * 2;
+
+  ul {
+    list-style-type: disc;
+    margin-top: -($default-space * 2);
+  }
+
+  iframe {
+    border: none;
+    width: 100%;
+  }
+
+  .new-h2 {
+    text-align: left;
+  }
+}
+
+.new-p {
+  margin-bottom: $new-p-margin-bottom;
+}

--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -55,4 +55,7 @@ class RootController < ApplicationController
 
     @dossier = Dossier.new(champs: all_champs)
   end
+
+  def suivi
+  end
 end

--- a/app/views/layouts/_matomo.html.haml
+++ b/app/views/layouts/_matomo.html.haml
@@ -1,0 +1,15 @@
+:javascript
+  var _paq = _paq || [];
+  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+  _paq.push(["setCookieDomain", "*.www.demarches-simplifiees.fr"]);
+  _paq.push(["setDomains", ["*.www.demarches-simplifiees.fr"]]);
+  _paq.push(["setDoNotTrack", true]);
+  _paq.push(['trackPageView']);
+  _paq.push(['enableLinkTracking']);
+  (function() {
+    var u="//stats.data.gouv.fr/";
+    _paq.push(['setTrackerUrl', u+'piwik.php']);
+    _paq.push(['setSiteId', '73']);
+    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+    g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
+  })();

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -16,10 +16,13 @@
     = javascript_include_tag 'application', defer: true, 'data-turbolinks-track': 'reload'
     = csrf_meta_tags
 
+    = render partial: "layouts/matomo"
+
     :javascript
       DATA = [{
         sentry: #{raw(sentry_config)}
       }];
+
   %body{ class: browser.platform.ios? ? 'ios' : nil }
     = render partial: 'layouts/outdated_browser_banner'
     = render partial: 'layouts/pre_maintenance'

--- a/app/views/layouts/new_application.html.haml
+++ b/app/views/layouts/new_application.html.haml
@@ -21,10 +21,14 @@
     - if Rails.env.development?
       = stylesheet_link_tag :xray
 
+    - if !current_user
+      = render partial: "layouts/matomo"
+
     :javascript
       DATA = [{
         sentry: #{raw(sentry_config)}
       }];
+
   %body{ class: browser.platform.ios? ? 'ios' : nil }
     .page-wrapper
       = render partial: "layouts/outdated_browser_banner"

--- a/app/views/root/_footer.html.haml
+++ b/app/views/root/_footer.html.haml
@@ -26,6 +26,8 @@
             = link_to "CGU", CGU_URL, :class => "footer-link", :target => "_blank", rel: "noopener noreferrer"
           %li.footer-link
             = link_to "Mentions légales", MENTIONS_LEGALES_URL,  :class => "footer-link", :target => "_blank", rel: "noopener noreferrer"
+          %li.footer-link
+            = link_to "Suivi d'audience et vie privée", suivi_path,  :class => "footer-link"
 
       %li.footer-column
         %ul.footer-links

--- a/app/views/root/suivi.html.haml
+++ b/app/views/root/suivi.html.haml
@@ -1,0 +1,23 @@
+- content_for(:title, 'Suivi')
+
+.suivi
+  %h1.new-h1 Cookies déposés et configuration du suivi
+
+  %p.new-p
+    Ce site dépose un petit fichier texte (un « cookie ») sur votre ordinateur lorsque vous le consultez. Cela nous permet de mesurer le nombre de visites et de comprendre quelles sont les pages les plus consultées.
+
+  %iframe{ :src => MATOMO_IFRAME_URL }
+
+  %h2.new-h2 Ce site n’affiche pas de bannière de consentement aux cookies, pourquoi ?
+  %p.new-p
+    C’est vrai, vous n’avez pas eu à cliquer sur un bloc qui recouvre la moitié de la page pour dire que vous êtes d’accord avec le dépôt de cookies.
+    %br
+    %br
+    Rien d'exceptionnel, pas de passe-droit. Nous respectons simplement la loi, qui dit que certains outils de suivi d’audience, correctement configurés pour respecter la vie privée, sont exemptés d’autorisation préalable.
+    %br
+    %br
+    Nous utilisons pour cela <a href="https://matomo.org/" target="_blank" >Matomo</a>, un outil <a href="https://matomo.org/free-software/" target="_blank">libre</a>, paramétré pour être en conformité avec la <a href="https://www.cnil.fr/fr/solutions-pour-la-mesure-daudience">recommandation « Cookies » </a>de la CNIL. Cela signifie que votre adresse IP, par exemple, est anonymisée avant d’être enregistrée. Il est donc impossible d’associer vos visites sur ce site à votre personne.
+
+  %h2.new-h2 Je contribue à enrichir vos données, puis-je y accéder ?
+  %p.new-p
+    Bien sûr ! Les statistiques d’usage sont en accès libre sur <a href="https://stats.data.gouv.fr/index.php?module=MultiSites&action=index&idSite=1&period=range&date=previous30&updated=1#?idSite=1&period=range&date=previous30&category=Dashboard_Dashboard&subcategory=1&module=MultiSites&action=index" target="_blank">stats.data.gouv.fr</a>.

--- a/config/initializers/urls.rb
+++ b/config/initializers/urls.rb
@@ -22,3 +22,4 @@ MENTIONS_LEGALES_URL = [CGU_URL, "4-mentions-legales"].join("#")
 API_DOC_URL = [DOC_URL, "pour-aller-plus-loin", "api"].join("/")
 WEBHOOK_DOC_URL = [DOC_URL, "pour-aller-plus-loin", "webhook"].join("/")
 FAQ_URL = "https://faq.demarches-simplifiees.fr"
+MATOMO_IFRAME_URL = "https://stats.data.gouv.fr/index.php?module=CoreAdminHome&action=optOut&language=fr&&fontColor=333333&fontSize=16px&fontFamily=Muli"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -128,6 +128,7 @@ Rails.application.routes.draw do
   end
 
   get "patron" => "root#patron"
+  get "suivi" => "root#suivi"
 
   get "contact", to: "support#index"
   post "contact", to: "support#create"


### PR DESCRIPTION
Fixes #2946 

Ajout de Matomo (analytics) pour les pages 

- https://demarches-simplifiees.fr/
- https://demarches-simplifiees.fr/contact
- https://demarches-simplifiees.fr/administration
- https://demarches-simplifiees.fr/admin

Je n'ai pas réussi à exclure uniquement les pages usagers. Les analytics ne sont donc pas présent sur toute la partie instructeur aussi
