### PR TITLE
Formulaire de contact pour les admins

### DIFF
--- a/app/assets/stylesheets/new_design/landing.scss
+++ b/app/assets/stylesheets/new_design/landing.scss
@@ -159,8 +159,13 @@ $landing-breakpoint: 1040px;
 }
 
 .usagers-panel,
-.numbers-panel {
+.numbers-panel,
+.cta-panel-2 {
   background-color: $light-grey;
+}
+
+.more-info {
+  background-color: #FFFFFF;
 }
 
 .numbers {
@@ -316,6 +321,15 @@ $users-breakpoint: 950px;
   }
 }
 
+.role-more-info-image {
+  text-align: left;
+
+  @media (max-width: $users-breakpoint) {
+    text-align: center;
+    margin-bottom: 45px;
+  }
+}
+
 .role-usagers-image {
   @media (max-width: $users-breakpoint) {
     text-align: center;
@@ -436,4 +450,13 @@ $cta-panel-button-border-size: 2px;
     color: #FFFFFF;
     text-decoration: underline;
   }
+}
+
+.half {
+  width: 45%;
+  float: left;
+}
+
+.first-half {
+  margin-right: 10%;
 }

--- a/app/controllers/support_controller.rb
+++ b/app/controllers/support_controller.rb
@@ -16,7 +16,7 @@ class SupportController < ApplicationController
       redirect_to root_path(formulaire_contact_general_submitted: true)
     else
       setup_context
-      flash.now.alert = "Une erreur est survenue. Vous pouvez nous contactez à #{helpers.mail_to(CONTACT_EMAIL)}."
+      flash.now.alert = "Une erreur est survenue. Vous pouvez nous contacter à #{helpers.mail_to(CONTACT_EMAIL)}."
 
       render :index
     end

--- a/app/controllers/support_controller.rb
+++ b/app/controllers/support_controller.rb
@@ -5,6 +5,10 @@ class SupportController < ApplicationController
     setup_context
   end
 
+  def admin
+    setup_context_admin
+  end
+
   def create
     if direct_message? && create_commentaire
       flash.notice = "Votre message a été envoyé sur la messagerie de votre dossier."
@@ -13,12 +17,21 @@ class SupportController < ApplicationController
     elsif create_conversation
       flash.notice = "Votre message a été envoyé."
 
-      redirect_to root_path(formulaire_contact_general_submitted: true)
+      if params[:admin]
+        redirect_to root_path(formulaire_contact_admin_submitted: true)
+      else
+        redirect_to root_path(formulaire_contact_general_submitted: true)
+      end
     else
-      setup_context
       flash.now.alert = "Une erreur est survenue. Vous pouvez nous contacter à #{helpers.mail_to(CONTACT_EMAIL)}."
 
-      render :index
+      if params[:admin]
+        setup_context_admin
+        render :admin
+      else
+        setup_context
+        render :index
+      end
     end
   end
 
@@ -30,10 +43,16 @@ class SupportController < ApplicationController
     @options = Helpscout::FormAdapter::OPTIONS
   end
 
+  def setup_context_admin
+    @tags = tags
+    @options = Helpscout::FormAdapter::ADMIN_OPTIONS
+  end
+
   def create_conversation
     Helpscout::FormAdapter.new(
       subject: params[:subject],
       email: email,
+      phone: params[:phone],
       text: params[:text],
       file: params[:file],
       dossier_id: dossier&.id,

--- a/app/lib/helpscout/api.rb
+++ b/app/lib/helpscout/api.rb
@@ -3,6 +3,8 @@ class Helpscout::API
   CONVERSATIONS = 'conversations'
   TAGS = 'tags'
   FIELDS = 'fields'
+  CUSTOMERS = 'customers'
+  PHONES = 'phones'
   OAUTH2_TOKEN = 'oauth2/token'
 
   def add_tags(conversation_id, tags)
@@ -40,6 +42,21 @@ class Helpscout::API
     }.compact
 
     call_api(:post, CONVERSATIONS, body)
+  end
+
+  def add_phone_number(email, phone)
+    query = URI.encode("(email:#{email})")
+    response = call_api(:get, "#{CUSTOMERS}?mailbox=#{mailbox_id}&query=#{query}")
+    if response.success?
+      body = parse_response_body(response)
+      if body[:page][:totalElements] > 0
+        customer_id = body[:_embedded][:customers].first[:id]
+        call_api(:post, "#{CUSTOMERS}/#{customer_id}/#{PHONES}", {
+          type: "work",
+          value: phone
+        })
+      end
+    end
   end
 
   private

--- a/app/lib/helpscout/form_adapter.rb
+++ b/app/lib/helpscout/form_adapter.rb
@@ -20,6 +20,18 @@ class Helpscout::FormAdapter
     [I18n.t(TYPE_AUTRE, scope: [:support]), TYPE_AUTRE]
   ]
 
+  ADMIN_TYPE_RDV = 'admin demande rdv'
+  ADMIN_TYPE_QUESTION = 'admin question'
+  ADMIN_TYPE_SOUCIS = 'admin soucis'
+  ADMIN_TYPE_AUTRE = 'admin autre'
+
+  ADMIN_OPTIONS = [
+    [I18n.t(ADMIN_TYPE_QUESTION, scope: [:supportadmin]), ADMIN_TYPE_QUESTION],
+    [I18n.t(ADMIN_TYPE_RDV, scope: [:supportadmin]), ADMIN_TYPE_RDV],
+    [I18n.t(ADMIN_TYPE_SOUCIS, scope: [:supportadmin]), ADMIN_TYPE_SOUCIS],
+    [I18n.t(ADMIN_TYPE_AUTRE, scope: [:supportadmin]), ADMIN_TYPE_AUTRE]
+  ]
+
   def send_form
     conversation_id = create_conversation
 
@@ -51,6 +63,11 @@ class Helpscout::FormAdapter
       params[:file]
     )
 
-    response.success? ? response.headers['Resource-ID'] : nil
+    if response.success?
+      if params[:phone].present?
+        @api.add_phone_number(params[:email], params[:phone])
+      end
+      response.headers['Resource-ID']
+    end
   end
 end

--- a/app/views/root/administration.html.haml
+++ b/app/views/root/administration.html.haml
@@ -26,7 +26,7 @@
           %img.role-image{ :src => image_url("landing/roles/administrations.svg"), alt: "" }
 
         .role-panel-70
-          %h1.role-panel-title Vous êtes une administration et vous souhaitez dématérialiser une démarche papier et réduire vos temps d'instruction ?
+          %h1.role-panel-title Vous êtes une administration et êtes prête pour dématérialiser ?
           %p.role-panel-explanation Créez des formulaires en ligne en quelques minutes et instruisez les demandes des usagers sur une plateforme dédiée
 
           = link_to "Demander un compte administrateur",
@@ -34,11 +34,25 @@
             class: "role-panel-button-primary",
             rel: "noopener noreferrer"
 
-          = link_to "Voir la documentation",
+  .landing-panel.more-info
+    .container
+      .role-panel-wrapper.role-administrations-panel
+        .role-panel-70
+          %h1.role-panel-title Vous voulez en savoir plus ?
+          %p.role-panel-explanation Découvrez notre outil
+
+          = link_to "Contactez-nous",
+            contact_admin_path,
+            rel: "noopener noreferrer",
+            class: "role-panel-button-primary"
+
+          = link_to "Consultez notre documentation",
             DOC_URL,
-            target: "_blank",
             rel: "noopener noreferrer",
             class: "role-panel-button-secondary"
+
+        .role-panel-30.role-more-info-image
+          %img.role-image{ :src => image_url("landing/roles/usagers.svg"), alt: "" }
 
   .landing-panel.features-panel
     .container
@@ -181,6 +195,24 @@
           = link_to "http://www.lillemetropole.fr/", target: :blank, rel: "noopener noreferrer" do
             %img.user-image{ :src => image_url("landing/users/mel.jpg"), alt: "Métropole Européenne de Lille" }
 
+  .landing-panel.cta-panel-2
+    .container
+      .half.first-half
+        %h1.cta-panel-title Vous êtes prêt pour dématérialiser ?
+        %p.cta-panel-explanation Réduisez vos temps d'instruction de 50 %
+        = link_to "Demander un compte",
+          new_demande_path,
+          class: "cta-panel-button-blue"
+
+      .half
+        %h1.cta-panel-title Vous voulez en savoir plus ?
+        %p.cta-panel-explanation Nous vous faisons découvrir l'outil
+        = link_to "Contactez-nous",
+          contact_admin_path,
+          class: "cta-panel-button-blue"
+
+      .clearfix
+
   .landing-panel.cta-panel
     .container
       .cta-panel-wrapper
@@ -188,19 +220,5 @@
           %h1.cta-panel-title Une question, un problème ?
           %p.cta-panel-explanation Notre équipe est disponible pour vous renseigner et vous aider
         %div
-          = contact_link "Contactez-nous",
-            tags: 'administration',
-            class: "cta-panel-button-white",
-            target: "_blank",
-            rel: "noopener noreferrer"
-
-  .landing-panel
-    .container
-      .cta-panel-wrapper
-        %div
-          %h1.cta-panel-title Vous êtes prêt pour dématérialiser ?
-          %p.cta-panel-explanation Réduisez vos temps d'instruction de 50 %
-        %div
-          = link_to "Demander un compte administrateur",
-            new_demande_path,
-            class: "cta-panel-button-blue"
+          %a.cta-panel-button-white{ rel: 'noopener noreferrer', href:'/contact-admin' }
+            Contactez-nous

--- a/app/views/root/administration.html.haml
+++ b/app/views/root/administration.html.haml
@@ -13,8 +13,8 @@
       .hero-wrapper
         .hero-text
           %p.hero-tagline
-            %em.hero-tagline-em Dématérialiser et simplifier
-            les démarches administratives
+            %em.hero-tagline-em Dématérialisez et simplifiez
+            vos démarches administratives
 
         .hero-illustration
           %img{ :src => image_url("landing/hero/dematerialiser.svg"), alt: "" }

--- a/app/views/support/admin.html.haml
+++ b/app/views/support/admin.html.haml
@@ -1,0 +1,51 @@
+- content_for(:title, 'Contact')
+
+#contact-form
+  .container
+    %h1.new-h1 Contactez notre équipe
+
+    .description
+      En tant qu'administration, vous pouvez nous contactez via ce formulaire. Nous vous répondrons dans les plus brefs délais, par email ou par téléphone.
+      %br
+      %br
+      %strong
+        Attention, ce formulaire est réservée uniquement aux organismes publics.
+      Il ne concerne ni les particuliers, ni les entreprises, ni les associations (sauf celles reconnues d'utilité publique). Si c'est votre cas, rendez-vous sur notre
+      = link_to contact_path do
+        formulaire de contact public
+      \.
+
+    = form_tag contact_path, method: :post, class: 'form' do |f|
+      - if !logged_in?
+        .contact-champ
+          = label_tag :email do
+            Adresse email professionnelle
+            %span.mandatory *
+          = text_field_tag :email, params[:email], required: true
+
+      .contact-champ
+        = label_tag :type do
+          Catégorie
+          %span.mandatory *
+        = select_tag :type, options_for_select(@options, params[:type])
+
+      .contact-champ
+        = label_tag :phone, 'Numéro de téléphone professionnel (ligne directe)'
+        = text_field_tag :phone
+
+      .contact-champ
+        = label_tag :subject do
+          Sujet
+        = text_field_tag :subject, params[:subject], required: false
+
+      .contact-champ
+        = label_tag :text do
+          Message
+          %span.mandatory *
+        = text_area_tag :text, params[:text], rows: 6, required: true
+
+      = hidden_field_tag :tags, @tags&.join(',')
+      = hidden_field_tag :admin, true
+
+      .send-wrapper
+        = button_tag 'Envoyer le message', type: :submit, class: 'button send primary'

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -61,6 +61,11 @@ fr:
     produit: J'ai une idée d'amélioration pour votre site
     usager perdu: Je ne trouve pas la démarche que je veux faire
     autre: Autre sujet
+  supportadmin:
+    admin demande rdv: Demande de RDV pour une présentation à distance de demarches-simplifiees.fr
+    admin question: J'ai une question sur demarches-simplifiees.fr
+    admin soucis: J'ai un problème technique avec demarches-simplifiees.fr
+    admin autre: Autre sujet
 
   number:
     currency:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -137,6 +137,8 @@ Rails.application.routes.draw do
   get "contact", to: "support#index"
   post "contact", to: "support#create"
 
+  get "contact-admin", to: "support#admin"
+
   post "webhooks/helpscout", to: "webhook#helpscout"
   match "webhooks/helpscout", to: lambda { |_| [204, {}, nil] }, via: :head
 

--- a/spec/lib/helpscout/form_adapter_spec.rb
+++ b/spec/lib/helpscout/form_adapter_spec.rb
@@ -66,5 +66,45 @@ describe Helpscout::FormAdapter do
           .with(conversation_id, nil, nil)
       end
     end
+
+    context 'add_phone' do
+      before do
+        allow(api).to receive(:create_conversation)
+          .and_return(
+            double(
+              success?: true,
+              headers: {
+                'Resource-ID' => conversation_id
+              }
+            )
+          )
+
+        described_class.new(params, api).send_form
+      end
+
+      let(:params) {
+        {
+          email: email,
+          subject: subject,
+          text: text,
+          phone: '0666666666'
+        }
+      }
+      let(:phone) { '0666666666' }
+      let(:email) { 'paul.chavard@beta.gouv.fr' }
+      let(:subject) { 'Bonjour' }
+      let(:text) { "J'ai un problem" }
+      let(:tags) { ['info demarche'] }
+      let(:conversation_id) { '123' }
+
+      it 'should call method' do
+        expect(api).to have_received(:create_conversation)
+          .with(email, subject, text, nil)
+        expect(api).to have_received(:add_phone_number)
+          .with(email, phone)
+        expect(api).to have_received(:add_custom_fields)
+          .with(conversation_id, nil, nil)
+      end
+    end
   end
 end


### PR DESCRIPTION
fixes #2948 

Je n'ai pas pu tester en local l'arrivé des messages sur HS. Mais @fredZen a reussi et ca marche (avec les bons tag)

J'ai légèrement modifié /administration pour mettre en avant la page contact (pour l'instant, des administrations s'inscrivent alors qu'elles veulent des infos en realité). J'ai rajouté une ligne pour la documentation. 

![capture d ecran 2018-11-06 18 01 48](https://user-images.githubusercontent.com/3593868/48080543-30ae5e80-e1ee-11e8-941d-6fd31939c591.png)
![capture d ecran 2018-11-06 18 01 15](https://user-images.githubusercontent.com/3593868/48080547-3310b880-e1ee-11e8-8f7c-e9897863c22b.png)
