### PR TITLE
manager: hide dangerous features

### DIFF
--- a/app/views/fields/features_field/_show.html.haml
+++ b/app/views/fields/features_field/_show.html.haml
@@ -6,9 +6,9 @@
   end
 
 %table#features
-  - Flipflop.feature_set.features.each do |feature|
-    - if !feature.group || feature.group.key != :production
-      %tr
-        %td= feature.title
-        %td
-          = check_box_tag "enable-feature", "enable", field.data[feature.name], data: { url: url, key: feature.key }
+  - admin_features = Flipflop.feature_set.features.reject{ |f| f.group.try(:key) == :production }
+  - admin_features.each do |feature|
+    %tr
+      %td= feature.title
+      %td
+        = check_box_tag "enable-feature", "enable", field.data[feature.name], data: { url: url, key: feature.key }

--- a/config/features.rb
+++ b/config/features.rb
@@ -27,8 +27,7 @@ Flipflop.configure do
       default: ENV['FOG_ENABLED'] == 'enabled'
     feature :weekly_overview,
       default: ENV['APP_NAME'] == 'tps'
+    feature :pre_maintenance_mode
+    feature :maintenance_mode
   end
-
-  feature :pre_maintenance_mode
-  feature :maintenance_mode
 end


### PR DESCRIPTION
The "maintenance" and "pre-maintenance" features are supposed to be site-wide, and should never be enabled for a single user.

Hide them from the manager UI.

<img width="1263" alt="capture d ecran 2018-11-12 a 12 28 34" src="https://user-images.githubusercontent.com/179923/48344841-86fc2100-e676-11e8-901c-9db74b6b1e2a.png">
