### PR TITLE
[Manager] Utilisation des termes métiers

### DIFF
--- a/config/locales/models/gestionnaire/fr.yml
+++ b/config/locales/models/gestionnaire/fr.yml
@@ -1,0 +1,6 @@
+fr:
+  activerecord:
+    models:
+      gestionnaire:
+        one: Instructeur
+        other: Instructeurs

--- a/config/locales/models/procedure/fr.yml
+++ b/config/locales/models/procedure/fr.yml
@@ -1,5 +1,9 @@
 fr:
   activerecord:
+    models:
+      procedure:
+        one: Démarche
+        other: Démarches
     attributes:
       procedure:
         path: Lien public


### PR DESCRIPTION
Le manager utilise le nom des entités (Procédure, Gestionnaire) plutôt que le terme métier (Démarche, Instructeur).

C'est perturbant ; en particulier quand on utilise le Manager sans être dev :)

Cette PR affiche les termes métiers dans le Manager.

<img width="177" alt="capture d ecran 2018-11-13 a 11 24 42" src="https://user-images.githubusercontent.com/179923/48407367-ee79a580-e736-11e8-9c69-802f33a56fc7.png">
