### PR TITLE
Restreint l'estimation de la durée de traitement à un mois

### DIFF
--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -426,6 +426,7 @@ class Procedure < ApplicationRecord
   def percentile_time(start_attribute, end_attribute, p)
     times = dossiers
       .state_termine
+      .where(end_attribute => 1.month.ago..DateTime.current)
       .pluck(start_attribute, end_attribute)
       .map { |(start_date, end_date)| end_date - start_date }
 

--- a/spec/models/procedure_spec.rb
+++ b/spec/models/procedure_spec.rb
@@ -708,12 +708,14 @@ describe Procedure do
   describe '#usual_instruction_time' do
     let(:procedure) { create(:procedure) }
 
+    def create_dossier(instruction_date:, processed_date:)
+      dossier = create(:dossier, :accepte, procedure: procedure)
+      dossier.update!(en_instruction_at: instruction_date, processed_at: processed_date)
+    end
+
     before do
       processed_delays.each do |delay|
-        dossier = create :dossier, :accepte, procedure: procedure
-        instruction_date = 1.month.ago
-        processed_date = instruction_date + delay
-        dossier.update!(en_instruction_at: instruction_date, processed_at: processed_date)
+        create_dossier(instruction_date: 1.week.ago - delay, processed_date: 1.week.ago)
       end
     end
 

--- a/spec/models/procedure_spec.rb
+++ b/spec/models/procedure_spec.rb
@@ -727,6 +727,15 @@ describe Procedure do
       end
     end
 
+    context 'when there are very old dossiers' do
+      let(:processed_delays) { [2.days, 2.days] }
+      let!(:old_dossier) { create_dossier(instruction_date: 3.months.ago, processed_date: 2.months.ago) }
+
+      it 'ignores dossiers older than 1 month' do
+        expect(procedure.usual_instruction_time).to be_within(10.seconds).of(2.days)
+      end
+    end
+
     context 'when there is only one processed dossier' do
       let(:processed_delays) { [1.day] }
       it { expect(procedure.usual_instruction_time).to be_within(10.seconds).of(1.day) }

--- a/spec/models/procedure_spec.rb
+++ b/spec/models/procedure_spec.rb
@@ -729,7 +729,7 @@ describe Procedure do
 
     context 'when there is only one processed dossier' do
       let(:processed_delays) { [1.day] }
-      it { expect(procedure.usual_instruction_time).to eq(1.day) }
+      it { expect(procedure.usual_instruction_time).to be_within(10.seconds).of(1.day) }
     end
 
     context 'where there is no processed dossier' do


### PR DESCRIPTION
En ce moment on calcule l'estimation de durée de traitement sur tous les dossiers traités de la démarche. C'est lent, et sans doute incorrect.

Ce qui est plus intéressant, c'est le temps des dossiers traités récemment.

Avec cette PR, on calcule le temps sur les dossiers instruits dans les 30 derniers jours. C'est plus rapide à calculer – et sans doute plus représentatif d'une augmentation ou d'une diminution récente du délai de traitement.