### PR TITLE
spec: fix Mina enabling Rails traces during tests

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -81,6 +81,7 @@ end
 DatabaseCleaner.strategy = :transaction
 
 TPS::Application.load_tasks
+Rake.application.options.trace = false
 
 include Warden::Test::Helpers
 


### PR DESCRIPTION
When requiring mina files, it automatically enables Rails traces. But
we don't want Rails traces during tests.

Fix this by disabling Rails traces before running tests.

Fix #2989