### PR TITLE
circleci: print files used by the shell command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,11 +74,13 @@ jobs:
             DATABASE_URL: "postgres://tps_test@localhost:5432/tps_test"
           name: Run Tests, Splitted by Timings
           command: |
-            bundle exec rspec --profile 10 \
+            COMMAND="bundle exec rspec --profile 10 \
               --format RspecJunitFormatter \
               --out ~/test_results/rspec.xml \
               --format progress \
-              $(circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings)
+              $(circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings)"
+            echo $COMMAND
+            eval $COMMAND
       - store_test_results:
           path: ~/test_results/rspec.xml
   lint:


### PR DESCRIPTION
CicleCI sépare nos fichiers de test en trois groupes, et les lance en parallèle.

Le problème, c'est que quand un de ces groupes échoue à cause d'une erreur causée par l'ordre des tests, on a bien la seed – mais on ne sait pas quels fichiers ont été exécutés. On ne peut donc pas reproduire le problème en local.

Cette PR fait en sorte qu'on puisse voir dans les logs les fichiers de spec utilisés, pour pouvoir reproduire facilement en local.