### PR TITLE
Fix order dependant test

### DIFF
--- a/spec/models/procedure_spec.rb
+++ b/spec/models/procedure_spec.rb
@@ -626,6 +626,7 @@ describe Procedure do
 
   describe "#export_filename" do
     before { Timecop.freeze(Time.zone.local(2018, 1, 2, 23, 11, 14)) }
+    after { Timecop.return }
 
     subject { procedure.export_filename }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -104,6 +104,11 @@ RSpec.configure do |config|
   config.infer_spec_type_from_file_location!
   config.tty = true
 
+  # Since rspec 3.8.0, bisect uses fork to improve bisection speed.
+  # This however fails as soon as we're running feature tests (which uses many processes).
+  # Default to the :shell bisect runner, so that bisecting over feature tests works.
+  config.bisect_runner = :shell
+
   config.include Shoulda::Matchers::ActiveRecord, type: :model
   config.include Shoulda::Matchers::ActiveModel, type: :model
   config.include Shoulda::Matchers::Independent, type: :model


### PR DESCRIPTION
Cette PR :

- **Corrige l'usage de `bin/rspec --bisect`**, en faisant en sorte que le bisect ne freeze plus bêtement quand il inclut des feature-tests ;
- **Corrige un test order-dependant** : il y avait un `Timecop.return` manquant.
