### PR TITLE
Fix instructeurs list filter

### DIFF
--- a/app/javascript/shared/rails-ujs-fix.js
+++ b/app/javascript/shared/rails-ujs-fix.js
@@ -20,9 +20,19 @@ delegate('ajax:send', '[data-remote]', ({ target }) => {
 // jQuery-less version of rails-ujs it breaks.
 // https://github.com/Sology/smart_listing/blob/master/app/assets/javascripts/smart_listing.coffee.erb#L9
 addEventListener('load', () => {
-  const { href } = Rails;
+  const { href, handleRemote } = Rails;
   Rails.href = function(element) {
     return element.href || href(element);
+  };
+  Rails.handleRemote = function(e) {
+    if (this instanceof HTMLElement) {
+      handleRemote.call(this, e);
+    } else {
+      let element = e.find('[data-remote]')[0];
+      let event = new CustomEvent('click');
+      Object.defineProperty(event, 'target', { value: element });
+      return handleRemote.call(element, event);
+    }
   };
 });
 


### PR DESCRIPTION
fix #3002 

Le problem c'est que `smart_listing` n'est plus maintenu et depend de la version de `rails-ujs` basée sur `jQuery`