### PR TITLE
tasks: remove outdated footers in mail templates

### DIFF
--- a/lib/tasks/deployment/20181120133842_remove_footer_from_email_templates.rake
+++ b/lib/tasks/deployment/20181120133842_remove_footer_from_email_templates.rake
@@ -1,0 +1,54 @@
+require Rails.root.join("lib", "tasks", "task_helper")
+
+namespace :after_party do
+  # Matches "ne pas répondre", plus some content before and after:
+  # - try to remove dashes before the footer
+  # - try to remove line-breaks and empty HTML tags before the footer text
+  # - matches "Veuillez ne pas répondre" or "Merci de ne pas répondre"
+  # - once the footer text is found, extend the match to the end of the body
+  FOOTER_REGEXP = /(—|---|-)?( |\r|\n|<br>|<p>|<\/p>|<small>|<\/small>|<b>|<\/b>|&nbsp;)*(Veuillez)?(Merci)?( |\r|\n)*(de)? ne pas répondre(.*)$/m
+  # When the footer contains any of these words, it is kept untouched.
+  FOOTER_EXCEPTIONS = [
+    'PDF',
+    '@',
+    'Hadrien',
+    'Esther',
+    'Sicoval',
+    'a323',
+    'SNC',
+    'Polynésie',
+    'drac',
+    'theplatform'
+  ]
+
+  desc 'Deployment task: remove_footer_from_email_templates'
+  task remove_footer_from_email_templates: :environment do
+    rake_puts "Running deploy task 'remove_footer_from_email_templates'"
+
+    models = [
+      Mails::ClosedMail,
+      Mails::InitiatedMail,
+      Mails::ReceivedMail,
+      Mails::RefusedMail,
+      Mails::WithoutContinuationMail
+    ]
+
+    models.each do |model_class|
+      model_class.all.find_each do |template|
+        remove_footer(template)
+      end
+    end
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord.create version: '20181120133842'
+  end # task :remove_footer_from_email_templates
+
+  def remove_footer(template)
+    matches = template.body.match(FOOTER_REGEXP)
+    if matches && FOOTER_EXCEPTIONS.none? { |exception| matches[0].include?(exception) }
+      rake_puts "#{template.model_name.to_s} \##{template.id}: removing footer"
+      template.update(body: matches.pre_match)
+    end
+  end
+end # namespace :after_party

--- a/spec/lib/tasks/deployment/20181120133842_remove_footer_from_email_templates.rake_spec.rb
+++ b/spec/lib/tasks/deployment/20181120133842_remove_footer_from_email_templates.rake_spec.rb
@@ -1,0 +1,72 @@
+describe '20181120133842_remove_footer_from_email_templates.rake' do
+  let(:rake_task) { Rake::Task['after_party:remove_footer_from_email_templates'] }
+  let(:templates) do
+    bodies.map { |body| create(:received_mail, body: body) }
+  end
+
+  before do
+    templates
+  end
+
+  subject! do
+    rake_task.invoke
+  end
+
+  after do
+    rake_task.reenable
+  end
+
+  context 'when emails have "do not reply" footers' do
+    let(:bodies) do
+      [
+        "<p>Some content</p>--- <br>\r\n<br>\r\nMerci de ne pas répondre à cet email. Postez directement vos questions dans\r\nvotre dossier sur la plateforme.</p>",
+        "<p>Some content</p>-<br>\r\n<br>\r\nMerci de ne pas répondre à cet email. Postez directement vos questions dans\r\nvotre dossier sur la plateforme.</p>",
+        "<p>Some content</p>— <br>\r\n<br>\r\nMerci de ne pas répondre à cet email. Postez directement vos questions dans\r\nvotre dossier sur la plateforme.</p>",
+        "<p>Some content</p>--- <br>\r\n<br>\r\nMerci de ne pas répondre à cet email. Postez directement vos questions dans\r\nvotre dossier sur demarches-simplifiees.fr.</p>",
+        "<p>Some content</p>— <br><br><small></small><b></b>Merci de ne pas répondre à cet email. Postez directement vos questions dans\r\nvotre dossier sur la plateforme.</p>",
+        "<p>Some content</p>--- <br>\r\n<br>\r\nMerci de ne pas répondre à cet email. Postez directement vos questions dans\r\nvotre dossier --libelle-dossier--.</p>",
+        "<p>Some content</p>--- <br>\r\n<br>\r\nMerci de ne pas répondre à cet email. Postez directement vos questions dans\r\nvotre dossier sur la plateforme, mais ne répondez pas à ce message.</p><p>\r\n\r\n</p><p>&nbsp;</p><p>\r\n<br></p><br>",
+        "<p>Some content</p>--- <br>\r\n<br>\r\Veuillez ne pas répondre à cet email. Postez directement vos questions dans\r\nvotre dossier sur la plateforme.</p>",
+        "<p>Some content</p>--- <br>\r\n<br>\r\nMerci\r\nde ne pas répondre à cet email. Postez directement vos questions dans\r\nvotre dossier sur la plateforme, mais ne répondez pas à ce message.</p><p>\r\n\r\n</p><p>&nbsp;</p><p>\r\n<br></p><br>",
+        "<p>Some content</p>--- <br>\r\n<br>\r\Veuillez ne pas répondre à ce mail. Postez directement vos questions dans\r\nvotre dossier sur la plateforme.</p>"
+      ]
+    end
+
+    it 'removes footer from mail template body' do
+      templates.each do |template|
+        expect(template.reload.body).to eq '<p>Some content</p>'
+      end
+    end
+  end
+
+  context 'when emails don’t have the standard boilerplate in the footer' do
+    let(:bodies) do
+      [
+        "<p>Some content.</p><p>Merci, l'équipe demarches-simplifiees.fr.\r\n</p>",
+        "<p>Some content.</p><p>Merci, l'équipe TPS.\r\n</p><small></small>"
+      ]
+    end
+
+    it 'keeps the footer' do
+      templates.each do |template|
+        expect(bodies).to include(template.reload.body)
+      end
+    end
+  end
+
+  context 'when the footer contains some excluded strings' do
+    let(:bodies) do
+      [
+        "<p>Some content</p>--- <br>\r\n<br>\r\nMerci de ne pas répondre à cet email. Le texte du présent e-mail n'a aucune valeur d'autorisation provisoire. Seule l'attestation d'autorisation provisoire de travail au format PDF, si délivrée, fera foi.",
+        "<p>Some content</p>--- <br>\r\n<br>\r\nMerci de ne pas répondre à cet email. En cas de question, utilisez la messagerie ou écrivez à instructeur@exemple.gouv.fr.",
+        "<p>Some content</p>--- <br>\r\n<br>Merci de ne pas répondre à cet email. Postez directement vos questions dans votre dossier sur la plateforme, ou trouvez le contact de votre conseiller cinéma sur <a target=\"_blank\" rel=\"nofollow\" href=\"http://www.cnc.fr/web/fr/conseillers-drac\">http://www.cnc.fr/web/fr/conseillers-drac</a><br>"
+      ]
+    end
+
+    it 'keeps the footer' do
+      templates.each do |template|
+        expect(bodies).to include(template.reload.body)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Cette moulinette supprime les anciens footers "Merci de ne pas répondre à cet email" des templates personnalisés par les administrateurs.

Ce texte est maintenant inclus dans le layout de l'email de notification. (Ça permet par exemple qu'il ne soit présent que dans l'email, mais pas dans le Commentaire créé dans la messagerie.)

## Détails technique

- Temps pris sur ma machine : 2 mn, pour mouliner environ 10 000 templates
- La regexp est moche, mais elle est bien testée
- Ils reste quelques textes personnalisés sur certaines démarches (~ 60, notamment "Work in France"), qui ne se prêtent pas vraiment à un moulinage automatique. On pourra ajuster à la main

Fix #1863 
