### PR TITLE
Fix width in manager procedure detail

### DIFF
--- a/app/views/fields/mail_template_field/_show.html.haml
+++ b/app/views/fields/mail_template_field/_show.html.haml
@@ -1,7 +1,7 @@
 %strong Sujet
-%pre
+%pre{ style: "white-space: pre-wrap;" }
   = field.data.subject
 
 %strong Corps
-%pre
+%pre{ style: "white-space: pre-wrap;" }
   = field.data.body


### PR DESCRIPTION
Fixes #2762

Avant :
<img width="1317" alt="capture d ecran 2018-11-20 a 17 45 38" src="https://user-images.githubusercontent.com/847942/48788966-39258f80-ecec-11e8-9cd5-097af208e527.png">

Après :
<img width="1254" alt="capture d ecran 2018-11-20 a 17 45 04" src="https://user-images.githubusercontent.com/847942/48788977-3fb40700-ecec-11e8-8199-1729add21b57.png">

