### PR TITLE
config: fix email assets not having the full URL domain prepended

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -46,6 +46,13 @@ Rails.application.configure do
 
   # Action Mailer settings
   config.action_mailer.delivery_method = :letter_opener_web
+  # Configure default root URL for generating URLs to routes
+  config.action_mailer.default_url_options = {
+    host: 'localhost',
+    port: 3000
+  }
+  # Configure default root URL for email assets
+  config.action_mailer.asset_host = "http://" + ENV['APP_HOST']
 
   Rails.application.routes.default_url_options = {
     host: 'localhost',

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -81,10 +81,13 @@ Rails.application.configure do
     config.action_mailer.delivery_method = :mailjet
   end
 
+  # Configure default root URL for generating URLs to routes
   config.action_mailer.default_url_options = {
     protocol: :https,
     host: ENV['APP_HOST']
   }
+  # Configure default root URL for email assets
+  config.action_mailer.asset_host = "https://" + ENV['APP_HOST']
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).


### PR DESCRIPTION
When sending emails, the mailer doesn't have access to the request host. It needs to infer it by itself.

For this we need two settings:

- `action_mailer.default_url_options`, to generate urls to routes
- `action_mailer.asset_host`, to generate full urls to assets

Only the first one of these settings was set in production.

Fix #2518