### PR TITLE
Re-enable releases cleanup

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -110,6 +110,7 @@ task :deploy do
       invoke :'service:restart_puma'
       invoke :'service:reload_nginx'
       invoke :'service:restart_delayed_job'
+      invoke :'deploy:cleanup'
     end
   end
 end


### PR DESCRIPTION
Le problème de permission venait de vieilles releases dans lesquelles les sockets avait été écrites par root. Je les ai supprimées à la main. Le problème ne se reproduira plus.