### PR TITLE
[Fix #2929] Improve readability of invitation for avis

### DIFF
--- a/app/mailers/avis_mailer.rb
+++ b/app/mailers/avis_mailer.rb
@@ -1,5 +1,7 @@
 # Preview all emails at http://localhost:3000/rails/mailers/avis_mailer
 class AvisMailer < ApplicationMailer
+  layout 'mailers/layout'
+
   def avis_invitation(avis)
     @avis = avis
     email = @avis.gestionnaire&.email || @avis.email

--- a/app/views/avis_mailer/avis_invitation.html.haml
+++ b/app/views/avis_mailer/avis_invitation.html.haml
@@ -1,16 +1,21 @@
+- content_for(:title, 'Vous avez été invité à donner votre avis')
+
 - avis_link = @avis.gestionnaire.present? ? gestionnaire_avis_url(@avis) : sign_up_gestionnaire_avis_url(@avis.id, @avis.email)
 
 %p
   Bonjour,
 
 %p
-  = "Vous avez été invité par #{@avis.claimant.email} à donner votre avis sur le dossier nº #{@avis.dossier.id} de la démarche \"#{@avis.dossier.procedure.libelle}\"."
+  Vous avez été invité par
+  %strong= @avis.claimant.email
+  = "à donner votre avis sur le dossier nº #{@avis.dossier.id} de la démarche :"
+  %strong= @avis.dossier.procedure.libelle
 
 %p
-  Message de votre interlocuteur :
+  = "#{@avis.claimant.email} vous a écrit :"
   %br
-  %span{ style: 'font-style: italic;' }
-    = @avis.introduction
+%p{ style: "padding: 8px; color: #333333; background-color: #EEEEEE; font-size: 16px;" }
+  = @avis.introduction
 
 - if @avis.gestionnaire.present?
   %p

--- a/spec/mailers/avis_mailer_spec.rb
+++ b/spec/mailers/avis_mailer_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe AvisMailer, type: :mailer do
     subject { described_class.avis_invitation(avis) }
 
     it { expect(subject.subject).to eq("Donnez votre avis sur le dossier nº #{avis.dossier.id} (#{avis.dossier.procedure.libelle})") }
-    it { expect(subject.body).to include("Vous avez été invité par #{avis.claimant.email} à donner votre avis sur le dossier nº #{avis.dossier.id} de la démarche &quot;#{avis.dossier.procedure.libelle}&quot;.") }
+    it { expect(subject.body).to have_text("Vous avez été invité par #{avis.claimant.email} à donner votre avis sur le dossier nº #{avis.dossier.id} de la démarche : #{avis.dossier.procedure.libelle}") }
     it { expect(subject.body).to include(avis.introduction) }
     it { expect(subject.body).to include(gestionnaire_avis_url(avis)) }
 


### PR DESCRIPTION
Avant 
<img width="1040" alt="capture d ecran 2018-11-23 a 11 13 49" src="https://user-images.githubusercontent.com/847942/48938255-fbee1700-ef10-11e8-8bed-3ede3634a37a.png">
Après
<img width="622" alt="capture d ecran 2018-11-23 a 10 56 02" src="https://user-images.githubusercontent.com/847942/48938260-ff819e00-ef10-11e8-89c5-d974136a7c5b.png">
