### PR TITLE
deploy: require mina only for deployment tasks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -175,7 +175,7 @@ group :development, :test do
   gem 'rspec-rails'
 
   # Deploy
-  gem 'mina', git: 'https://github.com/mina-deploy/mina.git'
+  gem 'mina', git: 'https://github.com/mina-deploy/mina.git', require: false
 
   gem 'rspec_junit_formatter'
 end


### PR DESCRIPTION
This fixes mina activating Rake traces when being required, which pollutes the output of rake tasks.

It also makes sense to require mina only for deployment tasks.

## Before

```
$ bin/rake db:migrate
** Invoke db:migrate (first_time)
** Invoke db:load_config (first_time)
** Invoke environment (first_time)
** Execute environment
** Execute db:load_config
** Execute db:migrate
== 20181121234008 RemoveChampIdFromCommentaires: migrating ====================
-- remove_column(:commentaires, :champ_id)
   -> 0.0411s
== 20181121234008 RemoveChampIdFromCommentaires: migrated (0.0414s) ===========
```

## After

```
$ bin/rake db:migrate
== 20181121234008 RemoveChampIdFromCommentaires: migrating ====================
-- remove_column(:commentaires, :champ_id)
   -> 0.0411s
== 20181121234008 RemoveChampIdFromCommentaires: migrated (0.0414s) ===========
```