### PR TITLE
Petites améliorations sur les emails de notification

### DIFF
--- a/app/views/dossier_mailer/notify_new_answer.html.haml
+++ b/app/views/dossier_mailer/notify_new_answer.html.haml
@@ -6,7 +6,7 @@
 
 %p
   Pour le consulter, merci de vous rendre sur
-  = messagerie_dossier_url(@dossier)
+  = link_to messagerie_dossier_url(@dossier), messagerie_dossier_url(@dossier), target: '_blank'
 
 %p
   Bonne journée,

--- a/app/views/layouts/mailers/notification.html.haml
+++ b/app/views/layouts/mailers/notification.html.haml
@@ -1,9 +1,10 @@
 = yield
 
-%p ---
-
-%p.footer
-  %strong
-    Merci de ne pas répondre à cet email. Pour vous adresser à votre administration, passez directement par votre
-    = succeed '.' do
-      = link_to 'messagerie', messagerie_dossier_url(@dossier), target: '_blank'
+%footer
+  %p
+    —
+    %br
+    %strong
+      Merci de ne pas répondre à cet email. Pour vous adresser à votre administration, passez directement par votre
+      = succeed '.' do
+        = link_to 'messagerie', messagerie_dossier_url(@dossier), target: '_blank'

--- a/spec/mailers/notification_mailer_spec.rb
+++ b/spec/mailers/notification_mailer_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe NotificationMailer, type: :mailer do
 
     it { expect(mail.subject).to eq(email_template.subject_for_dossier) }
     it { expect(mail.body).to include(email_template.body_for_dossier) }
-    it { expect(mail.body).to have_selector('.footer') }
+    it { expect(mail.body).to have_selector('footer') }
 
     it_behaves_like "create a commentaire not notified"
   end
@@ -50,7 +50,7 @@ RSpec.describe NotificationMailer, type: :mailer do
     it do
       expect(mail.subject).to eq(email_template.subject)
       expect(mail.body).to include(email_template.body)
-      expect(mail.body).to have_selector('.footer')
+      expect(mail.body).to have_selector('footer')
     end
 
     it_behaves_like "create a commentaire not notified"


### PR DESCRIPTION
- Le lien vers la messagerie est cliquable
- Le footer "Utilisez la messagerie pour répondre" est moins moche

<img width="672" alt="capture d ecran 2018-11-27 a 15 50 00" src="https://user-images.githubusercontent.com/179923/49089580-26ffa000-f25c-11e8-8829-4acc26afa883.png">

