### PR TITLE
Destroy dossier_operation_logs when dossier is destroyed

### DIFF
--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -26,7 +26,7 @@ class Dossier < ApplicationRecord
   has_many :followers_gestionnaires, through: :follows, source: :gestionnaire
   has_many :avis, dependent: :destroy
 
-  has_many :dossier_operation_logs
+  has_many :dossier_operation_logs, dependent: :destroy
 
   belongs_to :procedure
   belongs_to :user

--- a/lib/tasks/deployment/20181128155650_destroy_orphaned_dossier_operation_logs.rake
+++ b/lib/tasks/deployment/20181128155650_destroy_orphaned_dossier_operation_logs.rake
@@ -1,0 +1,17 @@
+namespace :after_party do
+  desc 'Deployment task: destroy_orphaned_dossier_operation_logs'
+  task destroy_orphaned_dossier_operation_logs: :environment do
+    bar = RakeProgressbar.new(DossierOperationLog.count)
+
+    DossierOperationLog.find_each do |log|
+      if log.dossier.blank?
+        log.destroy
+      end
+      bar.inc
+    end
+
+    bar.finished
+
+    AfterParty::TaskRecord.create version: '20181128155650'
+  end
+end


### PR DESCRIPTION
#3083 m'a fait penser que j'ai oublié de le faire sur les logs. Aujourd'hui le seul cas valide de suppression de dossier c'est brouillon ou test donc c'est OK de supprimer les logs dans ces cas-là.