### PR TITLE
[#2180] Passer sur le nouveau fournisseur de stockage

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -93,7 +93,7 @@ Rails.application.configure do
   # the I18n.default_locale when a translation cannot be found).
   config.i18n.fallbacks = true
 
-  config.active_storage.service = :clever_cloud
+  config.active_storage.service = :openstack
 
   # Send deprecation notices to registered listeners.
   config.active_support.deprecation = :notify


### PR DESCRIPTION
Cette PR active le nouveau fournisseur de stockage. Idéalement, j’aimerais
1. la passer sur l’env de dev
2. vérifier une dernière fois qu’on n’a pas de mauvaise surprise de dernière minute
3. la passer en prod en soirée
4. puis faire tourner le script qui finalise la migration des PJs (temps de run à déterminer ce soir)

Ça veut dire que si on a des changements à faire passer en prod avant 3., il faudra penser à rollbacker ce changement de config avant.