### PR TITLE
#2180 speed up migration

### DIFF
--- a/lib/active_storage/service/cellar_service.rb
+++ b/lib/active_storage/service/cellar_service.rb
@@ -37,7 +37,7 @@ module ActiveStorage
     def delete_prefixed(prefix)
       instrument :delete_prefixed, prefix: prefix do
         @adapter.session do |s|
-          keys = s.list_prefixed(prefix)
+          keys = s.list_prefixed(prefix).map(&:first)
           s.delete_keys(keys)
         end
       end

--- a/lib/cellar/cellar_adapter.rb
+++ b/lib/cellar/cellar_adapter.rb
@@ -91,7 +91,7 @@ module Cellar
           if response.is_a?(Net::HTTPSuccess)
             (listing, truncated) = parse_bucket_listing(response.body)
             result += listing
-            marker = listing.last
+            marker = listing.last.first
           else
             # TODO: error handling
             return nil
@@ -139,8 +139,13 @@ module Cellar
       def parse_bucket_listing(bucket_listing_xml)
         doc = Nokogiri::XML(bucket_listing_xml)
         listing = doc
-          .xpath('//xmlns:Contents/xmlns:Key')
-          .map(&:text)
+          .xpath('//xmlns:Contents')
+          .map do |node|
+          [
+            node.xpath('xmlns:Key').text,
+            DateTime.iso8601(node.xpath('xmlns:LastModified').text)
+          ]
+        end
         truncated = doc.xpath('//xmlns:IsTruncated').text == 'true'
         [listing, truncated]
       end

--- a/lib/tasks/2018_12_03_finish_piece_jointe_transfer.rake
+++ b/lib/tasks/2018_12_03_finish_piece_jointe_transfer.rake
@@ -67,12 +67,13 @@ namespace :'2018_12_03_finish_piece_jointe_transfer' do
       # This task ports them to the new storage after the switch, while being careful not to
       # overwrite attachments that may have changed in the new storage after the switch.
       def refresh_outdated_files
-        rake_puts "Refresh outdated attachments"
-
         refreshed_keys = []
         missing_keys = []
         old_pj_adapter.session do |old_pjs|
+          rake_puts "List old PJs"
           keys = old_pjs.list_prefixed('')
+
+          rake_puts "Refresh outdated attachments"
           progress = ProgressReport.new(keys.count)
           keys.each do |key|
             new_pj_metadata = new_pjs.files.head(key)

--- a/spec/lib/cellar/cellar_adapter_spec.rb
+++ b/spec/lib/cellar/cellar_adapter_spec.rb
@@ -43,7 +43,7 @@ describe 'CellarAdapter' do
           </Contents>
           <Contents>
             <Key>sample2.jpg</Key>
-            <LastModified>2011-02-26T01:56:20.000Z</LastModified>
+            <LastModified>2014-03-21T17:44:07.000Z</LastModified>
             <ETag>&quot;bf1d737a4d46a19f3bced6905cc8b902&quot;</ETag>
             <Size>142863</Size>
             <StorageClass>STANDARD</StorageClass>
@@ -54,7 +54,17 @@ describe 'CellarAdapter' do
 
     subject { session.send(:parse_bucket_listing, response) }
 
-    it { is_expected.to eq([["sample1.jpg", "sample2.jpg"], false]) }
+    it do
+      is_expected.to eq(
+        [
+          [
+            ["sample1.jpg", DateTime.new(2011, 2, 26, 1, 56, 20, 0)],
+            ["sample2.jpg", DateTime.new(2014, 3, 21, 17, 44, 7, 0)]
+          ],
+          false
+        ]
+      )
+    end
   end
 
   describe 'bulk_deletion_request_body' do


### PR DESCRIPTION
Deux astuces pour récupérer la metadata en faisant beaucoup moins d’allers-retours sur le service de stockage, et réduire le temps de migration d‘environ 1h.