### PR TITLE
Fix Sentry 114, Instructeur can delete pj in private champs

### DIFF
--- a/app/controllers/new_gestionnaire/dossiers_controller.rb
+++ b/app/controllers/new_gestionnaire/dossiers_controller.rb
@@ -136,6 +136,13 @@ module NewGestionnaire
       redirect_to annotations_privees_gestionnaire_dossier_path(procedure, dossier)
     end
 
+    def purge_champ_piece_justificative
+      @champ = dossier.champs_private.find(params[:champ_id])
+      @champ.piece_justificative_file.purge
+
+      flash.notice = 'La pièce jointe a bien été supprimée.'
+    end
+
     def print
       @dossier = dossier
       render layout: "print"

--- a/app/views/new_gestionnaire/dossiers/purge_champ_piece_justificative.js.erb
+++ b/app/views/new_gestionnaire/dossiers/purge_champ_piece_justificative.js.erb
@@ -1,0 +1,2 @@
+<%= render_flash(timeout: 5000, sticky: true) %>
+<%= remove_element("#piece_justificative_#{@champ.id}") %>

--- a/app/views/shared/dossiers/editable_champs/_piece_justificative.html.haml
+++ b/app/views/shared/dossiers/editable_champs/_piece_justificative.html.haml
@@ -13,7 +13,10 @@
   %div{ id: "piece_justificative_#{champ.id}" }
     = render partial: "shared/champs/piece_justificative/pj_link", locals: { champ: champ, user_can_upload: true }
     %br
-    = link_to 'supprimer', purge_champ_piece_justificative_dossier_path(champ_id: champ.id), remote: true, method: :delete
+    - if champ.private?
+      = link_to 'supprimer', gestionnaire_champ_purge_champ_piece_justificative_path(procedure_id: champ.dossier.procedure_id, dossier_id: champ.dossier_id, champ_id: champ.id), remote: true, method: :delete
+    - else
+      = link_to 'supprimer', purge_champ_piece_justificative_dossier_path(champ_id: champ.id), remote: true, method: :delete
     %br
     Modifier :
   = form.file_field :piece_justificative_file,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -327,6 +327,10 @@ Rails.application.routes.draw do
             post 'send-to-instructeurs' => 'dossiers#send_to_instructeurs'
             post 'avis' => 'dossiers#create_avis'
             get 'print' => 'dossiers#print'
+
+            resources :champs, only: [] do
+              delete 'purge_champ_piece_justificative' => 'dossiers#purge_champ_piece_justificative'
+            end
           end
         end
       end


### PR DESCRIPTION
Une fois ceci fait j'envisage d'adopter le même comportement pour la route de purge coté usager.
Ce sera plus restful et propre.