### PR TITLE
[Fix #1318] ETQ Instructeur, j'aimerais être averti que le texte de la motivation sera visible par les utilisateurs

### DIFF
--- a/app/views/new_gestionnaire/dossiers/_state_button.html.haml
+++ b/app/views/new_gestionnaire/dossiers/_state_button.html.haml
@@ -47,9 +47,9 @@
               .description
                 %h4 Refuser
                 L'usager sera notifié que son dossier a été refusé
-      = render partial: 'new_gestionnaire/dossiers/state_button_motivation', locals: { dossier: dossier, popup_title: 'Accepter le dossier',  popup_class: 'accept', process_action: 'accepter', title: 'Accepter', confirm: "Confirmez-vous l'acceptation ce dossier ?" }
-      = render partial: 'new_gestionnaire/dossiers/state_button_motivation', locals: { dossier: dossier, popup_title: 'Classer le dossier sans suite', popup_class: 'without-continuation', process_action: 'classer_sans_suite', title: 'Classer sans suite', confirm: 'Confirmez-vous le classement sans suite de ce dossier ?' }
-      = render partial: 'new_gestionnaire/dossiers/state_button_motivation', locals: { dossier: dossier, popup_title: 'Refuser le dossier', popup_class: 'refuse', process_action: 'refuser', title: 'Refuser', confirm: 'Confirmez-vous le refus de ce dossier ?' }
+      = render partial: 'new_gestionnaire/dossiers/state_button_motivation', locals: { dossier: dossier, popup_title: 'Accepter le dossier', placeholder: 'Expliquez au demandeur pourquoi ce dossier est accepté (facultatif)', popup_class: 'accept', process_action: 'accepter', title: 'Accepter', confirm: "Confirmez-vous l'acceptation ce dossier ?" }
+      = render partial: 'new_gestionnaire/dossiers/state_button_motivation', locals: { dossier: dossier, popup_title: 'Classer le dossier sans suite', placeholder: 'Expliquez au demandeur pourquoi ce dossier est classé sans suite (obligatoire)', popup_class: 'without-continuation', process_action: 'classer_sans_suite', title: 'Classer sans suite', confirm: 'Confirmez-vous le classement sans suite de ce dossier ?' }
+      = render partial: 'new_gestionnaire/dossiers/state_button_motivation', locals: { dossier: dossier, popup_title: 'Refuser le dossier', placeholder: 'Expliquez au demandeur pourquoi ce dossier est refusé (obligatoire)', popup_class: 'refuse', process_action: 'refuser', title: 'Refuser', confirm: 'Confirmez-vous le refus de ce dossier ?' }
 
 - else
   - if dossier.motivation.present? || dossier.attestation.present?

--- a/app/views/new_gestionnaire/dossiers/_state_button_motivation.html.haml
+++ b/app/views/new_gestionnaire/dossiers/_state_button_motivation.html.haml
@@ -5,7 +5,7 @@
 
   = form_tag(terminer_gestionnaire_dossier_path(dossier.procedure, dossier), remote: true, method: :post, class: 'form') do
     - if title == 'Accepter'
-      = text_area :dossier, :motivation, class: 'motivation-text-area', placeholder: 'Rédigez votre motivation ici (facultative)', required: false
+      = text_area :dossier, :motivation, class: 'motivation-text-area', placeholder: placeholder, required: false
       %p.help
         L'acceptation du dossier envoie automatiquement une attestation à l'usager.
 
@@ -27,7 +27,7 @@
               - unspecified_annotations_privees.each do |unspecified_annotations_privee|
                 %li= unspecified_annotations_privee.libelle
     - else
-      = text_area :dossier, :motivation, class: 'motivation-text-area', placeholder: 'Rédigez votre motivation ici (obligatoire)', required: true
+      = text_area :dossier, :motivation, class: 'motivation-text-area', placeholder: placeholder, required: true
     .text-right
       %span.button{ onclick: 'DS.motivationCancel();' } Annuler
       = button_tag 'Valider la décision', name: :process_action, value: process_action, class: 'button primary', title: title, data: { confirm: confirm }


### PR DESCRIPTION
N'ayant pas de nouvelle sur le commentaire posté, j'ai fait l'implémentation.
Le placeholder est réécrit comme décrit dans le commentaire précédent. (cf screenshots).
Deux avantages pour moi: 
- Certaines peronnes ne lisent pas les titres: le place holder répète l'action qui va être faite
- Le placeholder est mieux lu qu'un commentaire en dessous ou au dessus.

Fix #1318