### PR TITLE
Encourager la création de champs PJ plutôt que de vieilles PJs

### DIFF
--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -239,6 +239,10 @@ class Procedure < ApplicationRecord
     whitelisted_at.present?
   end
 
+  def has_old_pjs?
+    types_de_piece_justificative.any?
+  end
+
   def total_dossier
     self.dossiers.state_not_brouillon.size
   end

--- a/app/views/admin/pieces_justificatives/show.html.haml
+++ b/app/views/admin/pieces_justificatives/show.html.haml
@@ -1,3 +1,25 @@
 .row.white-back
-  #piece_justificative_form
-    = render 'form'
+  .alert.alert-info
+    .form-group
+      %p
+        Pour vos nouveaux besoins de pièces jointes, nous vous invitons à
+        = link_to(admin_procedure_types_de_champ_path(@procedure)) do
+          rajouter des champs
+        \ <em>pièce justificative</em> à votre formulaire.
+
+      %p
+        Ils offrent les avantages suivants :
+
+      %ul
+        %li Pièces justificatives au fil du formulaire, pour un déroulé plus fluide
+        %li Possibilité de fournir à l’usager un fichier type à remplir et renvoyer
+        %li Possibilité pour l’usager de supprimer les documents joints par erreur
+        %li Support des pièces de grande taille (jusqu’à 200 Mo par pièce)
+        %li Pas de limite de soumission simultanée de plusieurs pièces, pour une expérience usager plus confortable
+
+    = link_to(admin_procedure_types_de_champ_path(@procedure), class: 'btn btn-success') do
+      Ajouter un champ PJ
+
+  - if @procedure.has_old_pjs?
+    #piece_justificative_form
+      = render 'form'

--- a/spec/features/admin/add_type_de_piece_justificative_spec.rb
+++ b/spec/features/admin/add_type_de_piece_justificative_spec.rb
@@ -6,28 +6,31 @@ feature 'add a new type de piece justificative', js: true do
   before do
     login_as administrateur, scope: :administrateur
   end
-  context 'when there is no piece justificative' do
+  context 'when there is an existing piece justificative' do
     let(:procedure) { create(:procedure, administrateur: administrateur) }
     before do
+      # Create a dummy PJ, because adding PJs is no longer allowed on procedures that
+      # do not already have one
+      procedure.types_de_piece_justificative.create(libelle: "dummy PJ")
       visit admin_procedure_pieces_justificatives_path(procedure)
     end
     scenario 'displays a form to add new type de piece justificative' do
       within '#new_type_de_piece_justificative' do
-        expect(page).to have_css('#procedure_types_de_piece_justificative_attributes_0_libelle')
+        expect(page).to have_css('#procedure_types_de_piece_justificative_attributes_1_libelle')
       end
     end
     context 'when user fills field and submit' do
       let(:libelle) { 'ma piece' }
       let(:description) { 'ma description' }
       before do
-        page.find_by_id('procedure_types_de_piece_justificative_attributes_0_libelle').set(libelle)
-        page.find_by_id('procedure_types_de_piece_justificative_attributes_0_description').set(description)
+        page.find_by_id('procedure_types_de_piece_justificative_attributes_1_libelle').set(libelle)
+        page.find_by_id('procedure_types_de_piece_justificative_attributes_1_description').set(description)
         page.click_on 'Ajouter la pièce'
         wait_for_ajax
       end
       subject do
         procedure.reload
-        procedure.types_de_piece_justificative.first
+        procedure.types_de_piece_justificative.second
       end
       scenario 'creates new type de piece' do
         expect(subject.libelle).to eq(libelle)
@@ -35,23 +38,23 @@ feature 'add a new type de piece justificative', js: true do
       end
       scenario 'displays new created pj' do
         within '#liste_piece_justificative' do
-          expect(page).to have_css('#procedure_types_de_piece_justificative_attributes_0_libelle')
+          expect(page).to have_css('#procedure_types_de_piece_justificative_attributes_1_libelle')
           expect(page.body).to match(libelle)
           expect(page.body).to match(description)
         end
         within '#new_type_de_piece_justificative' do
-          expect(page).to have_css('#procedure_types_de_piece_justificative_attributes_1_libelle')
+          expect(page).to have_css('#procedure_types_de_piece_justificative_attributes_2_libelle')
         end
       end
       context 'when user delete pj' do
         before do
-          pj = procedure.types_de_piece_justificative.first
+          pj = procedure.types_de_piece_justificative.second
           page.find_by_id("delete_type_de_piece_justificative_#{pj.id}").click
           wait_for_ajax
         end
         scenario 'removes pj from page' do
           within '#liste_piece_justificative' do
-            expect(page).not_to have_css('#procedure_types_de_piece_justificative_attributes_0_libelle')
+            expect(page).not_to have_css('#procedure_types_de_piece_justificative_attributes_1_libelle')
             expect(page.body).not_to match(libelle)
             expect(page.body).not_to match(description)
           end
@@ -60,12 +63,12 @@ feature 'add a new type de piece justificative', js: true do
       context 'when user change existing type de pj' do
         let(:new_libelle) { 'mon nouveau libelle' }
         before do
-          page.find_by_id('procedure_types_de_piece_justificative_attributes_0_libelle').set(new_libelle)
+          page.find_by_id('procedure_types_de_piece_justificative_attributes_1_libelle').set(new_libelle)
           page.find_by_id('save').click
           wait_for_ajax
         end
         scenario 'saves change in database' do
-          pj = procedure.types_de_piece_justificative.first
+          pj = procedure.types_de_piece_justificative.second
           expect(pj.libelle).to eq(new_libelle)
         end
       end

--- a/spec/features/admin/procedure_creation_spec.rb
+++ b/spec/features/admin/procedure_creation_spec.rb
@@ -87,60 +87,68 @@ feature 'As an administrateur I wanna create a new procedure', js: true do
       procedure.update(service: create(:service))
     end
 
-    scenario 'Add champ, add file, visualize them in procedure preview' do
-      fill_in 'procedure_types_de_champ_attributes_0_libelle', with: 'libelle de champ'
-      click_on 'add_type_de_champ'
-      expect(page).to have_current_path(admin_procedure_types_de_champ_path(Procedure.last))
-      expect(page).to have_selector('#procedure_types_de_champ_attributes_1_libelle')
-      expect(Procedure.last.types_de_champ.first.libelle).to eq('libelle de champ')
-
-      click_on 'onglet-pieces'
-      expect(page).to have_current_path(admin_procedure_pieces_justificatives_path(Procedure.last))
-      fill_in 'procedure_types_de_piece_justificative_attributes_0_libelle', with: 'libelle de piece'
-      click_on 'add_piece_justificative'
-      expect(page).to have_current_path(admin_procedure_pieces_justificatives_path(Procedure.last))
-      expect(page).to have_selector('#procedure_types_de_piece_justificative_attributes_1_libelle')
-
-      preview_window = window_opened_by { click_on 'onglet-preview' }
-      within_window(preview_window) do
-        expect(page).to have_current_path(apercu_procedure_path(Procedure.last))
-        expect(page).to have_field('libelle de champ')
-        expect(page).to have_field('libelle de piece')
-      end
-    end
-
-    scenario 'After adding champ and file, check impossibility to publish procedure, add instructeur and make publication' do
-      fill_in 'procedure_types_de_champ_attributes_0_libelle', with: 'libelle de champ'
-      click_on 'add_type_de_champ'
-      click_on 'onglet-pieces'
-
-      expect(page).to have_current_path(admin_procedure_pieces_justificatives_path(Procedure.last))
-      fill_in 'procedure_types_de_piece_justificative_attributes_0_libelle', with: 'libelle de piece'
-      click_on 'add_piece_justificative'
-
-      click_on 'onglet-infos'
-      expect(page).to have_current_path(admin_procedure_path(Procedure.last))
-      expect(page).to have_selector('#disabled-publish-procedure')
-      expect(page.find_by_id('disabled-publish-procedure')[:disabled]).to eq('true')
-
-      click_on 'onglet-instructeurs'
-      expect(page).to have_current_path(admin_procedure_instructeurs_path(Procedure.last))
-      fill_in 'gestionnaire_email', with: 'gestionnaire@apientreprise.fr'
-      click_on 'add-gestionnaire-email'
-      page.first('.gestionnaire-affectation').click
-
-      click_on 'onglet-infos'
-      expect(page).to have_current_path(admin_procedure_path(Procedure.last))
-      expect(page).to have_selector('#publish-procedure', visible: true)
-      find('#publish-procedure').click
-
-      within '#publish-modal' do
-        expect(page).to have_field('procedure_path', with: 'lien-de-la-procedure')
-        click_on 'publish'
+    context 'With old PJ' do
+      before do
+        # Create a dummy PJ, because adding PJs is no longer allowed on procedures that
+        # do not already have one
+        Procedure.last.types_de_piece_justificative.create(libelle: "dummy PJ")
       end
 
-      expect(page).to have_text('Démarche publiée')
-      expect(page).to have_selector('.procedure-lien')
+      scenario 'Add champ, add file, visualize them in procedure preview' do
+        fill_in 'procedure_types_de_champ_attributes_0_libelle', with: 'libelle de champ'
+        click_on 'add_type_de_champ'
+        expect(page).to have_current_path(admin_procedure_types_de_champ_path(Procedure.last))
+        expect(page).to have_selector('#procedure_types_de_champ_attributes_1_libelle')
+        expect(Procedure.last.types_de_champ.first.libelle).to eq('libelle de champ')
+
+        click_on 'onglet-pieces'
+        expect(page).to have_current_path(admin_procedure_pieces_justificatives_path(Procedure.last))
+        fill_in 'procedure_types_de_piece_justificative_attributes_0_libelle', with: 'libelle de piece'
+        click_on 'add_piece_justificative'
+        expect(page).to have_current_path(admin_procedure_pieces_justificatives_path(Procedure.last))
+        expect(page).to have_selector('#procedure_types_de_piece_justificative_attributes_1_libelle')
+
+        preview_window = window_opened_by { click_on 'onglet-preview' }
+        within_window(preview_window) do
+          expect(page).to have_current_path(apercu_procedure_path(Procedure.last))
+          expect(page).to have_field('libelle de champ')
+          expect(page).to have_field('libelle de piece')
+        end
+      end
+
+      scenario 'After adding champ and file, check impossibility to publish procedure, add instructeur and make publication' do
+        fill_in 'procedure_types_de_champ_attributes_0_libelle', with: 'libelle de champ'
+        click_on 'add_type_de_champ'
+        click_on 'onglet-pieces'
+
+        expect(page).to have_current_path(admin_procedure_pieces_justificatives_path(Procedure.last))
+        fill_in 'procedure_types_de_piece_justificative_attributes_0_libelle', with: 'libelle de piece'
+        click_on 'add_piece_justificative'
+
+        click_on 'onglet-infos'
+        expect(page).to have_current_path(admin_procedure_path(Procedure.last))
+        expect(page).to have_selector('#disabled-publish-procedure')
+        expect(page.find_by_id('disabled-publish-procedure')[:disabled]).to eq('true')
+
+        click_on 'onglet-instructeurs'
+        expect(page).to have_current_path(admin_procedure_instructeurs_path(Procedure.last))
+        fill_in 'gestionnaire_email', with: 'gestionnaire@apientreprise.fr'
+        click_on 'add-gestionnaire-email'
+        page.first('.gestionnaire-affectation').click
+
+        click_on 'onglet-infos'
+        expect(page).to have_current_path(admin_procedure_path(Procedure.last))
+        expect(page).to have_selector('#publish-procedure', visible: true)
+        find('#publish-procedure').click
+
+        within '#publish-modal' do
+          expect(page).to have_field('procedure_path', with: 'lien-de-la-procedure')
+          click_on 'publish'
+        end
+
+        expect(page).to have_text('Démarche publiée')
+        expect(page).to have_selector('.procedure-lien')
+      end
     end
   end
 end


### PR DESCRIPTION
On laisse l’onglet PJ pour ne pas perdre l’administrateur, mais au lieu de lui permettre de créer des vieilles PJ, on l’oriente poliment vers les champs PJ.

![capture d ecran de 2018-12-19 12-00-46](https://user-images.githubusercontent.com/356570/50217577-569c5680-0389-11e9-97f2-9229e690a869.png)

Exception : si la procédure comportait déjà des vieilles PJ, on le laisse évidemment les modifier, et on le laisse aussi en ajouter (par souci de cohérence, mais ça pourrait se discuter)

![capture d ecran de 2018-12-19 12-01-01](https://user-images.githubusercontent.com/356570/50217649-8cd9d600-0389-11e9-95e4-d1fd2f5eb4c0.png)
