### PR TITLE
tasks: rename `--libellé procédure--` to `--libellé démarche--`

### DIFF
--- a/lib/tasks/deployment/20181219122438_fix_email_templates_subjects.rake
+++ b/lib/tasks/deployment/20181219122438_fix_email_templates_subjects.rake
@@ -1,0 +1,28 @@
+namespace :after_party do
+  desc 'Deployment task: fix_email_templates_subjects'
+  task fix_email_templates_subjects: :environment do
+    puts "Running deploy task 'fix_email_templates_subjects'"
+
+    klasses = [
+      Mails::ClosedMail,
+      Mails::InitiatedMail,
+      Mails::ReceivedMail,
+      Mails::RefusedMail,
+      Mails::WithoutContinuationMail
+    ]
+
+    klasses.each do |klass|
+      klass
+        .where("subject LIKE '%--libellé procédure--%'")
+        .each do |instance|
+
+        instance.update(subject: instance.subject.gsub("--libellé procédure--", "--libellé démarche--"))
+        rake_puts "Subject mis-à-jour pour #{klass.to_s}##{instance.id}"
+      end
+    end
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord.create version: '20181219122438'
+  end # task :fix_email_templates_subjects
+end # namespace :after_party


### PR DESCRIPTION
On a encore 150 templates d'emails qui ont dans leur sujet `--libellé procédure--` au lieu de `--libellé démarche--`. Normal, ils ont été créés avant le renommage, et on ne les a pas migré.

Ça donne des emails moches en prod, comme

> Sujet: Votre dossier --libellé procédure-- n° 2315542 a bien été déposé

Cette PR mouline les sujets pour les remplacer par le bon token. Elle tourne en 2s sur ma machine.