### PR TITLE
Fix 3195 modif demande admin et contact admin

### DIFF
--- a/app/lib/helpscout/form_adapter.rb
+++ b/app/lib/helpscout/form_adapter.rb
@@ -23,12 +23,16 @@ class Helpscout::FormAdapter
   ADMIN_TYPE_RDV = 'admin demande rdv'
   ADMIN_TYPE_QUESTION = 'admin question'
   ADMIN_TYPE_SOUCIS = 'admin soucis'
+  ADMIN_TYPE_PRODUIT = 'admin suggestion produit'
+  ADMIN_TYPE_DEMANDE_COMPTE = 'admin demande compte'
   ADMIN_TYPE_AUTRE = 'admin autre'
 
   ADMIN_OPTIONS = [
     [I18n.t(ADMIN_TYPE_QUESTION, scope: [:supportadmin]), ADMIN_TYPE_QUESTION],
     [I18n.t(ADMIN_TYPE_RDV, scope: [:supportadmin]), ADMIN_TYPE_RDV],
     [I18n.t(ADMIN_TYPE_SOUCIS, scope: [:supportadmin]), ADMIN_TYPE_SOUCIS],
+    [I18n.t(ADMIN_TYPE_PRODUIT, scope: [:supportadmin]), ADMIN_TYPE_PRODUIT],
+    [I18n.t(ADMIN_TYPE_DEMANDE_COMPTE, scope: [:supportadmin]), ADMIN_TYPE_DEMANDE_COMPTE],
     [I18n.t(ADMIN_TYPE_AUTRE, scope: [:supportadmin]), ADMIN_TYPE_AUTRE]
   ]
 

--- a/app/views/demandes/new.html.haml
+++ b/app/views/demandes/new.html.haml
@@ -30,9 +30,13 @@
     = text_field_tag :name, nil, required: true
 
     = label_tag :email do
-      Quelle est l'adresse email pour laquelle vous souhaitez un compte ?
+      Quelle est l'adresse email professionnelle pour laquelle vous souhaitez un compte ?
       %span.mandatory *
-    = email_field_tag :email, nil, required: true
+      %p.intro{ :style => "font-weight: normal" }
+        Vous utilisez un email orange, wanadoo, free, gmail etc. ? Merci de nous
+        %a{ href: contact_admin_path, target:'_blank' }
+          contacter préalablement.
+    = email_field_tag :email, nil, placeholder: 'jean.martin@developpement-durable.gouv.fr', required: true
 
     = label_tag :phone do
       Quel est votre numéro de téléphone (ligne directe) ?

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -65,6 +65,8 @@ fr:
     admin demande rdv: Demande de RDV pour une présentation à distance de demarches-simplifiees.fr
     admin question: J'ai une question sur demarches-simplifiees.fr
     admin soucis: J'ai un problème technique avec demarches-simplifiees.fr
+    admin suggestion produit: J'ai une proposition d'évolution
+    admin demande compte: Je souhaite ouvrir un compte administrateur avec un email Orange, Wanadoo, etc.
     admin autre: Autre sujet
 
   number:


### PR DESCRIPTION
Fixes #3195 

Modification du texte : 
<img width="1272" alt="capture d ecran 2018-12-20 14 19 41" src="https://user-images.githubusercontent.com/3593868/50287363-ccc0bc00-0462-11e9-927a-8c19c496164f.png">

Ajout de deux nouvelles catégories dans le formulaire de contact admin : 
<img width="1263" alt="capture d ecran 2018-12-20 14 19 58" src="https://user-images.githubusercontent.com/3593868/50287373-d1857000-0462-11e9-8883-f9a12fe63d38.png">

Ajout de 2 nouveaux tag sur HS : 
<img width="1280" alt="capture d ecran 2018-12-20 14 20 30" src="https://user-images.githubusercontent.com/3593868/50287377-d3e7ca00-0462-11e9-99e7-a38711631345.png">
