### PR TITLE
Task should not fail if service already exists

### DIFF
--- a/lib/tasks/deployment/20181219164523_clone_service_for_transferred_procedures.rake
+++ b/lib/tasks/deployment/20181219164523_clone_service_for_transferred_procedures.rake
@@ -14,12 +14,15 @@ namespace :after_party do
 
     service_and_admin_list.each do |service_id, administrateur_id|
       cloned_service = Service.find(service_id).clone_and_assign_to_administrateur(Administrateur.find(administrateur_id))
-      cloned_service.save!
 
-      procedures_to_fix
-        .where(service_id: service_id, administrateur_id: administrateur_id)
-        .update_all(service_id: cloned_service.id)
-
+      if cloned_service.save
+        puts "Fixing Service #{service_id} for Administrateur #{administrateur_id}"
+        procedures_to_fix
+          .where(service_id: service_id, administrateur_id: administrateur_id)
+          .update_all(service_id: cloned_service.id)
+      else
+        puts "Cannot fix Service #{service_id} for Administrateur #{administrateur_id}, it should be fixed manually. Errors : #{cloned_service.errors.full_messages}"
+      end
       progress.inc
     end
 


### PR DESCRIPTION
On a quelques cas de services qui ont été récréés avec le même nom par les admins, on pourra les corriger manuellement.