### PR TITLE
[Fix #3213] complete mailer previews

### DIFF
--- a/spec/mailers/previews/administrateur_mailer_preview.rb
+++ b/spec/mailers/previews/administrateur_mailer_preview.rb
@@ -1,5 +1,8 @@
 class AdministrateurMailerPreview < ActionMailer::Preview
   def activate_before_expiration
-    AdministrateurMailer.activate_before_expiration(Administrateur.inactive.where.not(reset_password_token: nil).last)
+    administrateur = Administrateur.new
+    administrateur.reset_password_sent_at = Time.now.utc
+
+    AdministrateurMailer.activate_before_expiration(administrateur, "a4d4e4f4b4d445")
   end
 end

--- a/spec/mailers/previews/administration_mailer_preview.rb
+++ b/spec/mailers/previews/administration_mailer_preview.rb
@@ -1,17 +1,45 @@
 class AdministrationMailerPreview < ActionMailer::Preview
   def dubious_procedures
     procedures_and_champs = [
-      [Procedure.first, [TypeDeChamp.new(libelle: 'iban'), TypeDeChamp.new(libelle: 'religion')]],
-      [Procedure.last, [TypeDeChamp.new(libelle: 'iban'), TypeDeChamp.new(libelle: 'numéro de carte bleu')]]
+      [procedure_1, [TypeDeChamp.new(libelle: 'iban'), TypeDeChamp.new(libelle: 'religion')]],
+      [procedure_2, [TypeDeChamp.new(libelle: 'iban'), TypeDeChamp.new(libelle: 'numéro de carte bleu')]]
     ]
     AdministrationMailer.dubious_procedures(procedures_and_champs)
   end
 
   def invite_admin
-    AdministrationMailer.invite_admin(Administrateur.last, "12345678", 0)
+    AdministrationMailer.invite_admin(administrateur, "12345678", 0)
   end
 
   def refuse_admin
     AdministrationMailer.refuse_admin('bad_admin@pipo.com')
+  end
+
+  def new_admin
+    AdministrationMailer.new_admin_email(administrateur,administration)
+  end
+
+  def dossier_expiration_summary
+    expiring_dossiers = [ Dossier.new(id: 100, procedure: procedure_1) ]
+    expired_dossiers = [ Dossier.new(id: 100, procedure: procedure_2) ]
+    AdministrationMailer.dossier_expiration_summary(expiring_dossiers, expired_dossiers)
+  end
+
+  private
+
+  def administration
+    Administration.new email: 'chef@gouv.fr'
+  end
+
+  def procedure_1
+    Procedure.new(id: 10, libelle: "Démarche des marches", administrateur: administrateur)
+  end
+
+  def procedure_2
+    Procedure.new(id: 20, libelle: "Démarche pieds", administrateur: administrateur)
+  end
+
+  def administrateur
+    Administrateur.new(id: 111, email: 'admin@administration.fr')
   end
 end

--- a/spec/mailers/previews/avis_mailer_preview.rb
+++ b/spec/mailers/previews/avis_mailer_preview.rb
@@ -1,6 +1,11 @@
 # Preview all emails at http://localhost:3000/rails/mailers/avis_mailer
 class AvisMailerPreview < ActionMailer::Preview
   def avis_invitation
-    AvisMailer.avis_invitation(Avis.last)
+    gestionaire = Gestionnaire.new(id: 1, email: 'jeanmichel.de-chauvigny@exemple.fr')
+    avis = Avis.new(id: 1, email: 'test@exemple.fr', claimant: gestionaire)
+    avis.dossier = Dossier.new(id: 1)
+    avis.dossier.procedure = Procedure.new(libelle: 'Démarche pour faire des marches')
+    avis.introduction = 'Il faudrait vérifier le certificat de conformité.'
+    AvisMailer.avis_invitation(avis)
   end
 end

--- a/spec/mailers/previews/devise_user_mailer_preview.rb
+++ b/spec/mailers/previews/devise_user_mailer_preview.rb
@@ -1,9 +1,15 @@
 class DeviseUserMailerPreview < ActionMailer::Preview
   def confirmation_instructions
-    DeviseUserMailer.confirmation_instructions(User.first, "faketoken", {})
+    DeviseUserMailer.confirmation_instructions(user, "faketoken", {})
   end
 
   def reset_password_instructions
-    DeviseUserMailer.reset_password_instructions(User.first, "faketoken", {})
+    DeviseUserMailer.reset_password_instructions(user, "faketoken", {})
+  end
+
+  private
+
+  def user
+    User.last || User.new(id: 10, email: 'user@ds.fr')
   end
 end

--- a/spec/mailers/previews/dossier_mailer_preview.rb
+++ b/spec/mailers/previews/dossier_mailer_preview.rb
@@ -1,18 +1,32 @@
 # Preview all emails at http://localhost:3000/rails/mailers/dossier_mailer
 class DossierMailerPreview < ActionMailer::Preview
   def notify_new_draft
-    DossierMailer.notify_new_draft(Dossier.last)
+    DossierMailer.notify_new_draft(dossier)
   end
 
   def notify_new_answer
-    DossierMailer.notify_new_answer(Dossier.last)
+    DossierMailer.notify_new_answer(dossier)
   end
 
   def notify_deletion_to_user
-    DossierMailer.notify_deletion_to_user(DeletedDossier.last, "user@ds.fr")
+    DossierMailer.notify_deletion_to_user(deleted_dossier, "user@ds.fr")
   end
 
   def notify_deletion_to_administration
-    DossierMailer.notify_deletion_to_administration(DeletedDossier.last, "admin@ds.fr")
+    DossierMailer.notify_deletion_to_administration(deleted_dossier, "admin@ds.fr")
+  end
+
+  private
+
+  def deleted_dossier
+    DeletedDossier.last || DeletedDossier.new(dossier_id: 1, procedure: test_procedure)
+  end
+
+  def dossier
+    Dossier.last || Dossier.new(id: 1, procedure: test_procedure)
+  end
+
+  def test_procedure
+    Procedure.new(libelle: 'Démarche pour des marches')
   end
 end

--- a/spec/mailers/previews/gestionnaire_mailer_preview.rb
+++ b/spec/mailers/previews/gestionnaire_mailer_preview.rb
@@ -1,14 +1,39 @@
 class GestionnaireMailerPreview < ActionMailer::Preview
   def last_week_overview
-    gestionnaire = Gestionnaire.first
-    GestionnaireMailer.last_week_overview(gestionnaire)
+    GestionnaireMailer.last_week_overview(Gestionnaire.last)
   end
 
   def send_dossier
-    GestionnaireMailer.send_dossier(Gestionnaire.first, Dossier.first, Gestionnaire.last)
+    GestionnaireMailer.send_dossier(gestionnaire, dossier, target_gestionnaire)
   end
 
   def send_login_token
-    GestionnaireMailer.send_login_token(Gestionnaire.first, "token")
+    GestionnaireMailer.send_login_token(gestionnaire, "token")
+  end
+
+  def invite_gestionnaire
+    GestionnaireMailer.invite_gestionnaire(gestionnaire,'aedfa0d0')
+  end
+
+  def user_to_gestionnaire
+    GestionnaireMailer.user_to_gestionnaire(gestionnaire.email)
+  end
+
+  private
+
+  def dossier
+    Dossier.new(id: 10, procedure: procedure)
+  end
+
+  def procedure
+    Procedure.new(id: 1, libelle: 'Démarche pied')
+  end
+
+  def gestionnaire
+    Gestionnaire.new(id: 10, email: 'Chef.gestionnaire@administration.com')
+  end
+
+  def target_gestionnaire
+    Gestionnaire.new(id: 12, email: 'target.gestionnaire@administration.com')
   end
 end

--- a/spec/mailers/previews/user_mailer_preview.rb
+++ b/spec/mailers/previews/user_mailer_preview.rb
@@ -1,5 +1,11 @@
 class UserMailerPreview < ActionMailer::Preview
   def new_account_warning
-    UserMailer.new_account_warning(User.first)
+    UserMailer.new_account_warning(user)
+  end
+
+  private
+
+  def user
+    User.new(id: 10, email: 'test@exemple.fr')
   end
 end


### PR DESCRIPTION
Tous les mails n'étaient pas visibles dans rails/mailers, cette PR y remédie et ajoute l'utilisation d'objets de test quand c'est possible pour fonctionner même sur une base fraîchement créée.
Note: vérifier la partie administration vs administrateur: je ne suis pas sûr de l'appel invite_admin par ex.
