### PR TITLE
Fix #3235 sendinblue automation

### DIFF
--- a/app/views/layouts/_sendinblue.html.haml
+++ b/app/views/layouts/_sendinblue.html.haml
@@ -1,9 +1,8 @@
 :javascript
   (function() {
     window.sib = { equeue: [], client_key: "pcxtf4lpkka986pf4l1kt" };
-      /* OPTIONAL: email for identify request*/
-       window.sib.email_id = '#{current_administrateur.email}';
-       ;
+    /* OPTIONAL: email for identify request*/
+    window.sib.email_id = '#{current_administrateur.email}';
     window.sendinblue = {}; for (var j = ['track', 'identify', 'trackLink', 'page'], i = 0; i < j.length; i++) { (function(k) { window.sendinblue[k] = function() { var arg = Array.prototype.slice.call(arguments); (window.sib[k] || function() { var t = {}; t[k] = arg; window.sib.equeue.push(t);})(arg[0], arg[1], arg[2]);};})(j[i]);}var n = document.createElement("script"),i = document.getElementsByTagName("script")[0]; n.type = "text/javascript", n.id = "sendinblue-js", n.async = !0, n.src = "https://sibautomation.com/sa.js?key=" + window.sib.client_key, i.parentNode.insertBefore(n, i), window.sendinblue.page();
   })();
 

--- a/app/views/layouts/_sendinblue.html.haml
+++ b/app/views/layouts/_sendinblue.html.haml
@@ -1,0 +1,27 @@
+:javascript
+  (function() {
+    window.sib = { equeue: [], client_key: "pcxtf4lpkka986pf4l1kt" };
+      /* OPTIONAL: email for identify request*/
+       window.sib.email_id = '#{current_administrateur.email}';
+       ;
+    window.sendinblue = {}; for (var j = ['track', 'identify', 'trackLink', 'page'], i = 0; i < j.length; i++) { (function(k) { window.sendinblue[k] = function() { var arg = Array.prototype.slice.call(arguments); (window.sib[k] || function() { var t = {}; t[k] = arg; window.sib.equeue.push(t);})(arg[0], arg[1], arg[2]);};})(j[i]);}var n = document.createElement("script"),i = document.getElementsByTagName("script")[0]; n.type = "text/javascript", n.id = "sendinblue-js", n.async = !0, n.src = "https://sibautomation.com/sa.js?key=" + window.sib.client_key, i.parentNode.insertBefore(n, i), window.sendinblue.page();
+  })();
+
+  sendinblue.identify('#{current_administrateur.email}', {
+  'nb_demarches_brouillons': '#{current_administrateur.procedures.brouillons.count}',
+  'nb_demarches_actives': '#{current_administrateur.procedures.publiees.count}',
+  'nb_demarches_archivees': '#{current_administrateur.procedures.archivees.count}',
+  'sign_in_count' : '#{current_administrateur.sign_in_count}',
+  'created_at' : '#{current_administrateur.created_at}',
+  'active' : '#{current_administrateur.active}'
+  // Dans l'ideal :
+  // 'nom' : //pour personnaliser les emails
+  // 'prenom' : //pour personnaliser les emails
+  // 'nb_demarches_prod' : // Avec plus de 20 dossiers
+  // 'nb_demarches_test' : // Avec entre 1 et 20 dossiers
+  // 'nb_services' : //combien de service ?
+  // 'nb_instructeurs' :  //combien d'instructeur en tout ?
+  // 'nb_dossiers' : //combien de dossier en tout ?
+  });
+
+

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -17,6 +17,7 @@
     = csrf_meta_tags
 
     = render partial: "layouts/matomo"
+    = render partial: "layouts/sendinblue"
 
     :javascript
       DATA = [{


### PR DESCRIPTION
Fixes #3235 
J'ai rajouter le tracking avec des variables utiles, qui serviront de déclencheur dans les scénarios d'emails : 

- date de creation du compte
- nb de démarche en ligne ou en brouillon 
- nb de connexions au backoffice 
- etc

Les URL des pages visités permettent aussi de déclencher. 

J'aurais aimé récupérer plus d'infos sur l'admin (nb de démarche total etc), mais je ne veux pas y passer trop de temps. J'ai mis ca en commentaire pour une prochaine itération. 

<img width="1244" alt="capture d ecran 2018-12-27 16 46 59" src="https://user-images.githubusercontent.com/3593868/50485939-ac12dc00-09f7-11e9-908c-5a9535302880.png">


Pour info, l'intégration est en JS, ca pourrait se faire via une API rest (mais dans ce cas il faudrait tracker explicitement l'affichage de chaque page par exemple)

