### PR TITLE
Refactor SignatureService to remove RbNaCl

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,7 +57,6 @@ gem 'activestorage-openstack', git: 'https://github.com/fredZen/activestorage-op
 
 gem 'pg'
 
-gem 'rbnacl-libsodium'
 gem 'bcrypt'
 
 gem 'rgeo-geojson'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -463,10 +463,6 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
-    rbnacl (5.0.0)
-      ffi
-    rbnacl-libsodium (1.0.16)
-      rbnacl (>= 3.0.1)
     regexp_parser (1.3.0)
     request_store (1.4.1)
       rack (>= 1.4)
@@ -720,7 +716,6 @@ DEPENDENCIES
   rails-controller-testing
   rails-i18n
   rake-progressbar
-  rbnacl-libsodium
   rest-client
   rgeo-geojson
   rspec-rails

--- a/spec/services/signature_service_spec.rb
+++ b/spec/services/signature_service_spec.rb
@@ -3,14 +3,22 @@ require 'spec_helper'
 describe SignatureService do
   let(:service) { SignatureService }
   let(:message) { { hello: 'World!' }.to_json }
-  let(:message2) { { hello: 'World' }.to_json }
+  let(:tampered_message) { { hello: 'Tampered' }.to_json }
 
-  it "sign and verify" do
+  it 'sign and verify' do
     signature = service.sign(message)
-    signature2 = service.sign(message2)
-
     expect(service.verify(signature, message)).to eq(true)
-    expect(service.verify(signature2, message)).to eq(false)
-    expect(service.verify(signature, message2)).to eq(false)
+  end
+
+  it 'fails the verification if the message changed' do
+    signature = service.sign(message)
+    expect(service.verify(signature, tampered_message)).to eq(false)
+  end
+
+  it 'fails the verification if the signature changed' do
+    other_signature = service.sign(tampered_message)
+    expect(service.verify(nil, message)).to eq(false)
+    expect(service.verify('', message)).to eq(false)
+    expect(service.verify(other_signature, message)).to eq(false)
   end
 end


### PR DESCRIPTION
Replace RbNaCl by ActiveSupport::MessageVerifier, and remove the `rbnacl` gem.

Fix #3160 

@tchak please review