### PR TITLE
spec: fix specs failing randomly

### DIFF
--- a/spec/controllers/admin/procedures_controller_spec.rb
+++ b/spec/controllers/admin/procedures_controller_spec.rb
@@ -40,7 +40,7 @@ describe Admin::ProceduresController, type: :controller do
 
   describe 'GET #index with sorting and pagination' do
     before do
-      admin.procedures << create(:procedure)
+      admin.procedures << create(:procedure, administrateur: admin)
     end
 
     subject {

--- a/spec/factories/administrateur.rb
+++ b/spec/factories/administrateur.rb
@@ -10,4 +10,10 @@ FactoryBot.define do
       admin.renew_api_token
     end
   end
+
+  trait :with_procedure do
+    after(:create) do |admin|
+      admin.procedures << create(:simple_procedure, administrateur: admin)
+    end
+  end
 end

--- a/spec/features/admin/connection_spec.rb
+++ b/spec/features/admin/connection_spec.rb
@@ -5,11 +5,10 @@ feature 'Administrator connection' do
 
   let(:email) { 'admin1@admin.com' }
   let(:password) { 'mon chien aime les bananes' }
-  let!(:admin) { create(:administrateur, email: email, password: password) }
+  let!(:admin) { create(:administrateur, :with_procedure, email: email, password: password) }
   let!(:gestionnaire) { create(:gestionnaire, :with_trusted_device, email: email, password: password) }
 
   before do
-    admin.procedures << create(:procedure)
     visit new_administrateur_session_path
   end
 

--- a/spec/features/admin/procedure_creation_spec.rb
+++ b/spec/features/admin/procedure_creation_spec.rb
@@ -4,10 +4,9 @@ require 'features/admin/procedure_spec_helper'
 feature 'As an administrateur I wanna create a new procedure', js: true do
   include ProcedureSpecHelper
 
-  let(:administrateur) { create(:administrateur) }
+  let(:administrateur) { create(:administrateur, :with_procedure) }
 
   before do
-    administrateur.procedures << create(:procedure)
     Flipflop::FeatureSet.current.test!.switch!(:publish_draft, true)
     login_as administrateur, scope: :administrateur
     visit root_path


### PR DESCRIPTION
This is because creating a procedure attempts to create an admin from
scratch, and fails to do so.

Broken by 802f2086d618796c93696743c40a00b1094f97cf