### PR TITLE
Messagerie : corrige l'affichage du bouton "Envoyer" sur mobile

### DIFF
--- a/app/assets/stylesheets/new_design/flex.scss
+++ b/app/assets/stylesheets/new_design/flex.scss
@@ -24,4 +24,8 @@
   &.justify-start {
     justify-content: flex-start;
   }
+
+  &.wrap {
+    flex-wrap: wrap;
+  }
 }

--- a/app/views/shared/dossiers/messages/_form.html.haml
+++ b/app/views/shared/dossiers/messages/_form.html.haml
@@ -1,6 +1,6 @@
 = form_for(commentaire, url: form_url, html: { class: 'form' }) do |f|
   = f.text_area :body, rows: 5, placeholder: 'Répondre ici', required: true, class: 'message-textarea'
-  .flex.justify-between
+  .flex.justify-between.wrap
     %div
       = f.file_field :file, id: :file, accept: commentaire.file.accept_extension_list
       %label{ for: :file }

--- a/app/views/shared/dossiers/messages/_form.html.haml
+++ b/app/views/shared/dossiers/messages/_form.html.haml
@@ -8,4 +8,4 @@
           (taille max : 20 Mo)
 
     %div
-      = f.submit 'Envoyer', class: 'button primary send', data: { disable: true }
+      = f.submit 'Envoyer le message', class: 'button primary send', data: { disable: true }

--- a/spec/features/new_user/dossier_shared_examples.rb
+++ b/spec/features/new_user/dossier_shared_examples.rb
@@ -31,7 +31,7 @@ RSpec.shared_examples 'the user can send messages to the instructeur' do
     expect(page).to have_content(commentaire.body)
 
     fill_in 'commentaire_body', with: message_body
-    click_on 'Envoyer'
+    click_on 'Envoyer le message'
 
     expect(page).to have_current_path(messagerie_dossier_path(dossier))
     expect(page).to have_content('Message envoyé')


### PR DESCRIPTION
## Avant

<img src="https://user-images.githubusercontent.com/179923/50775325-26fcb200-1296-11e9-8e3f-b12b2a5ec101.png" width="420" />

## Après

<img src="https://user-images.githubusercontent.com/179923/50775329-295f0c00-1296-11e9-8029-f4e98da35d4e.png" width="420" />


## À communiquer

`HS #10448`