### PR TITLE
tasks: prevent logs from being output to the console during tests

### DIFF
--- a/lib/tasks/deployment/20181219164523_clone_service_for_transferred_procedures.rake
+++ b/lib/tasks/deployment/20181219164523_clone_service_for_transferred_procedures.rake
@@ -1,7 +1,9 @@
+require Rails.root.join("lib", "tasks", "task_helper")
+
 namespace :after_party do
   desc 'Deployment task: clone_service_for_transferred_procedures'
   task clone_service_for_transferred_procedures: :environment do
-    puts "Running deploy task 'clone_service_for_transferred_procedures'"
+    rake_puts "Running deploy task 'clone_service_for_transferred_procedures'"
 
     procedures = Procedure.includes(:service).where.not(service_id: nil)
     procedures_to_fix_in_array = procedures.select do |p|
@@ -16,12 +18,12 @@ namespace :after_party do
       cloned_service = Service.find(service_id).clone_and_assign_to_administrateur(Administrateur.find(administrateur_id))
 
       if cloned_service.save
-        puts "Fixing Service #{service_id} for Administrateur #{administrateur_id}"
+        rake_puts "Fixing Service #{service_id} for Administrateur #{administrateur_id}"
         procedures_to_fix
           .where(service_id: service_id, administrateur_id: administrateur_id)
           .update_all(service_id: cloned_service.id)
       else
-        puts "Cannot fix Service #{service_id} for Administrateur #{administrateur_id}, it should be fixed manually. Errors : #{cloned_service.errors.full_messages}"
+        rake_puts "Cannot fix Service #{service_id} for Administrateur #{administrateur_id}, it should be fixed manually. Errors : #{cloned_service.errors.full_messages}"
       end
       progress.inc
     end


### PR DESCRIPTION
Pour éviter que les tâches rake émettent des logs dans la console quand on les teste, il vaut mieux utiliser `rake_puts` (plutôt que `puts`).