### PR TITLE
Corrige l'affichage des textsareas dans les demandes

### DIFF
--- a/app/views/shared/dossiers/_champs.html.haml
+++ b/app/views/shared/dossiers/_champs.html.haml
@@ -22,7 +22,7 @@
               - when TypeDeChamp.type_champs.fetch(:siret)
                 = render partial: "shared/champs/siret/show", locals: { champ: c, profile: profile }
               - when TypeDeChamp.type_champs.fetch(:textarea)
-                = render partial: "shared/champs/text_area/show", locals: { champ: c }
+                = render partial: "shared/champs/textarea/show", locals: { champ: c }
               - else
                 = sanitize(c.to_s)
 

--- a/spec/views/shared/dossiers/_champs.html.haml_spec.rb
+++ b/spec/views/shared/dossiers/_champs.html.haml_spec.rb
@@ -22,20 +22,24 @@ describe 'shared/dossiers/champs.html.haml', type: :view do
 
     before { dossier.avis << avis }
 
-    it { is_expected.to include(champ1.libelle) }
-    it { is_expected.to include(champ1.value) }
+    it "renders titles and values of champs" do
+      expect(subject).to include(champ1.libelle)
+      expect(subject).to include(champ1.value)
 
-    it { is_expected.to have_css(".header-section") }
-    it { is_expected.to include(champ2.libelle) }
+      expect(subject).to have_css(".header-section")
+      expect(subject).to include(champ2.libelle)
 
-    it { is_expected.not_to include(champ3.libelle) }
-    it { is_expected.not_to include(champ3.value) }
+      expect(subject).to have_link("Dossier nº #{dossier.id}")
+      expect(subject).to include(dossier.text_summary)
 
-    it { is_expected.to have_link("Dossier nº #{dossier.id}") }
-    it { is_expected.to include(dossier.text_summary) }
+      expect(subject).to include(champ5.libelle)
+      expect(subject).to include(champ5.libelle)
+    end
 
-    it { is_expected.to include(champ5.libelle) }
-    it { is_expected.to include(champ5.libelle) }
+    it "doesn't render explication champs" do
+      expect(subject).not_to include(champ3.libelle)
+      expect(subject).not_to include(champ3.value)
+    end
   end
 
   context "with a dossier champ, but we are not authorized to acces the dossier" do

--- a/spec/views/shared/dossiers/_champs.html.haml_spec.rb
+++ b/spec/views/shared/dossiers/_champs.html.haml_spec.rb
@@ -17,7 +17,8 @@ describe 'shared/dossiers/champs.html.haml', type: :view do
     let(:champ2) { create(:champ, :header_section, value: "Section") }
     let(:champ3) { create(:champ, :explication, value: "mazette") }
     let(:champ4) { create(:champ, :dossier_link, value: dossier.id) }
-    let(:champs) { [champ1, champ2, champ3, champ4] }
+    let(:champ5) { create(:champ_textarea, value: "Some long text in a textarea.") }
+    let(:champs) { [champ1, champ2, champ3, champ4, champ5] }
 
     before { dossier.avis << avis }
 
@@ -32,6 +33,9 @@ describe 'shared/dossiers/champs.html.haml', type: :view do
 
     it { is_expected.to have_link("Dossier nº #{dossier.id}") }
     it { is_expected.to include(dossier.text_summary) }
+
+    it { is_expected.to include(champ5.libelle) }
+    it { is_expected.to include(champ5.libelle) }
   end
 
   context "with a dossier champ, but we are not authorized to acces the dossier" do


### PR DESCRIPTION
Depuis quelques jours, dans le récapitulatif des demandes (Usager ou Instructeur), la page crashe si on essaie d'afficher une textarea.

Cette PR corrige le problème, et rajoute un test pour ça.