### PR TITLE
Fix feedback stats

### DIFF
--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -146,11 +146,13 @@ class StatsController < ApplicationController
         .count
         .map do |week, count|
           total = totals[week]
+          # By default a week is displayed by the first day of the week – but we'd rather display the last day
+          label = week.next_week
 
           if total > 0
-            [week, (count.to_f / total * 100).round(2)]
+            [label, (count.to_f / total * 100).round(2)]
           else
-            [week, 0]
+            [label, 0]
           end
         end.to_h
 

--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -133,17 +133,16 @@ class StatsController < ApplicationController
       Feedback.ratings.fetch(:neutral)  => "Neutres",
       Feedback.ratings.fetch(:unhappy)  => "Mécontents"
     }
-    interval = 6.weeks.ago.beginning_of_week..1.week.ago.beginning_of_week
 
+    number_of_weeks = 6
     totals = Feedback
-      .where(created_at: interval)
-      .group_by_week(:created_at)
+      .group_by_week(:created_at, last: number_of_weeks, current: false)
       .count
 
     Feedback.ratings.values.map do |rating|
       data = Feedback
-        .where(created_at: interval, rating: rating)
-        .group_by_week(:created_at)
+        .where(rating: rating)
+        .group_by_week(:created_at, last: number_of_weeks, current: false)
         .count
         .map do |week, count|
           total = totals[week]
@@ -151,7 +150,7 @@ class StatsController < ApplicationController
           if total > 0
             [week, (count.to_f / total * 100).round(2)]
           else
-            0
+            [week, 0]
           end
         end.to_h
 

--- a/config/initializers/groupdate.rb
+++ b/config/initializers/groupdate.rb
@@ -1,0 +1,1 @@
+Groupdate.week_start = :mon

--- a/spec/controllers/stats_controller_spec.rb
+++ b/spec/controllers/stats_controller_spec.rb
@@ -229,6 +229,63 @@ describe StatsController, type: :controller do
     it { expect(subject).to eq(@expected_hash) }
   end
 
+  describe "#satisfaction_usagers" do
+    before do
+      # Test the stats on October 2018 – where the 1st, 8th, 15th, 22th and 29th are conveniently Mondays
+      # Current week: 1 negative feedback
+      Timecop.freeze(Time.zone.local(2018, 10, 22, 12, 00)) { create(:feedback, :unhappy) }
+      # Last week: 3 positive, 1 negative
+      Timecop.freeze(Time.zone.local(2018, 10, 21, 12, 00)) { create(:feedback, :unhappy) }
+      Timecop.freeze(Time.zone.local(2018, 10, 19, 12, 00)) { create(:feedback, :happy) }
+      Timecop.freeze(Time.zone.local(2018, 10, 17, 12, 00)) { create(:feedback, :happy) }
+      Timecop.freeze(Time.zone.local(2018, 10, 15, 12, 00)) { create(:feedback, :happy) }
+      # N-2 week: 2 positive, 2 negative
+      Timecop.freeze(Time.zone.local(2018, 10, 14, 12, 00)) { create(:feedback, :unhappy) }
+      Timecop.freeze(Time.zone.local(2018, 10, 12, 12, 00)) { create(:feedback, :happy) }
+      Timecop.freeze(Time.zone.local(2018, 10, 10, 12, 00)) { create(:feedback, :unhappy) }
+      Timecop.freeze(Time.zone.local(2018, 10, 8, 12, 00)) { create(:feedback, :happy) }
+      # N-3 week: 1 positive, 3 negative
+      Timecop.freeze(Time.zone.local(2018, 10, 1, 12, 00)) { create(:feedback, :unhappy) }
+      Timecop.freeze(Time.zone.local(2018, 10, 3, 12, 00)) { create(:feedback, :happy) }
+      Timecop.freeze(Time.zone.local(2018, 10, 5, 12, 00)) { create(:feedback, :unhappy) }
+      Timecop.freeze(Time.zone.local(2018, 10, 7, 12, 00)) { create(:feedback, :unhappy) }
+    end
+
+    subject(:stats) do
+      Timecop.freeze(Time.zone.local(2018, 10, 28, 12, 00)) {
+        StatsController.new.send(:satisfaction_usagers)
+      }
+    end
+
+    it 'returns one set of values for each kind of feedback' do
+      expect(stats.count).to eq 3
+      expect(stats.map { |g| g[:name] }).to contain_exactly('Satisfaits', 'Neutres', 'Mécontents')
+    end
+
+    it 'returns weekly ratios between a given feedback and all feedback' do
+      happy_data = stats.find { |g| g[:name] == 'Satisfaits' }[:data]
+      expect(happy_data.values[0]).to eq 0
+      expect(happy_data.values[1]).to eq 0
+      expect(happy_data.values[2]).to eq 0
+      expect(happy_data.values[3]).to eq 25.0
+      expect(happy_data.values[4]).to eq 50.0
+      expect(happy_data.values[5]).to eq 75.0
+
+      unhappy_data = stats.find { |g| g[:name] == 'Mécontents' }[:data]
+      expect(unhappy_data.values[0]).to eq 0
+      expect(unhappy_data.values[1]).to eq 0
+      expect(unhappy_data.values[2]).to eq 0
+      expect(unhappy_data.values[3]).to eq 75.0
+      expect(unhappy_data.values[4]).to eq 50.0
+      expect(unhappy_data.values[5]).to eq 25.0
+    end
+
+    it 'excludes values still in the current week' do
+      unhappy_data = stats.find { |g| g[:name] == 'Mécontents' }[:data]
+      expect(unhappy_data.values).not_to include(100.0)
+    end
+  end
+
   describe '#avis_usage' do
     let!(:dossier) { create(:dossier) }
     let!(:avis_with_dossier) { create(:avis) }

--- a/spec/factories/feedback.rb
+++ b/spec/factories/feedback.rb
@@ -1,5 +1,17 @@
 FactoryBot.define do
   factory :feedback do
     rating { Feedback.ratings.fetch(:happy) }
+
+    trait :happy do
+      rating { Feedback.ratings.fetch(:happy) }
+    end
+
+    trait :neutral do
+      rating { Feedback.ratings.fetch(:neutral) }
+    end
+
+    trait :unhappy do
+      rating { Feedback.ratings.fetch(:unhappy) }
+    end
   end
 end


### PR DESCRIPTION
Cette PR :

- Utilise groupdate pour grouper les feedbacks par semaine (plutôt que de mélanger groupdate et une génération custom des intervalles) ; fix #3242
- Ajoute des tests à la génération des stats de feedback
- Fait en sorte d'afficher le jour où chaque valeur a été calculée (plutôt que le début de l'intervalle de calcul)

@fredZen tu en penses quoi ?