### PR TITLE
Ajout d'une page de garde pour les démarches

### DIFF
--- a/app/assets/stylesheets/new_design/commencer.scss
+++ b/app/assets/stylesheets/new_design/commencer.scss
@@ -1,0 +1,11 @@
+@import "constants";
+
+.commencer {
+  .button:first-of-type {
+    margin-top: 4 * $default-spacer;
+  }
+
+  .button {
+    margin-bottom: 2 * $default-spacer;
+  }
+}

--- a/app/assets/stylesheets/new_design/forms.scss
+++ b/app/assets/stylesheets/new_design/forms.scss
@@ -5,6 +5,10 @@
   h1 {
     text-align: center;
     margin-bottom: 20px;
+
+    @media (max-width: $two-columns-breakpoint) {
+      font-size: 28px;
+    }
   }
 
   hr {

--- a/app/controllers/new_user/commencer_controller.rb
+++ b/app/controllers/new_user/commencer_controller.rb
@@ -38,7 +38,7 @@ module NewUser
 
     def store_user_location!
       procedure = Procedure.find_by(path: params[:path])
-      store_location_for(:user, new_dossier_path(procedure_id: procedure.id))
+      store_location_for(:user, commencer_path(path: procedure.path))
     end
   end
 end

--- a/app/controllers/new_user/commencer_controller.rb
+++ b/app/controllers/new_user/commencer_controller.rb
@@ -1,25 +1,44 @@
 module NewUser
   class CommencerController < ApplicationController
-    def commencer_test
-      procedure = Procedure.brouillons.find_by(path: params[:path])
-
-      if procedure.present?
-        redirect_to new_dossier_path(procedure_id: procedure.id, brouillon: true)
-      else
-        flash.alert = "La démarche est inconnue."
-        redirect_to root_path
-      end
-    end
+    layout 'procedure_context'
 
     def commencer
-      procedure = Procedure.publiees.find_by(path: params[:path])
+      @procedure = Procedure.publiees.find_by(path: params[:path])
 
-      if procedure.present?
-        redirect_to new_dossier_path(procedure_id: procedure.id)
-      else
+      if @procedure.blank?
         flash.alert = "La démarche est inconnue, ou la création de nouveaux dossiers pour cette démarche est terminée."
-        redirect_to root_path
+        return redirect_to root_path
       end
+
+      render 'commencer/show'
+    end
+
+    def commencer_test
+      @procedure = Procedure.brouillons.find_by(path: params[:path])
+
+      if @procedure.blank?
+        flash.alert = "La démarche est inconnue, ou cette démarche n’est maintenant plus en test."
+        return redirect_to root_path
+      end
+
+      render 'commencer/show'
+    end
+
+    def sign_in
+      store_user_location!
+      redirect_to new_user_session_path
+    end
+
+    def sign_up
+      store_user_location!
+      redirect_to new_user_registration_path
+    end
+
+    private
+
+    def store_user_location!
+      procedure = Procedure.find_by(path: params[:path])
+      store_location_for(:user, new_dossier_path(procedure_id: procedure.id))
     end
   end
 end

--- a/app/helpers/dossier_helper.rb
+++ b/app/helpers/dossier_helper.rb
@@ -23,6 +23,14 @@ module DossierHelper
     end
   end
 
+  def url_for_new_dossier(procedure)
+    if procedure.brouillon?
+      new_dossier_url(procedure_id: procedure.id, brouillon: true)
+    else
+      new_dossier_url(procedure_id: procedure.id)
+    end
+  end
+
   def dossier_submission_is_closed?(dossier)
     dossier.brouillon? && dossier.procedure.archivee?
   end

--- a/app/views/commencer/show.html.haml
+++ b/app/views/commencer/show.html.haml
@@ -1,0 +1,30 @@
+- content_for(:title, @procedure.libelle)
+
+.commencer.form
+  - if !user_signed_in?
+    %h1 Commencer la démarche
+    = link_to 'Créer un compte demarches-simplifiees.fr', commencer_sign_up_path(path: @procedure.path), class: ['button large expand primary']
+    = link_to 'J’ai déjà un compte', commencer_sign_in_path(path: @procedure.path), class: ['button large expand']
+
+  - else
+    - dossiers = current_user.dossiers.where(procedure: @procedure)
+    - drafts = dossiers.merge(Dossier.state_brouillon)
+    - not_drafts = dossiers.merge(Dossier.state_not_brouillon)
+
+    - if dossiers.count == 0
+      = link_to 'Commencer la démarche', url_for_new_dossier(@procedure), class: ['button large expand primary']
+
+    - elsif drafts.count == 1 && not_drafts.count == 0
+      %h1 Vous avez déjà commencé à remplir un dossier
+      = link_to 'Continuer à remplir mon dossier', brouillon_dossier_path(drafts.first), class: ['button large expand primary']
+      = link_to 'Commencer un nouveau dossier', url_for_new_dossier(@procedure), class: ['button large expand']
+
+    - elsif not_drafts.count == 1
+      %h1 Vous avez déjà déposé un dossier
+      = link_to 'Voir mon dossier', dossier_path(not_drafts.first), class: ['button large expand primary']
+      = link_to 'Commencer un nouveau dossier', url_for_new_dossier(@procedure), class: ['button large expand']
+
+    - else
+      %h1 Vous avez déjà des dossiers pour cette démarche
+      = link_to 'Voir mes dossiers en cours', dossiers_path, class: ['button large expand primary']
+      = link_to 'Commencer un nouveau dossier', url_for_new_dossier(@procedure), class: ['button large expand']

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -265,6 +265,8 @@ Rails.application.routes.draw do
     namespace :commencer do
       get '/test/:path', action: 'commencer_test', as: :test
       get '/:path', action: 'commencer'
+      get '/:path/sign_in', action: 'sign_in', as: :sign_in
+      get '/:path/sign_up', action: 'sign_up', as: :sign_up
     end
 
     resources :dossiers, only: [:index, :show, :new] do

--- a/spec/controllers/concerns/procedure_context_concern_spec.rb
+++ b/spec/controllers/concerns/procedure_context_concern_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe ProcedureContextConcern, type: :controller do
       end
     end
 
-    context 'when no procedure_id is present in the stored return location' do
+    context 'when the stored return location is not a procedure URL' do
       before do
         controller.store_location_for(:user, dossiers_path)
       end
@@ -36,9 +36,9 @@ RSpec.describe ProcedureContextConcern, type: :controller do
     end
 
     context 'when a procedure location has been stored' do
-      context 'when the stored procedure does not exist' do
+      context 'when the procedure path does not exist' do
         before do
-          controller.store_location_for(:user, new_dossier_path(procedure_id: '0'))
+          controller.store_location_for(:user, commencer_path(path: 'non-existent-path'))
         end
 
         it 'redirects with an error' do
@@ -47,11 +47,11 @@ RSpec.describe ProcedureContextConcern, type: :controller do
         end
       end
 
-      context 'when the stored procedure is not published' do
-        let(:procedure) { create :procedure }
+      context 'when the procedure path exists, but not with the same publication status' do
+        let(:published_procedure) { create :procedure, :published }
 
         before do
-          controller.store_location_for(:user, new_dossier_path(procedure_id: procedure.id))
+          controller.store_location_for(:user, commencer_test_path(path: published_procedure.path))
         end
 
         it 'redirects with an error' do
@@ -60,16 +60,29 @@ RSpec.describe ProcedureContextConcern, type: :controller do
         end
       end
 
-      context 'when the stored procedure exists' do
-        let(:procedure) { create :procedure, :published }
+      context 'when the stored procedure is in test' do
+        let(:test_procedure) { create :procedure, :with_path }
 
         before do
-          controller.store_location_for(:user, new_dossier_path(procedure_id: procedure.id))
+          controller.store_location_for(:user, commencer_test_path(path: test_procedure.path))
         end
 
         it 'succeeds, and assigns the procedure on the controller' do
           expect(subject.status).to eq 200
-          expect(assigns(:procedure)).to eq procedure
+          expect(assigns(:procedure)).to eq test_procedure
+        end
+      end
+
+      context 'when the stored procedure is published' do
+        let(:published_procedure) { create :procedure, :published }
+
+        before do
+          controller.store_location_for(:user, commencer_path(path: published_procedure.path))
+        end
+
+        it 'succeeds, and assigns the procedure on the controller' do
+          expect(subject.status).to eq 200
+          expect(assigns(:procedure)).to eq published_procedure
         end
       end
     end

--- a/spec/controllers/new_user/commencer_controller_spec.rb
+++ b/spec/controllers/new_user/commencer_controller_spec.rb
@@ -2,39 +2,88 @@ require 'spec_helper'
 
 describe NewUser::CommencerController, type: :controller do
   let(:user) { create(:user) }
-  let(:procedure) { create(:procedure, :published) }
-  let(:procedure_id) { procedure.id }
+  let(:published_procedure) { create(:procedure, :published) }
+  let(:draft_procedure) { create(:procedure, :with_path) }
 
-  describe 'GET #commencer' do
+  describe '#commencer' do
     subject { get :commencer, params: { path: path } }
-    let(:path) { procedure.path }
 
-    it { expect(subject.status).to eq 302 }
-    it { expect(subject).to redirect_to new_dossier_path(procedure_id: procedure.id) }
+    context 'when the path is for a published procedure' do
+      let(:path) { published_procedure.path }
 
-    context 'when procedure path does not exist' do
+      it 'renders the view' do
+        expect(subject.status).to eq(200)
+        expect(subject).to render_template('show')
+        expect(assigns(:procedure)).to eq published_procedure
+      end
+    end
+
+    context 'when the path is for a non-published procedure' do
+      let(:path) { draft_procedure.path }
+
+      it 'redirects with an error message' do
+        expect(subject).to redirect_to(root_path)
+      end
+    end
+
+    context 'when the path does not exist' do
       let(:path) { 'hello' }
 
-      it { expect(subject).to redirect_to(root_path) }
+      it 'redirects with an error message' do
+        expect(subject).to redirect_to(root_path)
+      end
     end
   end
 
-  describe 'GET #commencer_test' do
-    before do
-      Flipflop::FeatureSet.current.test!.switch!(:publish_draft, true)
+  describe '#commencer_test' do
+    subject { get :commencer_test, params: { path: path } }
+
+    context 'when the path is for a draft procedure' do
+      let(:path) { draft_procedure.path }
+
+      it 'renders the view' do
+        expect(subject.status).to eq(200)
+        expect(subject).to render_template('show')
+        expect(assigns(:procedure)).to eq draft_procedure
+      end
     end
 
-    subject { get :commencer_test, params: { path: path } }
-    let(:procedure) { create(:procedure, :with_path) }
-    let(:path) { procedure.path }
+    context 'when the path is for a published procedure' do
+      let(:path) { published_procedure.path }
 
-    it { expect(subject.status).to eq 302 }
-    it { expect(subject).to redirect_to new_dossier_path(procedure_id: procedure.id, brouillon: true) }
+      it 'redirects with an error message' do
+        expect(subject).to redirect_to(root_path)
+      end
+    end
 
-    context 'when procedure path does not exist' do
+    context 'when the path does not exist' do
       let(:path) { 'hello' }
 
-      it { expect(subject).to redirect_to(root_path) }
+      it 'redirects with an error message' do
+        expect(subject).to redirect_to(root_path)
+      end
     end
+  end
+
+  describe '#sign_in' do
+    subject { get :sign_in, params: { path: published_procedure.path } }
+
+    it 'set the path to return after sign-in to the dossier creation path' do
+      subject
+      expect(controller.stored_location_for(:user)).to eq(new_dossier_path(procedure_id: published_procedure.id))
+    end
+
+    it { expect(subject).to redirect_to(new_user_session_path) }
+  end
+
+  describe '#sign_up' do
+    subject { get :sign_up, params: { path: published_procedure.path } }
+
+    it 'set the path to return after sign-up to the dossier creation path' do
+      subject
+      expect(controller.stored_location_for(:user)).to eq(new_dossier_path(procedure_id: published_procedure.id))
+    end
+
+    it { expect(subject).to redirect_to(new_user_registration_path) }
   end
 end

--- a/spec/controllers/new_user/commencer_controller_spec.rb
+++ b/spec/controllers/new_user/commencer_controller_spec.rb
@@ -70,7 +70,7 @@ describe NewUser::CommencerController, type: :controller do
 
     it 'set the path to return after sign-in to the dossier creation path' do
       subject
-      expect(controller.stored_location_for(:user)).to eq(new_dossier_path(procedure_id: published_procedure.id))
+      expect(controller.stored_location_for(:user)).to eq(commencer_path(path: published_procedure.path))
     end
 
     it { expect(subject).to redirect_to(new_user_session_path) }
@@ -81,7 +81,7 @@ describe NewUser::CommencerController, type: :controller do
 
     it 'set the path to return after sign-up to the dossier creation path' do
       subject
-      expect(controller.stored_location_for(:user)).to eq(new_dossier_path(procedure_id: published_procedure.id))
+      expect(controller.stored_location_for(:user)).to eq(commencer_path(path: published_procedure.path))
     end
 
     it { expect(subject).to redirect_to(new_user_registration_path) }

--- a/spec/controllers/users/registrations_controller_spec.rb
+++ b/spec/controllers/users/registrations_controller_spec.rb
@@ -27,7 +27,7 @@ describe Users::RegistrationsController, type: :controller do
       let(:procedure) { create :procedure, :published }
 
       before do
-        controller.store_location_for(:user, new_dossier_path(procedure_id: procedure.id))
+        controller.store_location_for(:user, commencer_path(path: procedure.path))
       end
 
       it 'makes the saved procedure available' do

--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -179,7 +179,7 @@ describe Users::SessionsController, type: :controller do
       let(:procedure) { create :procedure, :published }
 
       before do
-        controller.store_location_for(:user, new_dossier_path(procedure_id: procedure.id))
+        controller.store_location_for(:user, commencer_path(path: procedure.path))
       end
 
       it 'makes the saved procedure available' do

--- a/spec/features/new_gestionnaire/gestionnaire_spec.rb
+++ b/spec/features/new_gestionnaire/gestionnaire_spec.rb
@@ -19,6 +19,10 @@ feature 'The gestionnaire part' do
       expect(page).to have_current_path new_user_session_path
       sign_in_with(gestionnaire.email, password, true)
 
+      expect(page).to have_current_path(commencer_path(path: procedure.path))
+      click_on 'Commencer la démarche'
+
+      expect(page).to have_content('Identifier votre établissement')
       expect(page).to have_current_path(siret_dossier_path(procedure.reload.dossiers.last))
       expect(page).to have_content(procedure.libelle)
     end

--- a/spec/features/new_gestionnaire/gestionnaire_spec.rb
+++ b/spec/features/new_gestionnaire/gestionnaire_spec.rb
@@ -14,10 +14,12 @@ feature 'The gestionnaire part' do
 
     scenario 'a gestionnaire can fill a dossier' do
       visit commencer_path(path: procedure.path)
+      click_on 'J’ai déjà un compte'
 
       expect(page).to have_current_path new_user_session_path
       sign_in_with(gestionnaire.email, password, true)
 
+      expect(page).to have_current_path(siret_dossier_path(procedure.reload.dossiers.last))
       expect(page).to have_content(procedure.libelle)
     end
   end

--- a/spec/features/new_user/brouillon_spec.rb
+++ b/spec/features/new_user/brouillon_spec.rb
@@ -133,10 +133,12 @@ feature 'The user' do
     click_on 'J’ai déjà un compte'
 
     expect(page).to have_current_path(new_user_session_path)
+    sign_in_with(email, password)
 
-    fill_in 'user_email', with: email
-    fill_in 'user_password', with: password
-    click_on 'Se connecter'
+    expect(page).to have_current_path("/commencer/#{procedure.path}")
+    click_on 'Commencer la démarche'
+
+    expect(page).to have_content("Données d'identité")
     expect(page).to have_current_path(identite_dossier_path(user_dossier))
   end
 

--- a/spec/features/new_user/brouillon_spec.rb
+++ b/spec/features/new_user/brouillon_spec.rb
@@ -130,6 +130,8 @@ feature 'The user' do
 
   def log_in(email, password, procedure)
     visit "/commencer/#{procedure.path}"
+    click_on 'J’ai déjà un compte'
+
     expect(page).to have_current_path(new_user_session_path)
 
     fill_in 'user_email', with: email

--- a/spec/features/new_user/dossier_creation_spec.rb
+++ b/spec/features/new_user/dossier_creation_spec.rb
@@ -17,10 +17,10 @@ feature 'Creating a new dossier:' do
 
       before do
         visit commencer_path(path: procedure.path)
+        click_on 'Commencer la démarche'
 
-        expect(page).to have_content(procedure.libelle)
-        expect(page).to have_content(procedure.description)
-        expect(page).to have_content(procedure.service.email)
+        expect(page).to have_current_path identite_dossier_path(user.reload.dossiers.last)
+        expect_page_to_have_procedure_description(procedure)
 
         fill_in 'individual_nom',    with: 'Nom'
         fill_in 'individual_prenom', with: 'Prenom'
@@ -77,13 +77,12 @@ feature 'Creating a new dossier:' do
           .to_return(status: 404, body: '')
       end
 
-      scenario 'the user can enter the SIRET of its etablissement and create a new draft', vcr: { cassette_name: 'api_adresse_search_paris_3' }, js: true do
+      scenario 'the user can enter the SIRET of its etablissement and create a new draft', vcr: { cassette_name: 'api_adresse_search_paris_3' } do
         visit commencer_path(path: procedure.path)
+        click_on 'Commencer la démarche'
 
-        expect(page).to have_current_path(siret_dossier_path(dossier))
-        expect(page).to have_content(procedure.libelle)
-        expect(page).to have_content(procedure.description)
-        expect(page).to have_content(procedure.service.email)
+        expect(page).to have_current_path siret_dossier_path(dossier)
+        expect_page_to_have_procedure_description(procedure)
 
         fill_in 'Numéro SIRET', with: siret
         click_on 'Valider'
@@ -97,7 +96,10 @@ feature 'Creating a new dossier:' do
 
       scenario 'the user is notified when its SIRET is invalid' do
         visit commencer_path(path: procedure.path)
+        click_on 'Commencer la démarche'
+
         expect(page).to have_current_path(siret_dossier_path(dossier))
+        expect_page_to_have_procedure_description(procedure)
 
         fill_in 'Numéro SIRET', with: '0000'
         click_on 'Valider'

--- a/spec/features/new_user/linked_dropdown_spec.rb
+++ b/spec/features/new_user/linked_dropdown_spec.rb
@@ -52,10 +52,12 @@ feature 'linked dropdown lists' do
 
     expect(page).to have_current_path(new_user_session_path)
 
-    fill_in 'user_email', with: email
-    fill_in 'user_password', with: password
-    click_on 'Se connecter'
+    sign_in_with(email, password)
 
+    expect(page).to have_current_path(commencer_path(path: procedure.path))
+    click_on 'Commencer la démarche'
+
+    expect(page).to have_content("Données d'identité")
     expect(page).to have_current_path(identite_dossier_path(user_dossier))
   end
 

--- a/spec/features/new_user/linked_dropdown_spec.rb
+++ b/spec/features/new_user/linked_dropdown_spec.rb
@@ -48,11 +48,14 @@ feature 'linked dropdown lists' do
 
   def log_in(email, password, procedure)
     visit "/commencer/#{procedure.path}"
+    click_on 'J’ai déjà un compte'
+
     expect(page).to have_current_path(new_user_session_path)
 
     fill_in 'user_email', with: email
     fill_in 'user_password', with: password
     click_on 'Se connecter'
+
     expect(page).to have_current_path(identite_dossier_path(user_dossier))
   end
 

--- a/spec/features/new_user/sign_up_spec.rb
+++ b/spec/features/new_user/sign_up_spec.rb
@@ -41,8 +41,8 @@ feature 'Signing up:' do
     end
 
     scenario 'a new user can sign-up and fill the procedure' do
-      expect(page).to have_current_path new_user_session_path
       click_on 'Créer un compte'
+      expect(page).to have_current_path new_user_registration_path
       expect_page_to_have_procedure_description(procedure)
 
       sign_up_with user_email, user_password
@@ -50,6 +50,7 @@ feature 'Signing up:' do
 
       click_confirmation_link_for user_email
       expect(page).to have_content 'Votre compte a été activé'
+      expect(page).to have_current_path identite_dossier_path(procedure.reload.dossiers.last)
       expect_page_to_have_procedure_description(procedure)
     end
   end

--- a/spec/features/new_user/sign_up_spec.rb
+++ b/spec/features/new_user/sign_up_spec.rb
@@ -49,7 +49,11 @@ feature 'Signing up:' do
       expect(page).to have_content "nous avons besoin de vérifier votre adresse #{user_email}"
 
       click_confirmation_link_for user_email
+
+      expect(page).to have_current_path(commencer_path(path: procedure.path))
       expect(page).to have_content 'Votre compte a été activé'
+      click_on 'Commencer la démarche'
+
       expect(page).to have_current_path identite_dossier_path(procedure.reload.dossiers.last)
       expect_page_to_have_procedure_description(procedure)
     end

--- a/spec/features/sessions/sign_in_spec.rb
+++ b/spec/features/sessions/sign_in_spec.rb
@@ -21,6 +21,7 @@ feature 'Signin in:' do
     end
 
     scenario 'an existing user can sign-in and fill the procedure' do
+      click_on 'J’ai déjà un compte'
       expect(page).to have_current_path new_user_session_path
       expect_page_to_have_procedure_description(procedure)
 

--- a/spec/features/sessions/sign_in_spec.rb
+++ b/spec/features/sessions/sign_in_spec.rb
@@ -27,6 +27,9 @@ feature 'Signin in:' do
 
       sign_in_with user.email, password
 
+      expect(page).to have_current_path(commencer_path(path: procedure.path))
+      click_on 'Commencer la démarche'
+
       expect(page).to have_current_path identite_dossier_path(user.reload.dossiers.last)
       expect_page_to_have_procedure_description(procedure)
       expect(page).to have_content "Données d'identité"

--- a/spec/views/commencer/show.html.haml_spec.rb
+++ b/spec/views/commencer/show.html.haml_spec.rb
@@ -1,0 +1,76 @@
+require 'rails_helper'
+
+RSpec.describe 'commencer/show.html.haml', type: :view do
+  include Rails.application.routes.url_helpers
+
+  let(:procedure) { create(:procedure, :with_service, :published) }
+
+  before do
+    assign(:procedure, procedure)
+    if user
+      sign_in user
+    end
+  end
+
+  subject { render }
+
+  context 'when no user is signed in' do
+    let(:user) { nil }
+
+    it 'renders sign-in and sign-up links' do
+      subject
+      expect(rendered).to have_link('Créer un compte')
+      expect(rendered).to have_link('J’ai déjà un compte')
+    end
+  end
+
+  context 'when the user is already signed in' do
+    let(:user) { create :user }
+
+    shared_examples_for 'it renders a link to create a new dossier' do |button_label|
+      it 'renders a link to create a new dossier' do
+        subject
+        expect(rendered).to have_link(button_label, href: new_dossier_url(procedure_id: procedure.id))
+      end
+    end
+
+    context 'and they don’t have any dossier on this procedure' do
+      it_behaves_like 'it renders a link to create a new dossier', 'Commencer la démarche'
+    end
+
+    context 'and they have a pending draft' do
+      let!(:brouillon) { create(:dossier, user: user, procedure: procedure) }
+
+      it_behaves_like 'it renders a link to create a new dossier', 'Commencer un nouveau dossier'
+
+      it 'renders a link to resume the pending draft' do
+        subject
+        expect(rendered).to have_link('Continuer à remplir mon dossier', href: brouillon_dossier_path(brouillon))
+      end
+    end
+
+    context 'and they have a submitted dossier' do
+      let!(:brouillon) { create(:dossier, user: user, procedure: procedure) }
+      let!(:dossier) { create(:dossier, :en_construction, :for_individual, user: user, procedure: procedure) }
+
+      it_behaves_like 'it renders a link to create a new dossier', 'Commencer un nouveau dossier'
+
+      it 'renders a link to the submitted dossier' do
+        subject
+        expect(rendered).to have_link('Voir mon dossier', href: dossier_path(dossier))
+      end
+    end
+
+    context 'and they have several submitted dossiers' do
+      let!(:brouillon) { create(:dossier, user: user, procedure: procedure) }
+      let!(:dossiers) { create_list(:dossier, 2, :en_construction, :for_individual, user: user, procedure: procedure) }
+
+      it_behaves_like 'it renders a link to create a new dossier', 'Commencer un nouveau dossier'
+
+      it 'renders a link to the dossiers list' do
+        subject
+        expect(rendered).to have_link('Voir mes dossiers en cours', href: dossiers_path)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Hop, voici enfin la PR qui crée une page de garde pour les démarches.

Fonctionnellement, c'est similaire aux mockups de #2225.

Au niveau de l'implémentation, c'est assez simple : la plupart des lignes modifiées sont pour mettre à jour les test.

Pour la revue, malgré le côté impressionnant, ça se relit bien commit-par-commit. Et c'est assez bien testé, normalement.

## Démo : s'inscrire, puis commencer à remplir une démarche

![page-de-garde-inscription](https://user-images.githubusercontent.com/179923/51312615-fb26bc80-1a4b-11e9-9309-d2e344fe4ea5.gif)

## Démo : cliquer à nouveau sur le lien de la démarche, se connecter, reprendre son brouillon

![page-de-garde-connexion](https://user-images.githubusercontent.com/179923/51312623-feba4380-1a4b-11e9-8db3-f183c182a13f.gif)

Fix #2225, fix #2767, fix #1895, fix #194, fix #530, fix #314, and fix #312.