### PR TITLE
tasks: delete dossiers without procedures

### DIFF
--- a/app/controllers/admin/procedures_controller.rb
+++ b/app/controllers/admin/procedures_controller.rb
@@ -54,6 +54,7 @@ class Admin::ProceduresController < AdminController
       return render json: {}, status: 401
     end
 
+    procedure.reset!
     procedure.destroy
 
     flash.notice = 'Démarche supprimée'

--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -6,7 +6,7 @@ class Procedure < ApplicationRecord
   has_many :types_de_piece_justificative, -> { ordered }, dependent: :destroy
   has_many :types_de_champ, -> { root.public_only.ordered }, dependent: :destroy
   has_many :types_de_champ_private, -> { root.private_only.ordered }, class_name: 'TypeDeChamp', dependent: :destroy
-  has_many :dossiers
+  has_many :dossiers, dependent: :restrict_with_exception
   has_many :deleted_dossiers, dependent: :destroy
 
   has_one :module_api_carto, dependent: :destroy

--- a/lib/tasks/deployment/20190117154829_delete_dossiers_without_procedure.rake
+++ b/lib/tasks/deployment/20190117154829_delete_dossiers_without_procedure.rake
@@ -1,0 +1,25 @@
+require Rails.root.join("lib", "tasks", "task_helper")
+
+namespace :after_party do
+  desc 'Deployment task: delete_dossiers_without_procedure'
+  task delete_dossiers_without_procedure: :environment do
+    rake_puts "Running deploy task 'delete_dossiers_without_procedure'"
+
+    dossiers_without_procedure = Dossier.left_outer_joins(:procedure).where(procedures: { id: nil })
+    total = dossiers_without_procedure.count
+    expected_dossiers_count = 60
+
+    if total > expected_dossiers_count
+      raise "Error: #{expected_dossiers_count} dossiers expected, but found #{total}. Aborting."
+    end
+
+    dossiers_without_procedure.each do |dossier|
+      rake_puts "Destroy dossier #{dossier.id}"
+      dossier.destroy!
+    end
+
+    rake_puts "#{total} dossiers without procedure were destroyed."
+
+    AfterParty::TaskRecord.create version: '20190117154829'
+  end # task :delete_dossiers_without_procedure
+end # namespace :after_party

--- a/spec/controllers/admin/procedures_controller_spec.rb
+++ b/spec/controllers/admin/procedures_controller_spec.rb
@@ -97,24 +97,18 @@ describe Admin::ProceduresController, type: :controller do
 
     subject { delete :destroy, params: { id: procedure.id } }
 
-    context 'when procedure is draft' do
+    context 'when the procedure is a draft' do
       let!(:procedure) { procedure_draft }
 
-      describe 'tech params' do
-        before do
-          subject
-        end
-
-        it { expect(subject.status).to eq 302 }
-        it { expect(flash[:notice]).to be_present }
+      it 'destroys the procedure' do
+        expect { subject }.to change { Procedure.count }.by(-1)
       end
 
-      it 'destroy procedure is call' do
-        expect_any_instance_of(Procedure).to receive(:destroy)
+      it 'redirects to the procedure drafts page' do
         subject
+        expect(response).to redirect_to admin_procedures_draft_path
+        expect(flash[:notice]).to be_present
       end
-
-      it { expect { subject }.to change { Procedure.count }.by(-1) }
     end
 
     context 'when procedure is published' do

--- a/spec/lib/tasks/deployment/20190117154829_delete_dossiers_without_procedure.rake_spec.rb
+++ b/spec/lib/tasks/deployment/20190117154829_delete_dossiers_without_procedure.rake_spec.rb
@@ -1,0 +1,42 @@
+describe '20190117154829_delete_dossiers_without_procedure.rake' do
+  let(:rake_task) { Rake::Task['after_party:delete_dossiers_without_procedure'] }
+
+  subject do
+    rake_task.invoke
+  end
+
+  after do
+    rake_task.reenable
+  end
+
+  context 'when the procedure of some dossiers has been deleted' do
+    let!(:procedure1) { create(:procedure_with_dossiers, dossiers_count: 2) }
+    let!(:procedure2) { create(:procedure_with_dossiers, :published, dossiers_count: 2) }
+    let!(:procedure3) { create(:procedure_with_dossiers, :published, dossiers_count: 2) }
+    let!(:procedure4) { create(:procedure_with_dossiers, :archived, dossiers_count: 2) }
+
+    let(:procedure_2_dossier_ids) { procedure2.dossiers.pluck(:id) }
+
+    before do
+      procedure_2_dossier_ids
+      procedure2.delete
+      expect(procedure_2_dossier_ids.count).to eq(2)
+      expect(Dossier.find_by(id: procedure_2_dossier_ids.first).procedure).to be nil
+      expect(Dossier.find_by(id: procedure_2_dossier_ids.second).procedure).to be nil
+    end
+
+    it 'destroy dossiers without an existing procedure' do
+      subject
+      expect(Dossier.unscoped.find_by(id: procedure_2_dossier_ids.first)).to be nil
+      expect(Dossier.unscoped.find_by(id: procedure_2_dossier_ids.last)).to be nil
+    end
+
+    it 'doesn’t destroy other dossiers' do
+      subject
+      expect(Dossier.all.count).to eq(6)
+      expect(procedure1.reload.dossiers.count).to eq(2)
+      expect(procedure3.reload.dossiers.count).to eq(2)
+      expect(procedure4.reload.dossiers.count).to eq(2)
+    end
+  end
+end


### PR DESCRIPTION
Fix #3279 

J'ai d'abord fait une version qui faisait juste un `hidden_at` – mais je me suis dit que pour faire ensuite le hidden_at -> destroy, ça serait le même risque d'erreur.

Du coup j'ai préférer blinder cette version, avec des tests et un safeguard sur le nombre de dossiers.