### PR TITLE
Explain to administrateur why the attestation cannot be deactivated

### DIFF
--- a/app/views/admin/attestation_templates/edit.html.haml
+++ b/app/views/admin/attestation_templates/edit.html.haml
@@ -66,6 +66,12 @@
       = f.label :footer, 'Pied de page'
       = f.text_field :footer, class: 'form-control', maxlength: 190
 
+    - if @attestation_template.activated && @procedure.locked?
+      .row
+        .col-md-12
+          .pull-right
+            %p.help-block L’attestation ne peut plus être désactivée car la démarche a déjà été publiée.
+
     %button.btn.btn-primary{ formaction: admin_procedure_attestation_template_preview_path, formtarget: '_blank' } Prévisualiser
 
     .pull-right


### PR DESCRIPTION
Rajoute un texte d’aide au dessus du bouton « enregistrer » pour expliquer à l’administratrice ou administrateur pourquoi elle ou il ne peut plus désactiver l’attestation.

![capture d ecran de 2019-01-17 17-29-55](https://user-images.githubusercontent.com/356570/51333701-9afd3e00-1a7e-11e9-90cb-2abf18bc2fcc.png)
