### PR TITLE
Modification du texte d’information vers les pages d’information sur …

### DIFF
--- a/app/views/admin/procedures/_informations.html.haml
+++ b/app/views/admin/procedures/_informations.html.haml
@@ -20,8 +20,8 @@
     = f.number_field :duree_conservation_dossiers_hors_ds, class: 'form-control', placeholder: '6', required: true
 
 .form-group
-  %h4 Lien site internet
-  = f.text_field :lien_site_web, class: 'form-control', placeholder: 'https://www.exemple.fr/'
+  %h4 Où les usagers trouveront-ils le lien vers la démarche ?
+  = f.text_field :lien_site_web, class: 'form-control', placeholder: 'https://exemple.gouv.fr/ma_demarche'
 
 - if  Flipflop.web_hook?
   .form-group


### PR DESCRIPTION
…internet

Aujourd’hui, les administrateurs doivent proposer un lien vers un site internet dans la description de leur démarche.
Toutefois, l’adresse qui est la plus importante à connaître, est le lien vers la page du site institutionnel sur laquelle les usager vont trouver le lien vers la démarche.
Il est proposé de clarifier cette attente par une phrase plus précise. ( cela n'empêche pas de publier avec une adresse générique, car cette information n’est pas obligatoire, et être modifiée après publication).