### PR TITLE
commencer: add temporal context about the dossier

### DIFF
--- a/app/views/commencer/show.html.haml
+++ b/app/views/commencer/show.html.haml
@@ -15,13 +15,21 @@
       = link_to 'Commencer la démarche', url_for_new_dossier(@procedure), class: ['button large expand primary']
 
     - elsif drafts.count == 1 && not_drafts.count == 0
+      - dossier = drafts.first
       %h1 Vous avez déjà commencé à remplir un dossier
-      = link_to 'Continuer à remplir mon dossier', brouillon_dossier_path(drafts.first), class: ['button large expand primary']
+      %p
+        Il y a <strong>#{time_ago_in_words(dossier.created_at)}</strong>,
+        vous avez commencé à remplir un dossier sur la démarche « #{dossier.procedure.libelle} ».
+      = link_to 'Continuer à remplir mon dossier', brouillon_dossier_path(dossier), class: ['button large expand primary']
       = link_to 'Commencer un nouveau dossier', url_for_new_dossier(@procedure), class: ['button large expand']
 
     - elsif not_drafts.count == 1
+      - dossier = not_drafts.first
       %h1 Vous avez déjà déposé un dossier
-      = link_to 'Voir mon dossier', dossier_path(not_drafts.first), class: ['button large expand primary']
+      %p
+        Il y a <strong>#{time_ago_in_words(dossier.en_construction_at)}</strong>,
+        vous avez déposé un dossier sur la démarche « #{dossier.procedure.libelle} ».
+      = link_to 'Voir mon dossier déposé', dossier_path(dossier), class: ['button large expand primary']
       = link_to 'Commencer un nouveau dossier', url_for_new_dossier(@procedure), class: ['button large expand']
 
     - else

--- a/spec/views/commencer/show.html.haml_spec.rb
+++ b/spec/views/commencer/show.html.haml_spec.rb
@@ -45,6 +45,7 @@ RSpec.describe 'commencer/show.html.haml', type: :view do
 
       it 'renders a link to resume the pending draft' do
         subject
+        expect(rendered).to have_text(time_ago_in_words(brouillon.created_at))
         expect(rendered).to have_link('Continuer à remplir mon dossier', href: brouillon_dossier_path(brouillon))
       end
     end
@@ -57,6 +58,7 @@ RSpec.describe 'commencer/show.html.haml', type: :view do
 
       it 'renders a link to the submitted dossier' do
         subject
+        expect(rendered).to have_text(time_ago_in_words(dossier.en_construction_at))
         expect(rendered).to have_link('Voir mon dossier', href: dossier_path(dossier))
       end
     end


### PR DESCRIPTION
Ajout d'informations sur la durée de vie du dossier sur la page "Commencer".

## Quand l'usager a déjà un brouillon

![screenshot_2019-01-21 des sous par le siret demarches-simplifiees fr](https://user-images.githubusercontent.com/179923/51480043-4d3f4900-1d90-11e9-8556-59e4faba5feb.png)

## Quand l'usager a déjà un dossier déposé

![screenshot_2019-01-21 des sous par le siret demarches-simplifiees fr 1](https://user-images.githubusercontent.com/179923/51480045-503a3980-1d90-11e9-9062-002e2ee8abcd.png)

Ref #2225