### PR TITLE
commencer: increase description font size

### DIFF
--- a/app/assets/stylesheets/new_design/procedure_context.scss
+++ b/app/assets/stylesheets/new_design/procedure_context.scss
@@ -34,7 +34,7 @@ $procedure-context-breakpoint: $two-columns-breakpoint;
   }
 
   .procedure-description {
-    font-size: 14px;
+    font-size: 16px;
 
     p {
       margin-bottom: 2 * $default-spacer;


### PR DESCRIPTION
Dans le cadre de #3316, on commence déjà par une p'tite amélioration facile : rendre la description des démarches moins illisible.

## Avant

![screenshot_2019-01-22 deposer une offre de stage demarches-simplifiees fr 1](https://user-images.githubusercontent.com/179923/51538855-a1126680-1e52-11e9-9343-0467ee4b1e83.png)

## Après

![screenshot_2019-01-22 deposer une offre de stage demarches-simplifiees fr](https://user-images.githubusercontent.com/179923/51538864-a53e8400-1e52-11e9-9160-4f6742576402.png)
