### PR TITLE
analytics: send Matomo event when navigating using Turbolinks

### DIFF
--- a/app/views/layouts/_matomo.html.haml
+++ b/app/views/layouts/_matomo.html.haml
@@ -1,15 +1,34 @@
 :javascript
   var _paq = _paq || [];
-  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+  // Configure Matomo analytics
   _paq.push(["setCookieDomain", "*.www.demarches-simplifiees.fr"]);
   _paq.push(["setDomains", ["*.www.demarches-simplifiees.fr"]]);
   _paq.push(["setDoNotTrack", true]);
   _paq.push(['trackPageView']);
   _paq.push(['enableLinkTracking']);
+
+  // Load script from Matomo
   (function() {
     var u="//stats.data.gouv.fr/";
     _paq.push(['setTrackerUrl', u+'piwik.php']);
     _paq.push(['setSiteId', '73']);
     var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
     g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
+  })();
+
+  // Send Matomo a new event when navigating to a new page using Turbolinks
+  // (see https://developer.matomo.org/guides/spa-tracking)
+  (function() {
+    var previousPageUrl = null;
+    addEventListener('turbolinks:load', function(event) {
+      if (previousPageUrl) {
+        var loadTimeMs = event.data.timing.visitEnd - event.data.timing.visitStart;
+        _paq.push(['setReferrerUrl', previousPageUrl]);
+        _paq.push(['setCustomUrl', '/' + window.location.href]);
+        _paq.push(['setDocumentTitle', document.title]);
+        _paq.push(['setGenerationTimeMs', loadTimeMs]);
+        _paq.push(['trackPageView']);
+      }
+      previousPageUrl = window.location.href;
+    });
   })();


### PR DESCRIPTION
Aujourd'hui on a un script qui envoie des évènements d'analytics à Matomo – mais ce script rate une bonne partie des chargements de pages.

C'est parce que la plupart du temps, quand un utilisateur clique sur un lien, Rails charge la page en Javascript avec [Turbolinks](https://github.com/turbolinks/turbolinks) (plutôt que de faire une "vraie" navigation complète). Et Matomo passe complètement à côté de ça.

On ne remote donc à Matomo que la page d'entrée, mais pas les pages suivantes – ce qui fausse _un peu_ les statistiques 🙀 

Il faut donc signaler manuellement à Matomo qu'on a changé de page. En suivant la [doc de Matomo](https://developer.matomo.org/guides/spa-tracking) à ce sujet, j'ai implémenté le truc. Ça a l'air de bien fonctionner.

(Et quand on aura vérifié que ça fonctionne bien, j'irai mettre à jour [l'issue dans Turbolinks au sujet de Matomo](https://github.com/turbolinks/turbolinks/issues/436).)

/cc @chaibax 
