### PR TITLE
search: exclude more special characters

### DIFF
--- a/app/services/dossier_search_service.rb
+++ b/app/services/dossier_search_service.rb
@@ -39,7 +39,7 @@ class DossierSearchService
 
   def self.to_tsquery(search_terms)
     search_terms.strip
-      .gsub(/['?\\:&|!]/, "") # drop disallowed characters
+      .gsub(/['?\\:&|!<>\(\)]/, "") # drop disallowed characters
       .split(/\s+/)           # split words
       .map { |x| "#{x}:*" }   # enable prefix matching
       .join(" & ")

--- a/spec/services/dossier_search_service_spec.rb
+++ b/spec/services/dossier_search_service_spec.rb
@@ -90,5 +90,11 @@ describe DossierSearchService do
 
       it { expect(subject.size).to eq(1) }
     end
+
+    describe 'search with characters disallowed by the tsquery parser' do
+      let(:terms) { "'?\\:&!(OCTO) <plop>" }
+
+      it { expect(subject.size).to eq(1) }
+    end
   end
 end


### PR DESCRIPTION
On a encore des recherches Instructeur qui plantent sur des caractères spéciaux. ([Sentry](http://localhost:9006/sentry/ds-prod/issues/159/))

Après investigation, les caractères qu'on n'exclut pas encore et qui font planter la recherche sont `()<>`. On les rajoute donc à la blacklist.

@fredZen ça te va ?