### PR TITLE
brouillon: remove the "Delete draft" button

### DIFF
--- a/app/assets/stylesheets/new_design/forms.scss
+++ b/app/assets/stylesheets/new_design/forms.scss
@@ -311,8 +311,9 @@
         margin-left: $default-spacer;
       }
 
-      .button.danger {
-        margin-right: auto;
+      // If there are more than one button, align the "Send" button to the right
+      .button:not(:first-of-type).send {
+        margin-left: auto;
       }
     }
 
@@ -321,8 +322,7 @@
       flex-direction: column-reverse;
       align-items: center;
 
-      .button,
-      .button.danger {
+      .button {
         width: 100%;
         max-width: 350px;
         line-height: 30px;

--- a/app/views/new_user/dossiers/index.html.haml
+++ b/app/views/new_user/dossiers/index.html.haml
@@ -52,7 +52,7 @@
                   = dossier.updated_at.strftime("%d/%m/%Y")
               %td.action-col.delete-col
                 - if dossier.brouillon?
-                  = link_to(ask_deletion_dossier_path(dossier), method: :post, class: 'button danger', data: { disable: true, confirm: "En continuant, vous allez supprimer ce dossier ainsi que les informations qu’il contient. Toute suppression entraine l’annulation de la démarche en cours.\n\nConfirmer la suppression ?" }) do
+                  = link_to(ask_deletion_dossier_path(dossier), method: :post, class: 'button danger', data: { disable: true, confirm: "En continuant, vous allez supprimer ce dossier ainsi que les informations qu’il contient. Toute suppression entraine l’annulation de la démarche en cours.\n\nConfirmer la suppression ?" }) do
                     %span.icon.delete
                     Supprimer
     = paginate(@dossiers)

--- a/app/views/root/patron.html.haml
+++ b/app/views/root/patron.html.haml
@@ -40,7 +40,7 @@
         %input{ type: "password", value: "12345678" }
         .send-wrapper
           = f.submit 'Enregistrer un brouillon (formnovalidate)', formnovalidate: true, class: 'button send'
-          = f.submit 'Envoyer', class: 'button send'
+          = f.submit 'Envoyer', class: 'button send primary'
 
         %hr
 

--- a/app/views/shared/dossiers/_edit.html.haml
+++ b/app/views/shared/dossiers/_edit.html.haml
@@ -70,13 +70,6 @@
     - if !apercu
       .send-wrapper
         - if dossier.brouillon?
-          - if current_user.owns?(dossier)
-            = link_to ask_deletion_dossier_path(dossier),
-              method: :post,
-              class: 'button danger',
-              data: { disable: true, confirm: "En continuant, vous allez supprimer ce dossier ainsi que les informations qu’il contient. Toute suppression entraine l’annulation de la démarche en cours.\n\nConfirmer la suppression ?" } do
-              Supprimer le brouillon
-
           = f.button 'Enregistrer le brouillon',
             formnovalidate: true,
             name: :save_draft,

--- a/spec/features/new_user/brouillon_spec.rb
+++ b/spec/features/new_user/brouillon_spec.rb
@@ -112,20 +112,6 @@ feature 'The user' do
     expect(page).to have_current_path(merci_dossier_path(user_dossier))
   end
 
-  scenario 'delete a draft', js: true do
-    log_in(user.email, password, simple_procedure)
-    fill_individual
-
-    page.accept_alert('Confirmer la suppression ?') do
-      click_on 'Supprimer le brouillon'
-    end
-
-    expect(page).to have_current_path(dossiers_path)
-    expect(page).to have_text('Votre dossier a bien été supprimé')
-    expect(page).not_to have_text(user_dossier.procedure.libelle)
-    expect(user_dossier.reload.hidden_at).to be_present
-  end
-
   private
 
   def log_in(email, password, procedure)

--- a/spec/features/new_user/list_dossiers_spec.rb
+++ b/spec/features/new_user/list_dossiers_spec.rb
@@ -49,13 +49,13 @@ describe 'user access to the list of his dossier' do
     expect(page).not_to have_link(nil, href: ask_deletion_dossier_path(dossier1))
   end
 
-  context 'when user clicks on delete brouillon list', js: true do
-    before do
-      find(:xpath, "//a[@href='#{ask_deletion_dossier_path(dossier_brouillon)}']").click
-      page.driver.browser.switch_to.alert.accept
-    end
+  context 'when user clicks on delete brouillon', js: true do
     scenario 'dossier is deleted' do
-      expect(page).not_to have_link("Supprimer", href: dossier_brouillon.procedure.libelle)
+      page.accept_alert('Confirmer la suppression ?') do
+        find(:xpath, "//a[@href='#{ask_deletion_dossier_path(dossier_brouillon)}']").click
+      end
+
+      expect(page).to have_content('Votre dossier a bien été supprimé.')
     end
   end
 


### PR DESCRIPTION
Maintenant que les dossiers en brouillon peuvent être supprimés via la liste des dossiers, le bouton "Supprimer le brouillon" sur la page du formulaire n'a plus vraiment lieu d'être.

En plus il introduit du bruit cognitif : au moment où l'usager cherche à voir comment remplir son formulaire, on lui dit « Bon, tu peux déposer ton dossier, ou enregistrer le brouillon… OU LE SUPPRIMER, TIENS ! »

Bref, plus de simplicité, moins de bruit.

## Avant (écran large)

<img width="1076" alt="capture d ecran 2019-01-24 a 16 22 27" src="https://user-images.githubusercontent.com/179923/51688294-8d9f0100-1ff4-11e9-86e6-9fdc3d729650.png">

## Après (écran large)

<img width="1087" alt="capture d ecran 2019-01-24 a 16 19 31" src="https://user-images.githubusercontent.com/179923/51688301-91cb1e80-1ff4-11e9-97dd-85b6d4d94fa9.png">

## Avant (mobile)

<img width="363" alt="capture d ecran 2019-01-24 a 16 22 08" src="https://user-images.githubusercontent.com/179923/51688315-98599600-1ff4-11e9-9b78-f1631f5bf2dc.png">

## Après (mobile)

<img width="363" alt="capture d ecran 2019-01-24 a 16 21 45" src="https://user-images.githubusercontent.com/179923/51688317-9c85b380-1ff4-11e9-9913-073c7a422da1.png">
