### PR TITLE
Stats : amélioration du graphique de satisfaction

### DIFF
--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -129,9 +129,9 @@ class StatsController < ApplicationController
 
   def satisfaction_usagers
     legend = {
-      Feedback.ratings.fetch(:happy)    => "Satisfaits",
-      Feedback.ratings.fetch(:neutral)  => "Neutres",
-      Feedback.ratings.fetch(:unhappy)  => "Mécontents"
+      Feedback.ratings.fetch(:unhappy) => "Mécontents",
+      Feedback.ratings.fetch(:neutral) => "Neutres",
+      Feedback.ratings.fetch(:happy)   => "Satisfaits"
     }
 
     number_of_weeks = 6
@@ -139,7 +139,7 @@ class StatsController < ApplicationController
       .group_by_week(:created_at, last: number_of_weeks, current: false)
       .count
 
-    Feedback.ratings.values.map do |rating|
+    legend.keys.map do |rating|
       data = Feedback
         .where(rating: rating)
         .group_by_week(:created_at, last: number_of_weeks, current: false)

--- a/app/views/stats/index.html.haml
+++ b/app/views/stats/index.html.haml
@@ -27,6 +27,7 @@
         .chart
           = area_chart @satisfaction_usagers,
             stacked: true,
+            suffix: ' %',
             max: 100,
             colors: ["#BD0107", "#F28900", "#15AD70"]
 

--- a/app/views/stats/index.html.haml
+++ b/app/views/stats/index.html.haml
@@ -29,7 +29,8 @@
             stacked: true,
             suffix: ' %',
             max: 100,
-            colors: ["#BD0107", "#F28900", "#15AD70"]
+            library: { plotOptions: { series: { marker: { enabled: true }}}},
+            colors: ["#C31C25", "#F5962A", "#25B177"]
 
     .stat-card.stat-card-half.pull-left
       %span.stat-card-title

--- a/app/views/stats/index.html.haml
+++ b/app/views/stats/index.html.haml
@@ -25,8 +25,10 @@
 
       .chart-container
         .chart
-          = line_chart @satisfaction_usagers,
-            colors: ["#15AD70", "#F28900", "rgba(161, 0, 5, 0.9)"]
+          = area_chart @satisfaction_usagers,
+            stacked: true,
+            max: 100,
+            colors: ["#BD0107", "#F28900", "#15AD70"]
 
     .stat-card.stat-card-half.pull-left
       %span.stat-card-title

--- a/config/initializers/chartkick.rb
+++ b/config/initializers/chartkick.rb
@@ -1,5 +1,7 @@
 Chartkick.options = {
   content_for: :charts_js,
   defer: true,
-  colors: ["rgba(61, 149, 236, 1)"]
+  colors: ["rgba(61, 149, 236, 1)"],
+  thousands: ' ',
+  decimal: ','
 }


### PR DESCRIPTION
Le graphique de satisfaction est une somme de pourcentages normalisés : on affiche le pourcentage d'avis positifs, neutres et négatifs – et la somme fait 100 %.

Aujourd'hui ce n'est pas évident à lire : on a trois courbes, qui se croisent parfois, mais pas vraiment image que ce qui est important c'est la façon dont les courbes s'aditionnent.

Cette PR change un peu le graphique pour rendre ça plus lisible. Par exemple, on peut voir clairement l'évolution des satisfaits, ou des "satisfais + neutres".

Ça montre aussi que le but est de faire monter la partie verte, mais qu'elle ne sera jamais à 100%.

Moi ça me semble plus lisible. Vous, vous en pensez quoi ?

## Avant (avec données de test ne reflétant pas la réalité)

<img width="527" alt="capture d ecran 2019-01-28 a 15 18 08" src="https://user-images.githubusercontent.com/179923/51842161-8e93a380-2310-11e9-80fd-9a922ca28819.png">

## Après (avec données de test ne reflétant pas la réalité)

<img width="541" alt="capture d ecran 2019-01-28 a 15 21 37" src="https://user-images.githubusercontent.com/179923/51842169-92bfc100-2310-11e9-9968-09164398dc51.png">
