### PR TITLE
Balises pour les menus liés

### DIFF
--- a/app/models/champs/linked_drop_down_list_champ.rb
+++ b/app/models/champs/linked_drop_down_list_champ.rb
@@ -30,7 +30,7 @@ class Champs::LinkedDropDownListChamp < Champ
   end
 
   def to_s
-    value.present? ? [primary_value, secondary_value].compact.join(' / ') : ""
+    value.present? ? [primary_value, secondary_value].select(&:present?).join(' / ') : ""
   end
 
   def for_export

--- a/app/models/concerns/tags_substitution_concern.rb
+++ b/app/models/concerns/tags_substitution_concern.rb
@@ -167,12 +167,14 @@ module TagsSubstitutionConcern
   end
 
   def types_de_champ_tags(types_de_champ, available_for_states)
-    types_de_champ.map do |tdc|
-      {
-        libelle: tdc.libelle,
-        description: tdc.description,
-        available_for_states: available_for_states
-      }
+    types_de_champ.flat_map do |tdc|
+      [
+        {
+          libelle: tdc.libelle,
+          description: tdc.description,
+          available_for_states: available_for_states
+        }
+      ]
     end
   end
 

--- a/app/models/concerns/tags_substitution_concern.rb
+++ b/app/models/concerns/tags_substitution_concern.rb
@@ -195,34 +195,32 @@ module TagsSubstitutionConcern
 
   def replace_type_de_champ_tags(text, tags, dossier_champs)
     tags.inject(text) do |acc, tag|
-      champ = dossier_champs
-        .detect { |dossier_champ| dossier_champ.libelle == tag[:libelle] }
-
-      replace_tag(acc, tag, champ)
+      replace_tag(acc, tag, dossier_champs)
     end
   end
 
   def replace_tags_with_values_from_data(text, tags, data)
     if data.present?
       tags.inject(text) do |acc, tag|
-        if tag.key?(:target)
-          value = data.send(tag[:target])
-        else
-          value = instance_exec(data, &tag[:lambda])
-        end
-        replace_tag(acc, tag, value)
+        replace_tag(acc, tag, data)
       end
     else
       text
     end
   end
 
-  def replace_tag(text, tag, value)
+  def replace_tag(text, tag, data)
     libelle = Regexp.quote(tag[:libelle])
 
     # allow any kind of space (non-breaking or other) in the tag’s libellé to match any kind of space in the template
     # (the '\\ |' is there because plain ASCII spaces were escaped by preceding Regexp.quote)
     libelle.gsub!(/\\ |[[:blank:]]/, "[[:blank:]]")
+
+    if tag.key?(:target)
+      value = data.send(tag[:target])
+    else
+      value = instance_exec(data, &tag[:lambda])
+    end
 
     text.gsub(/--#{libelle}--/, value.to_s)
   end

--- a/app/models/concerns/tags_substitution_concern.rb
+++ b/app/models/concerns/tags_substitution_concern.rb
@@ -179,8 +179,8 @@ module TagsSubstitutionConcern
       return ''
     end
 
-    text = replace_type_de_champ_tags(text, filter_tags(champ_public_tags), dossier.champs)
-    text = replace_type_de_champ_tags(text, filter_tags(champ_private_tags), dossier.champs_private)
+    text = replace_tags_with_values_from_data(text, filter_tags(champ_public_tags), dossier.champs)
+    text = replace_tags_with_values_from_data(text, filter_tags(champ_private_tags), dossier.champs_private)
 
     tags_and_datas = [
       [dossier_tags, dossier],
@@ -191,12 +191,6 @@ module TagsSubstitutionConcern
     tags_and_datas
       .map { |(tags, data)| [filter_tags(tags), data] }
       .inject(text) { |acc, (tags, data)| replace_tags_with_values_from_data(acc, tags, data) }
-  end
-
-  def replace_type_de_champ_tags(text, tags, dossier_champs)
-    tags.inject(text) do |acc, tag|
-      replace_tag(acc, tag, dossier_champs)
-    end
   end
 
   def replace_tags_with_values_from_data(text, tags, data)

--- a/app/models/concerns/tags_substitution_concern.rb
+++ b/app/models/concerns/tags_substitution_concern.rb
@@ -167,15 +167,11 @@ module TagsSubstitutionConcern
   end
 
   def types_de_champ_tags(types_de_champ, available_for_states)
-    types_de_champ.flat_map do |tdc|
-      [
-        {
-          libelle: tdc.libelle,
-          description: tdc.description,
-          available_for_states: available_for_states
-        }
-      ]
+    tags = types_de_champ.flat_map(&:tags_for_template)
+    tags.each do |tag|
+      tag[:available_for_states] = available_for_states
     end
+    tags
   end
 
   def replace_tags(text, dossier)

--- a/app/models/concerns/tags_substitution_concern.rb
+++ b/app/models/concerns/tags_substitution_concern.rb
@@ -193,8 +193,8 @@ module TagsSubstitutionConcern
       .inject(text) { |acc, (tags, data)| replace_tags_with_values_from_data(acc, tags, data) }
   end
 
-  def replace_type_de_champ_tags(text, types_de_champ, dossier_champs)
-    types_de_champ.inject(text) do |acc, tag|
+  def replace_type_de_champ_tags(text, tags, dossier_champs)
+    tags.inject(text) do |acc, tag|
       champ = dossier_champs
         .detect { |dossier_champ| dossier_champ.libelle == tag[:libelle] }
 

--- a/app/models/concerns/tags_substitution_concern.rb
+++ b/app/models/concerns/tags_substitution_concern.rb
@@ -179,10 +179,9 @@ module TagsSubstitutionConcern
       return ''
     end
 
-    text = replace_tags_with_values_from_data(text, filter_tags(champ_public_tags), dossier.champs)
-    text = replace_tags_with_values_from_data(text, filter_tags(champ_private_tags), dossier.champs_private)
-
     tags_and_datas = [
+      [champ_public_tags, dossier.champs],
+      [champ_private_tags, dossier.champs_private],
       [dossier_tags, dossier],
       [INDIVIDUAL_TAGS, dossier.individual],
       [ENTREPRISE_TAGS, dossier.etablissement&.entreprise]

--- a/app/models/concerns/tags_substitution_concern.rb
+++ b/app/models/concerns/tags_substitution_concern.rb
@@ -196,8 +196,7 @@ module TagsSubstitutionConcern
   def replace_type_de_champ_tags(text, types_de_champ, dossier_champs)
     types_de_champ.inject(text) do |acc, tag|
       champ = dossier_champs
-        .select { |dossier_champ| dossier_champ.libelle == tag[:libelle] }
-        .first
+        .detect { |dossier_champ| dossier_champ.libelle == tag[:libelle] }
 
       replace_tag(acc, tag, champ)
     end

--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -174,6 +174,15 @@ class TypeDeChamp < ApplicationRecord
     end
   end
 
+  def tags_for_template
+    [
+      {
+        libelle: libelle,
+        description: description
+      }
+    ]
+  end
+
   private
 
   def setup_procedure

--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -38,6 +38,7 @@ class TypeDeChamp < ApplicationRecord
   has_many :types_de_champ, -> { ordered }, foreign_key: :parent_id, class_name: 'TypeDeChamp', dependent: :destroy
 
   store_accessor :options, :cadastres, :quartiers_prioritaires, :parcelles_agricoles, :old_pj
+  delegate :tags_for_template, to: :dynamic_type
 
   # TODO simplify after migrating `options` column to (non YAML encoded) JSON
   class MaybeYaml
@@ -172,19 +173,6 @@ class TypeDeChamp < ApplicationRecord
     if piece_justificative_template.attached?
       piece_justificative_template.filename
     end
-  end
-
-  def tags_for_template
-    l = libelle
-    [
-      {
-        libelle: l,
-        description: description,
-        lambda: -> (champs) {
-          champs.detect { |champ| champ.libelle == l }
-        }
-      }
-    ]
   end
 
   private

--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -175,10 +175,14 @@ class TypeDeChamp < ApplicationRecord
   end
 
   def tags_for_template
+    l = libelle
     [
       {
-        libelle: libelle,
-        description: description
+        libelle: l,
+        description: description,
+        lambda: -> (champs) {
+          champs.detect { |champ| champ.libelle == l }
+        }
       }
     ]
   end

--- a/app/models/types_de_champ/linked_drop_down_list_type_de_champ.rb
+++ b/app/models/types_de_champ/linked_drop_down_list_type_de_champ.rb
@@ -21,6 +21,34 @@ class TypesDeChamp::LinkedDropDownListTypeDeChamp < TypesDeChamp::TypeDeChampBas
     secondary_options
   end
 
+  def tags_for_template
+    tags = super
+    l = libelle
+    tags.push(
+      {
+        libelle: "#{l}/primaire",
+        description: "#{description} (menu primaire)",
+        lambda: -> (champs) {
+          champs
+            .detect { |champ| champ.libelle == l }
+            &.primary_value
+        }
+      }
+    )
+    tags.push(
+      {
+        libelle: "#{l}/secondaire",
+        description: "#{description} (menu secondaire)",
+        lambda: -> (champs) {
+          champs
+            .detect { |champ| champ.libelle == l }
+            &.secondary_value
+        }
+      }
+    )
+    tags
+  end
+
   private
 
   def check_presence_of_primary_options

--- a/app/models/types_de_champ/type_de_champ_base.rb
+++ b/app/models/types_de_champ/type_de_champ_base.rb
@@ -1,9 +1,22 @@
 class TypesDeChamp::TypeDeChampBase
   include ActiveModel::Validations
 
-  delegate :libelle, to: :@type_de_champ
+  delegate :description, :libelle, to: :@type_de_champ
 
   def initialize(type_de_champ)
     @type_de_champ = type_de_champ
+  end
+
+  def tags_for_template
+    l = libelle
+    [
+      {
+        libelle: l,
+        description: description,
+        lambda: -> (champs) {
+          champs.detect { |champ| champ.libelle == l }
+        }
+      }
+    ]
   end
 end

--- a/spec/models/concern/tags_substitution_concern_spec.rb
+++ b/spec/models/concern/tags_substitution_concern_spec.rb
@@ -129,7 +129,7 @@ describe TagsSubstitutionConcern, type: :model do
           c.primary_value = 'primo'
           c.save
         end
-        it { is_expected.to eq('tout : primo / , primaire : primo, secondaire : ') }
+        it { is_expected.to eq('tout : primo, primaire : primo, secondaire : ') }
       end
 
       context 'and the champ has a primary and secondary value' do

--- a/spec/models/concern/tags_substitution_concern_spec.rb
+++ b/spec/models/concern/tags_substitution_concern_spec.rb
@@ -110,6 +110,40 @@ describe TagsSubstitutionConcern, type: :model do
       end
     end
 
+    context 'when the procedure has a linked drop down menus type de champ' do
+      let(:types_de_champ) do
+        [
+          create(:type_de_champ_linked_drop_down_list, libelle: 'libelle')
+        ]
+      end
+
+      let(:template) { 'tout : --libelle--, primaire : --libelle/primaire--, secondaire : --libelle/secondaire--' }
+
+      context 'and the champ has no value' do
+        it { is_expected.to eq('tout : , primaire : , secondaire : ') }
+      end
+
+      context 'and the champ has a primary value' do
+        before do
+          c = dossier.champs.detect { |champ| champ.libelle == 'libelle' }
+          c.primary_value = 'primo'
+          c.save
+        end
+        it { is_expected.to eq('tout : primo / , primaire : primo, secondaire : ') }
+      end
+
+      context 'and the champ has a primary and secondary value' do
+        before do
+          c = dossier.champs.detect { |champ| champ.libelle == 'libelle' }
+          c.primary_value = 'primo'
+          c.secondary_value = 'secundo'
+          c.save
+        end
+
+        it { is_expected.to eq('tout : primo / secundo, primaire : primo, secondaire : secundo') }
+      end
+    end
+
     context 'when the dossier has a motivation' do
       let(:dossier) { create(:dossier, motivation: 'motivation') }
 


### PR DESCRIPTION
On avait déjà une balise `--libellé--` qui sortait le choix fait dans les deux menus, au le format `primaire / secondaire`

Cette PR
- ajoute les balises `--libellé/primaire--` et `--libellé/secondaire--` qui ne sortent respectivement que le choix fait dans le menu primaire ou secondaire
- améliore le formatage de la balise `--libellé--` dans le cas où seule une entrée de menu primaire a été sélectionnée : avant ça sortait `primaire / `, maintenant ça sort `primaire`