### PR TITLE
carto: properly handle RestClient::ServiceUnavailable exceptions

### DIFF
--- a/app/lib/api_carto/api.rb
+++ b/app/lib/api_carto/api.rb
@@ -15,7 +15,7 @@ class ApiCarto::API
     params = geojson.to_s
     RestClient.post(url, params, content_type: 'application/json')
 
-  rescue RestClient::InternalServerError, RestClient::BadGateway, RestClient::GatewayTimeout => e
+  rescue RestClient::InternalServerError, RestClient::BadGateway, RestClient::GatewayTimeout, RestClient::ServiceUnavailable => e
     Rails.logger.error "[ApiCarto] Error on #{url}: #{e}"
     raise RestClient::ResourceNotFound
   end


### PR DESCRIPTION
Depuis #3332 on gère proprement les erreurs d'API carto.

Mais il y en a une que j'ai oublié de gérer : quand l'API carto renvoie une `RestClient::ServiceUnavailable`, on crashe salement et on logue une erreur dans Sentry.

Cette PR fait en sorte de gérer les exceptions `RestClient::ServiceUnavailable` de l'API carto de la même manière que les autres.

Fix http://localhost:9006/sentry/ds-prod/issues/200/activity/