### PR TITLE
Affiche le bouton pour supprimer un dossier en construction

### DIFF
--- a/app/controllers/new_user/dossiers_controller.rb
+++ b/app/controllers/new_user/dossiers_controller.rb
@@ -188,7 +188,7 @@ module NewUser
     def ask_deletion
       dossier = current_user.dossiers.includes(:user, procedure: :administrateur).find(params[:id])
 
-      if !dossier.instruction_commencee?
+      if dossier.can_be_deleted_by_user?
         dossier.delete_and_keep_track
         flash.notice = 'Votre dossier a bien été supprimé.'
         redirect_to dossiers_path

--- a/app/controllers/new_user/dossiers_controller.rb
+++ b/app/controllers/new_user/dossiers_controller.rb
@@ -257,7 +257,7 @@ module NewUser
     end
 
     def ensure_dossier_can_be_updated
-      if !dossier.can_be_updated_by_the_user?
+      if !dossier.can_be_updated_by_user?
         flash.alert = 'Votre dossier ne peut plus être modifié'
         redirect_to dossiers_path
       end

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -170,6 +170,10 @@ class Dossier < ApplicationRecord
     brouillon? || en_construction?
   end
 
+  def can_be_deleted_by_user?
+    brouillon? || en_construction?
+  end
+
   def retention_end_date
     if instruction_commencee?
       en_instruction_at + procedure.duree_conservation_dossiers_dans_ds.months

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -166,7 +166,7 @@ class Dossier < ApplicationRecord
     !procedure.archivee? && brouillon?
   end
 
-  def can_be_updated_by_the_user?
+  def can_be_updated_by_user?
     brouillon? || en_construction?
   end
 

--- a/app/views/new_user/dossiers/index.html.haml
+++ b/app/views/new_user/dossiers/index.html.haml
@@ -51,7 +51,7 @@
                 = link_to(url_for_dossier(dossier), class: 'cell-link') do
                   = dossier.updated_at.strftime("%d/%m/%Y")
               %td.action-col.delete-col
-                - if dossier.brouillon?
+                - if dossier.can_be_deleted_by_user?
                   = link_to(ask_deletion_dossier_path(dossier), method: :post, class: 'button danger', data: { disable: true, confirm: "En continuant, vous allez supprimer ce dossier ainsi que les informations qu’il contient. Toute suppression entraine l’annulation de la démarche en cours.\n\nConfirmer la suppression ?" }) do
                     %span.icon.delete
                     Supprimer

--- a/spec/controllers/new_user/dossiers_controller_spec.rb
+++ b/spec/controllers/new_user/dossiers_controller_spec.rb
@@ -798,13 +798,13 @@ describe NewUser::DossiersController, type: :controller do
     subject { post :ask_deletion, params: { id: dossier.id } }
 
     shared_examples_for "the dossier can not be deleted" do
-      it do
+      it "doesn’t notify the deletion" do
         expect(DossierMailer).not_to receive(:notify_deletion_to_administration)
         expect(DossierMailer).not_to receive(:notify_deletion_to_user)
         subject
       end
 
-      it do
+      it "doesn’t delete the dossier" do
         subject
         expect(Dossier.find_by(id: dossier.id)).not_to eq(nil)
         expect(dossier.procedure.deleted_dossiers.count).to eq(0)
@@ -814,13 +814,13 @@ describe NewUser::DossiersController, type: :controller do
     context 'when dossier is owned by signed in user' do
       let(:dossier) { create(:dossier, :en_construction, user: user, autorisation_donnees: true) }
 
-      it do
+      it "notifies the user and the admin of the deletion" do
         expect(DossierMailer).to receive(:notify_deletion_to_administration).with(kind_of(DeletedDossier), dossier.procedure.administrateur.email).and_return(double(deliver_later: nil))
         expect(DossierMailer).to receive(:notify_deletion_to_user).with(kind_of(DeletedDossier), dossier.user.email).and_return(double(deliver_later: nil))
         subject
       end
 
-      it do
+      it "deletes the dossier" do
         procedure = dossier.procedure
         dossier_id = dossier.id
         subject

--- a/spec/features/new_user/list_dossiers_spec.rb
+++ b/spec/features/new_user/list_dossiers_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'user access to the list of his dossier' do
   let(:user) { create(:user) }
   let!(:last_updated_dossier) { create(:dossier, :with_entreprise, user: user, state: Dossier.states.fetch(:en_construction)) }
-  let!(:dossier1) { create(:dossier, :with_entreprise, user: user, state: Dossier.states.fetch(:en_construction)) }
+  let!(:dossier1) { create(:dossier, :with_entreprise, user: user, state: Dossier.states.fetch(:en_instruction)) }
   let!(:dossier2) { create(:dossier, :with_entreprise) }
   let!(:dossier_brouillon) { create(:dossier, :with_entreprise, user: user) }
   let!(:dossier_archived) { create(:dossier, :with_entreprise, user: user, state: Dossier.states.fetch(:en_construction)) }

--- a/spec/features/new_user/list_dossiers_spec.rb
+++ b/spec/features/new_user/list_dossiers_spec.rb
@@ -1,13 +1,13 @@
 require 'spec_helper'
 
-describe 'user access to the list of his dossier' do
+describe 'user access to the list of their dossiers' do
   let(:user) { create(:user) }
-  let!(:last_updated_dossier) { create(:dossier, :with_entreprise, user: user, state: Dossier.states.fetch(:en_construction)) }
-  let!(:dossier1) { create(:dossier, :with_entreprise, user: user, state: Dossier.states.fetch(:en_instruction)) }
-  let!(:dossier2) { create(:dossier, :with_entreprise) }
-  let!(:dossier_brouillon) { create(:dossier, :with_entreprise, user: user) }
-  let!(:dossier_archived) { create(:dossier, :with_entreprise, user: user, state: Dossier.states.fetch(:en_construction)) }
+  let!(:dossier_brouillon)       { create(:dossier, user: user) }
+  let!(:dossier_en_construction) { create(:dossier, :en_construction, user: user) }
+  let!(:dossier_en_instruction)  { create(:dossier, :en_instruction, user: user) }
+  let!(:dossier_archived)        { create(:dossier, :en_instruction, :archived, user: user) }
   let(:dossiers_per_page) { 25 }
+  let(:last_updated_dossier) { dossier_en_construction }
 
   before do
     @default_per_page = Dossier.default_per_page
@@ -15,12 +15,8 @@ describe 'user access to the list of his dossier' do
 
     last_updated_dossier.update_column(:updated_at, "19/07/2052 15:35".to_time)
 
-    visit new_user_session_path
-    within('#new_user') do
-      page.find_by_id('user_email').set user.email
-      page.find_by_id('user_password').set user.password
-      page.click_on 'Se connecter'
-    end
+    login_as user, scope: :user
+    visit dossiers_path
   end
 
   after do
@@ -28,52 +24,59 @@ describe 'user access to the list of his dossier' do
   end
 
   it 'the list of dossier is displayed' do
-    expect(page).to have_content(dossier1.procedure.libelle)
-    expect(page).to have_content('en construction')
-  end
-
-  it 'dossiers belonging to other users are not displayed' do
-    expect(page).not_to have_content(dossier2.procedure.libelle)
-  end
-
-  it 'the list must be ordered by last updated' do
-    expect(page.body).to match(/#{last_updated_dossier.procedure.libelle}.*#{dossier1.procedure.libelle}/m)
-  end
-
-  it 'should list archived dossiers' do
+    expect(page).to have_content(dossier_brouillon.procedure.libelle)
+    expect(page).to have_content(dossier_en_construction.procedure.libelle)
+    expect(page).to have_content(dossier_en_instruction.procedure.libelle)
     expect(page).to have_content(dossier_archived.procedure.libelle)
   end
 
-  it 'should have link to only delete brouillon' do
-    expect(page).to have_link(nil, href: ask_deletion_dossier_path(dossier_brouillon))
-    expect(page).not_to have_link(nil, href: ask_deletion_dossier_path(dossier1))
+  it 'the list must be ordered by last updated' do
+    expect(page.body).to match(/#{last_updated_dossier.procedure.libelle}.*#{dossier_en_instruction.procedure.libelle}/m)
   end
 
-  context 'when user clicks on delete brouillon', js: true do
-    scenario 'dossier is deleted' do
-      page.accept_alert('Confirmer la suppression ?') do
-        find(:xpath, "//a[@href='#{ask_deletion_dossier_path(dossier_brouillon)}']").click
-      end
+  context 'when there are dossiers from other users' do
+    let!(:dossier_other_user) { create(:dossier) }
 
-      expect(page).to have_content('Votre dossier a bien été supprimé.')
-    end
-  end
-
-  context 'when user clicks on a projet in list', js: true do
-    before do
-      page.click_on(dossier1.procedure.libelle)
-    end
-    scenario 'user is redirected to dossier page' do
-      expect(page).to have_current_path(dossier_path(dossier1))
+    it 'doesn’t display dossiers belonging to other users' do
+      expect(page).not_to have_content(dossier_other_user.procedure.libelle)
     end
   end
 
   context 'when there is more than one page' do
     let(:dossiers_per_page) { 2 }
 
-    scenario 'the user can navigate through the other pages', js: true do
+    scenario 'the user can navigate through the other pages' do
+      expect(page).not_to have_content(dossier_en_instruction.procedure.libelle)
       page.click_link("Suivant")
-      expect(page).to have_content(dossier_archived.procedure.libelle)
+      expect(page).to have_content(dossier_en_instruction.procedure.libelle)
+    end
+  end
+
+  context 'when user clicks on a projet in list' do
+    before do
+      page.click_on(dossier_en_construction.procedure.libelle)
+    end
+
+    scenario 'user is redirected to dossier page' do
+      expect(page).to have_current_path(dossier_path(dossier_en_construction))
+    end
+  end
+
+  describe 'deletion' do
+    it 'should have links to delete dossiers' do
+      expect(page).to have_link(nil, href: ask_deletion_dossier_path(dossier_brouillon))
+      expect(page).to have_link(nil, href: ask_deletion_dossier_path(dossier_en_construction))
+      expect(page).not_to have_link(nil, href: ask_deletion_dossier_path(dossier_en_instruction))
+    end
+
+    context 'when user clicks on delete button', js: true do
+      scenario 'the dossier is deleted' do
+        page.accept_alert('Confirmer la suppression ?') do
+          find(:xpath, "//a[@href='#{ask_deletion_dossier_path(dossier_brouillon)}']").click
+        end
+
+        expect(page).to have_content('Votre dossier a bien été supprimé.')
+      end
     end
   end
 
@@ -91,25 +94,27 @@ describe 'user access to the list of his dossier' do
     end
 
     context "when the dossier does not belong to the user" do
+      let!(:dossier_other_user) { create(:dossier) }
+
       before do
-        page.find_by_id('dossier_id').set(dossier2.id)
+        page.find_by_id('dossier_id').set(dossier_other_user.id)
         click_button("Rechercher")
       end
 
       it "shows an error message on the dossiers page" do
         expect(current_path).to eq(dossiers_path)
-        expect(page).to have_content("Vous n’avez pas de dossier avec le nº #{dossier2.id}.")
+        expect(page).to have_content("Vous n’avez pas de dossier avec le nº #{dossier_other_user.id}.")
       end
     end
 
     context "when the dossier belongs to the user" do
       before do
-        page.find_by_id('dossier_id').set(dossier1.id)
+        page.find_by_id('dossier_id').set(dossier_en_construction.id)
         click_button("Rechercher")
       end
 
       it "redirects to the dossier page" do
-        expect(current_path).to eq(dossier_path(dossier1))
+        expect(current_path).to eq(dossier_path(dossier_en_construction))
       end
     end
   end


### PR DESCRIPTION
Aujourd'hui on a une incohérence : le controller de dossiers permet de supprimer un dossier en construction, mais pas la vue.

Cette PR harmonise le comportement des deux derrière une méthode `Dossier#can_be_deleted_by_user?`, qui est utilisée dans les deux cas, et permet d'afficher le bouton "Supprimer" pour les dossiers en construction.

Au passage, je refactore également les tests d'intégration de la liste des dossiers, qui avaient besoin d'amour.

Fix #3354