### PR TITLE
autocomplete: fix initialization happening several times

### DIFF
--- a/app/javascript/shared/autocomplete.js
+++ b/app/javascript/shared/autocomplete.js
@@ -48,9 +48,8 @@ addEventListener('ajax:success', function() {
 function autocompleteSetup() {
   for (let { type, url } of sources) {
     for (let element of document.querySelectorAll(selector(type))) {
-      if (!element.dataset.autocompleteInitialized) {
-        autocompleteInitializeElement(element, url);
-      }
+      element.removeAttribute('data-autocomplete');
+      autocompleteInitializeElement(element, url);
     }
   }
 }
@@ -61,5 +60,4 @@ function autocompleteInitializeElement(element, url) {
     fire(target, 'autocomplete:select', suggestion);
     select.autocomplete.setVal(suggestion.label);
   });
-  element.dataset.autocompleteInitialized = true;
 }


### PR DESCRIPTION
En fait la solution que j'ai proposé est cassée, pour deux raisons :

- l'autocomplete remplace complètement l'élément (donc on ne peut pas conserver de data attribute dessus)
- l'autocomplete crée des éléments enfants qui matchent notre sélecteur.

Deux solutions possibles :

1. Exclure les éléments déjà initialisés, en matchant le CSS d'autocomplete.js
2. Rendre notre sélecteur à nous plus spécifique, pour ne matcher que nos éléments.

Je suis parti avec la solution 1. dans cette PR, mais ça me semble fragile. Je vais y réfléchir.