### PR TITLE
README: mention rbenv as a dev dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Vous souhaitez y apporter des changements ou des améliorations ? Lisez notre [
 
 #### Développement
 
+- rbenv : voir https://github.com/rbenv/rbenv-installer#rbenv-installer--doctor-scripts
 - Yarn : voir https://yarnpkg.com/en/docs/install
 - Overmind :
   * Mac : `brew install overmind`


### PR DESCRIPTION
Pour l'instant le README explique comment installer toutes les dépendances – sauf la principale : Ruby.

Le mieux est sans doute de recommander `rbenv`, qui permet d'avoir un ruby par utilisateur (plutôt que d'utiliser le ruby du système), et donc de faire `gem install` et `bundle install` sans avoir besoin de `sudo`.