### PR TITLE
Add ruby debugger support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ storage/
 /node_modules
 yarn-debug.log*
 .yarn-integrity
+/.vscode

--- a/Gemfile
+++ b/Gemfile
@@ -99,6 +99,7 @@ group :development, :test do
   gem 'pry-byebug'
   gem 'rspec-rails'
   gem 'rspec_junit_formatter'
+  gem 'ruby-debug-ide', require: false
   gem 'spring' # Spring speeds up development by keeping your application running in the background
   gem 'spring-commands-rspec'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -510,6 +510,8 @@ GEM
       unicode-display_width (~> 1.4.0)
     rubocop-rspec-focused (1.0.0)
       rubocop (>= 0.51)
+    ruby-debug-ide (0.6.1)
+      rake (>= 0.8.1)
     ruby-progressbar (1.10.0)
     ruby_dep (1.5.0)
     ruby_parser (3.12.0)
@@ -713,6 +715,7 @@ DEPENDENCIES
   rspec_junit_formatter
   rubocop
   rubocop-rspec-focused
+  ruby-debug-ide
   sanitize-url
   sassc-rails
   scenic


### PR DESCRIPTION
Ça permet d'avoir du debug dans VS Code

Solution alternative est d’ajouter `.vscode` à git ignore et il est peut-être possible d'installer `ruby-debug-ide` en global...