### PR TITLE
Affichage de la surface cadastrale dans les cartes

### DIFF
--- a/app/assets/stylesheets/new_design/common.scss
+++ b/app/assets/stylesheets/new_design/common.scss
@@ -53,6 +53,11 @@ strong {
   font-weight: bold;
 }
 
+sup {
+  vertical-align: super;
+  font-size: 0.83em;
+}
+
 .container {
   @include horizontal-padding($default-padding);
   max-width: $page-width + 2 * $default-padding;

--- a/app/views/shared/champs/carte/_geo_areas.html.haml
+++ b/app/views/shared/champs/carte/_geo_areas.html.haml
@@ -24,7 +24,7 @@
     - else
       %ul
         - champ.cadastres.each do |pc|
-          %li Parcelle n° #{pc.numero} - Feuille #{pc.code_arr} #{pc.section} #{pc.feuille}
+          %li Parcelle n° #{pc.numero} - Feuille #{pc.code_arr} #{pc.section} #{pc.feuille} - #{pc.surface_parcelle.round} m<sup>2</sup>
 
 - if champ.parcelles_agricoles?
   .areas-title Parcelles agricoles (RPG)


### PR DESCRIPTION
L'issue associée: https://github.com/betagouv/tps/issues/3403
Grace au partial _geo_areas l'affichage a lieu aussi bien dans un dossier déposé que dans un dossier en cours d'édition.
J'ai du [re-styler](https://stackoverflow.com/a/501696) la balise sup, dont le comportement était effacé par le reset CSS.

Le rendu:
![image](https://user-images.githubusercontent.com/1223316/52650537-baa34d00-2eea-11e9-8631-87f49fd68d21.png)
