### PR TITLE
matomo: fix JS error when timing data are not available

### DIFF
--- a/app/views/layouts/_matomo.html.haml
+++ b/app/views/layouts/_matomo.html.haml
@@ -22,11 +22,12 @@
     var previousPageUrl = null;
     addEventListener('turbolinks:load', function(event) {
       if (previousPageUrl) {
-        var loadTimeMs = event.data.timing.visitEnd - event.data.timing.visitStart;
         _paq.push(['setReferrerUrl', previousPageUrl]);
         _paq.push(['setCustomUrl', '/' + window.location.href]);
         _paq.push(['setDocumentTitle', document.title]);
-        _paq.push(['setGenerationTimeMs', loadTimeMs]);
+        if (event.data && event.data.timing) {
+          _paq.push(['setGenerationTimeMs', event.data.timing.visitEnd - event.data.timing.visitStart]);
+        }
         _paq.push(['trackPageView']);
       }
       previousPageUrl = window.location.href;


### PR DESCRIPTION
Happened when navigating on IE 11 for some reason.