### PR TITLE
2019-02-14-02

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ storage/
 /node_modules
 yarn-debug.log*
 .yarn-integrity
+/.vscode

--- a/Gemfile
+++ b/Gemfile
@@ -99,6 +99,7 @@ group :development, :test do
   gem 'pry-byebug'
   gem 'rspec-rails'
   gem 'rspec_junit_formatter'
+  gem 'ruby-debug-ide', require: false
   gem 'spring' # Spring speeds up development by keeping your application running in the background
   gem 'spring-commands-rspec'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -510,6 +510,8 @@ GEM
       unicode-display_width (~> 1.4.0)
     rubocop-rspec-focused (1.0.0)
       rubocop (>= 0.51)
+    ruby-debug-ide (0.6.1)
+      rake (>= 0.8.1)
     ruby-progressbar (1.10.0)
     ruby_dep (1.5.0)
     ruby_parser (3.12.0)
@@ -713,6 +715,7 @@ DEPENDENCIES
   rspec_junit_formatter
   rubocop
   rubocop-rspec-focused
+  ruby-debug-ide
   sanitize-url
   sassc-rails
   scenic

--- a/app/lib/active_storage/service/ds_proxy_service.rb
+++ b/app/lib/active_storage/service/ds_proxy_service.rb
@@ -27,7 +27,7 @@ module ActiveStorage
 
     def publicize(url)
       search = %r{^https://[^/]+/v1/AUTH_[a-f0-9]{32}}
-      replace = "https://#{ENV['APP_HOST']}/direct-upload"
+      replace = 'https://static.demarches-simplifiees.fr'
       url.gsub(search, replace)
     end
   end

--- a/app/lib/active_storage/service/ds_proxy_service.rb
+++ b/app/lib/active_storage/service/ds_proxy_service.rb
@@ -27,7 +27,7 @@ module ActiveStorage
 
     def publicize(url)
       search = %r{^https://[^/]+/v1/AUTH_[a-f0-9]{32}}
-      replace = 'https://static.demarches-simplifiees.fr'
+      replace = "https://#{ENV['APP_HOST']}/direct-upload"
       url.gsub(search, replace)
     end
   end

--- a/app/views/new_user/dossiers/index.html.haml
+++ b/app/views/new_user/dossiers/index.html.haml
@@ -5,8 +5,6 @@
 
 .dossiers-headers.sub-header
   .container
-    = link_to "Commencer une nouvelle démarche", demarches_url, class: "button secondary new-demarche"
-
     - if @dossiers_invites.count == 0
       %h1.page-title Mes dossiers
 
@@ -71,5 +69,7 @@
   - else
     .blank-tab
       %h2.empty-text Aucun dossier.
-      %p.empty-text-details Vous n’avez pas encore commencé de démarche.
-      = link_to "Commencer une nouvelle démarche", demarches_url, class: "button primary"
+      %p.empty-text-details
+        Pour remplir une démarche, contactez votre administration en lui demandant le lien de la démarche.
+        %br
+        Celui ci doit ressembler à https://www.demarches-simplifiees.fr/commencer/xxx.

--- a/spec/lib/active_storage/service/ds_proxy_service.rb
+++ b/spec/lib/active_storage/service/ds_proxy_service.rb
@@ -1,17 +1,20 @@
 describe ActiveStorage::Service::DsProxyService do
   let(:private_host) { 'storage.sbg1.cloud.ovh.net:443' }
-  let(:public_host) { 'static.demarches-simplifiees.fr' }
+  let(:public_host) { 'www.demarches-simplifiees.fr' }
   let(:auth) { 'AUTH_a24c37ed11a84896914514384898c34b' }
   let(:bucket) { 'test_local' }
   let(:key) { '2R6rr89nFeSRkSgXHd3smvEf' }
   let(:temp_url_params) { 'temp_url_sig=5ab8cfc3ba5da2598a6c88cc6b1b461fe4e115bc&temp_url_expires=1547598179' }
-
   let(:storage_service) { storage_service = double(ActiveStorage::Service) }
-  subject { ActiveStorage::Service::DsProxyService.new(wrapped: storage_service) }
+
+  subject do
+    allow(ENV).to receive(:[]).with('APP_HOST').and_return(public_host)
+    ActiveStorage::Service::DsProxyService.new(wrapped: storage_service)
+  end
 
   describe '#url' do
     let(:private_url) { "https://#{private_host}/v1/#{auth}/#{bucket}/#{key}?#{temp_url_params}" }
-    let(:public_url) { "https://#{public_host}/#{bucket}/#{key}?#{temp_url_params}" }
+    let(:public_url) { "https://#{public_host}/direct-upload/#{bucket}/#{key}?#{temp_url_params}" }
 
     before do
       expect(storage_service).to receive(:url).and_return(private_url)
@@ -25,7 +28,7 @@ describe ActiveStorage::Service::DsProxyService do
   describe '#url_for_direct_upload' do
     let(:download_params) { 'inline&filename=documents_top_confidentiels.bmp' }
     let(:private_url) { "https://#{private_host}/v1/#{auth}/#{bucket}/#{key}?#{temp_url_params}&#{download_params}" }
-    let(:public_url) { "https://#{public_host}/#{bucket}/#{key}?#{temp_url_params}&#{download_params}" }
+    let(:public_url) { "https://#{public_host}/direct-upload/#{bucket}/#{key}?#{temp_url_params}&#{download_params}" }
 
     before do
       expect(storage_service).to receive(:url_for_direct_upload).and_return(private_url)

--- a/spec/lib/active_storage/service/ds_proxy_service.rb
+++ b/spec/lib/active_storage/service/ds_proxy_service.rb
@@ -1,20 +1,17 @@
 describe ActiveStorage::Service::DsProxyService do
   let(:private_host) { 'storage.sbg1.cloud.ovh.net:443' }
-  let(:public_host) { 'www.demarches-simplifiees.fr' }
+  let(:public_host) { 'static.demarches-simplifiees.fr' }
   let(:auth) { 'AUTH_a24c37ed11a84896914514384898c34b' }
   let(:bucket) { 'test_local' }
   let(:key) { '2R6rr89nFeSRkSgXHd3smvEf' }
   let(:temp_url_params) { 'temp_url_sig=5ab8cfc3ba5da2598a6c88cc6b1b461fe4e115bc&temp_url_expires=1547598179' }
-  let(:storage_service) { storage_service = double(ActiveStorage::Service) }
 
-  subject do
-    allow(ENV).to receive(:[]).with('APP_HOST').and_return(public_host)
-    ActiveStorage::Service::DsProxyService.new(wrapped: storage_service)
-  end
+  let(:storage_service) { storage_service = double(ActiveStorage::Service) }
+  subject { ActiveStorage::Service::DsProxyService.new(wrapped: storage_service) }
 
   describe '#url' do
     let(:private_url) { "https://#{private_host}/v1/#{auth}/#{bucket}/#{key}?#{temp_url_params}" }
-    let(:public_url) { "https://#{public_host}/direct-upload/#{bucket}/#{key}?#{temp_url_params}" }
+    let(:public_url) { "https://#{public_host}/#{bucket}/#{key}?#{temp_url_params}" }
 
     before do
       expect(storage_service).to receive(:url).and_return(private_url)
@@ -28,7 +25,7 @@ describe ActiveStorage::Service::DsProxyService do
   describe '#url_for_direct_upload' do
     let(:download_params) { 'inline&filename=documents_top_confidentiels.bmp' }
     let(:private_url) { "https://#{private_host}/v1/#{auth}/#{bucket}/#{key}?#{temp_url_params}&#{download_params}" }
-    let(:public_url) { "https://#{public_host}/direct-upload/#{bucket}/#{key}?#{temp_url_params}&#{download_params}" }
+    let(:public_url) { "https://#{public_host}/#{bucket}/#{key}?#{temp_url_params}&#{download_params}" }
 
     before do
       expect(storage_service).to receive(:url_for_direct_upload).and_return(private_url)


### PR DESCRIPTION
# Technique
- Envoi des pièces jointes via `static.demarches-simplifiees.fr` à nouveau
- Support de `ruby-debug-ide` pour VSCode