### PR TITLE
pj_link: fix an exception when the scan is not associated yet

### DIFF
--- a/app/views/shared/champs/piece_justificative/_pj_link.html.haml
+++ b/app/views/shared/champs/piece_justificative/_pj_link.html.haml
@@ -1,12 +1,12 @@
 - pj = champ.piece_justificative_file
 
 .pj-link
-  - if champ.virus_scan.safe? || champ.virus_scan.blank?
+  - if champ.virus_scan.blank? || champ.virus_scan.safe?
     = link_to url_for(pj), target: '_blank', title: "Télécharger la pièce jointe" do
       %span.icon.attachment
       = pj.filename.to_s
     - if champ.virus_scan.blank?
-      (ce fichier n'a pas été analysé par notre antivirus, téléchargez-le avec précaution)
+      (ce fichier n’a pas été analysé par notre antivirus, téléchargez-le avec précaution)
 
   - else
     = pj.filename.to_s
@@ -16,6 +16,6 @@
       )
     - elsif champ.virus_scan.infected?
       - if user_can_upload
-        (virus détecté, merci d'envoyer un autre fichier)
+        (virus détecté, merci d’envoyer un autre fichier)
       - else
         (virus détecté, le téléchargement de ce fichier est bloqué)

--- a/spec/factories/virus_scan.rb
+++ b/spec/factories/virus_scan.rb
@@ -1,4 +1,17 @@
 FactoryBot.define do
   factory :virus_scan do
+    add_attribute(:status) { VirusScan.statuses.fetch(:pending) }
+
+    trait :pending do
+      add_attribute(:status) { VirusScan.statuses.fetch(:pending) }
+    end
+
+    trait :safe do
+      add_attribute(:status) { VirusScan.statuses.fetch(:safe) }
+    end
+
+    trait :infected do
+      add_attribute(:status) { VirusScan.statuses.fetch(:infected) }
+    end
   end
 end

--- a/spec/views/shared/champs/piece_justificative/_pj_link.html.haml_spec.rb
+++ b/spec/views/shared/champs/piece_justificative/_pj_link.html.haml_spec.rb
@@ -1,0 +1,51 @@
+require 'rails_helper'
+
+describe 'shared/champs/piece_justificative/_pj_link.html.haml', type: :view do
+  let(:champ) { create(:champ, :piece_justificative, :with_piece_justificative_file) }
+  let(:virus_scan) { nil }
+
+  before do
+    if virus_scan
+      champ.update(virus_scan: virus_scan)
+    end
+  end
+
+  subject { render 'shared/champs/piece_justificative/pj_link', champ: champ, user_can_upload: false }
+
+  context 'when there is no anti-virus scan' do
+    let(:virus_scan) { nil }
+
+    it 'allows to download the file' do
+      expect(subject).to have_link(champ.piece_justificative_file.filename.to_s)
+      expect(subject).to have_text('ce fichier n’a pas été analysé par notre antivirus')
+    end
+  end
+
+  context 'when the anti-virus scan is pending' do
+    let(:virus_scan) { create(:virus_scan, :pending) }
+
+    it 'displays the filename, but doesn’t allow to download the file' do
+      expect(subject).to have_text(champ.piece_justificative_file.filename.to_s)
+      expect(subject).not_to have_link(champ.piece_justificative_file.filename.to_s)
+      expect(subject).to have_text('analyse antivirus en cours')
+    end
+  end
+
+  context 'when the file is scanned and safe' do
+    let(:virus_scan) { create(:virus_scan, :safe) }
+
+    it 'allows to download the file' do
+      expect(subject).to have_link(champ.piece_justificative_file.filename.to_s)
+    end
+  end
+
+  context 'when the file is scanned and infected' do
+    let(:virus_scan) { create(:virus_scan, :infected) }
+
+    it 'displays the filename, but doesn’t allow to download the file' do
+      expect(subject).to have_text(champ.piece_justificative_file.filename.to_s)
+      expect(subject).not_to have_link(champ.piece_justificative_file.filename.to_s)
+      expect(subject).to have_text('virus détecté')
+    end
+  end
+end


### PR DESCRIPTION
Corrige une exception introduite hier soir dans #3461 : quand le virus_scan n'est pas encore associé à une PJ, la vue plante.

Pour la peine j'ai rajouté des specs sur toute la vue.

http://localhost:9006/sentry/ds-prod/issues/234/?environment=production