### PR TITLE
Revert "Redesign admin roles menu"

### DIFF
--- a/app/assets/stylesheets/switch_menu.scss
+++ b/app/assets/stylesheets/switch_menu.scss
@@ -1,16 +1,6 @@
 #switch-menu {
   position: fixed;
+  left: 10px;
   bottom: 10px;
-  color: #FFFFFF;
-  list-style: none;
-  text-decoration: none;
-  padding-left: 20px;
-}
-
-#switch-menu a,
-#switch-menu a:link,
-#switch-menu a:visited,
-#switch-menu a:hover {
-  text-decoration: none;
-  color: #FFFFFF;
+  z-index: 300;
 }

--- a/app/views/layouts/_switch_devise_profile_module.html.haml
+++ b/app/views/layouts/_switch_devise_profile_module.html.haml
@@ -1,14 +1,25 @@
 - if SwitchDeviseProfileService.new(warden).multiple_devise_profile_connect?
-  %ul#switch-menu
-    %li
-      Changer de rôle
-    - if user_signed_in?
-      %li
-        = link_to(dossiers_path, id: :menu_item_procedure, title: 'Aller dans votre espace usager. Vous pourrez revenir ici ensuite') do
-          %i.fa.fa-users
-          &nbsp; Usager
-    - if gestionnaire_signed_in?
-      %li
-        = link_to(gestionnaire_procedures_path, title: 'Aller dans votre espace instructeur. Vous pourrez revenir ici ensuite.') do
-          %i.fa.fa-user
-          &nbsp; Instructeur
+  #switch-menu.dropdown.dropup
+    %button.btn.btn-default.dropdown-toggle{ type: :button, 'data-toggle' => 'dropdown', 'aria-haspopup' => true, 'aria-expanded' => false }
+      %i.fa.fa-toggle-on
+      %span.caret
+    %ul.dropdown-menu.dropdown-menu-left
+      - if user_signed_in?
+        %li
+          = link_to(dossiers_path, id: :menu_item_procedure) do
+            %i.fa.fa-user
+            &nbsp;
+            Usager
+      - if gestionnaire_signed_in?
+        %li
+          = link_to(gestionnaire_procedures_path) do
+            %i.fa.fa-user
+            &nbsp;
+            Instructeur
+
+      - if administrateur_signed_in?
+        %li
+          = link_to(admin_procedures_path) do
+            %i.fa.fa-user
+            &nbsp;
+            Administrateur

--- a/app/views/layouts/application_old.html.haml
+++ b/app/views/layouts/application_old.html.haml
@@ -48,4 +48,6 @@
       %h1
         %i.fa.fa-times{ style: 'position: fixed; top: 10; right: 30; color: white;' }
 
+    = render partial: 'layouts/switch_devise_profile_module'
+
     = render partial: 'layouts/footer', locals: { main_container_size: main_container_size }

--- a/app/views/layouts/left_panels/_left_panel_admin_procedurescontroller_index.html.haml
+++ b/app/views/layouts/left_panels/_left_panel_admin_procedurescontroller_index.html.haml
@@ -31,7 +31,6 @@
           = current_administrateur.procedures.archivees.count
 
   .split-hr-left
-  = render partial: 'layouts/switch_devise_profile_module'
 
 
 #infos-block


### PR DESCRIPTION
#3419 a un effet de bord inattendu : 

> On a un problème sur le nouveau chemin après la connexion d'un admin qui n'a jamais créé une démarche. Le premier écran oblige l'admin a créer une démarche sans même avoir accès au bouton permettant de changer de profile. Le problème c'est que certains admins sont avant tout des instructeurs à qui on a créé un compte admin pendant le tour de France... Du coup ces personnes se retrouvent bloquées car connectées par défaut sur leur compte admin et contraintes à créer une démarche. Il faut absolument et urgement mettre un bouton de changement de profile sur cette page !!!!!