### PR TITLE
Add rel=noopener to links with target=_blank

### DIFF
--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -33,7 +33,7 @@ class WebhookController < ActionController::Base
   private
 
   def link_to_manager(model, url)
-    "<a target='_blank' href='#{url}'>#{model.model_name.human}##{model.id}</a>"
+    "<a target='_blank' href='#{url}' rel='noopener'>#{model.model_name.human}##{model.id}</a>"
   end
 
   def verify_signature!

--- a/app/helpers/string_to_html_helper.rb
+++ b/app/helpers/string_to_html_helper.rb
@@ -1,7 +1,7 @@
 module StringToHtmlHelper
   def string_to_html(str)
     html_formatted = simple_format(str)
-    with_links = html_formatted.gsub(URI.regexp, '<a target="_blank" href="\0">\0</a>')
-    sanitize(with_links, attributes: ['href', 'target'])
+    with_links = html_formatted.gsub(URI.regexp, '<a target="_blank" rel="noopener" href="\0">\0</a>')
+    sanitize(with_links, attributes: ['target', 'rel', 'href'])
   end
 end

--- a/app/javascript/new_design/administrateur/DraggableItem.vue
+++ b/app/javascript/new_design/administrateur/DraggableItem.vue
@@ -96,7 +96,7 @@
           Modèle
         </label>
         <template v-if="pieceJustificativeTemplateUrl">
-          <a :href="pieceJustificativeTemplateUrl" target="_blank">
+          <a :href="pieceJustificativeTemplateUrl" rel="noopener" target="_blank">
             {{pieceJustificativeTemplateFilename}}
           </a>
           <br> Modifier :

--- a/app/views/admin/procedures/_informations.html.haml
+++ b/app/views/admin/procedures/_informations.html.haml
@@ -30,7 +30,7 @@
     %p.help-block
       %i.fa.fa-info-circle
       Vous pouvez définir un lien de rappel HTTP (aussi appelé webhook) pour notifier un service tiers du changement de l'état d’un dossier de cette démarche sur demarches-simplifiees.fr.
-      = link_to("Consulter la documentation du webhook", WEBHOOK_DOC_URL, target: "_blank")
+      = link_to("Consulter la documentation du webhook", WEBHOOK_DOC_URL, target: "_blank", rel: "noopener")
       \.
 
 .form-group
@@ -40,7 +40,7 @@
     %li Texte de loi (loi, décret, circulaire, arrêté,…)
     %li Texte juridique (statuts, délibération, décision du conseil d'administration…)
     %li
-      = link_to("En savoir plus", CADRE_JURIDIQUE_URL, target: "_blank")
+      = link_to("En savoir plus", CADRE_JURIDIQUE_URL, target: "_blank", rel: "noopener")
 
   %p.help-block
     %i.fa.fa-info-circle
@@ -57,7 +57,7 @@
         = f.file_field :deliberation,
           direct_upload: true
       - else
-        %a{ href: url_for(deliberation), target: '_blank' }
+        %a{ href: url_for(deliberation), target: '_blank', rel: 'noopener' }
           = deliberation.filename.to_s
         - if @procedure.persisted?
           = link_to 'supprimer', delete_deliberation_admin_procedure_path(@procedure), method: :delete
@@ -73,7 +73,7 @@
     = f.file_field :notice,
       direct_upload: true
   - else
-    %a{ href: url_for(notice), target: '_blank' }
+    %a{ href: url_for(notice), target: '_blank', rel: 'noopener' }
       = notice.filename.to_s
     - if @procedure.persisted?
       \-

--- a/app/views/admin/procedures/new_from_existing.html.haml
+++ b/app/views/admin/procedures/new_from_existing.html.haml
@@ -23,7 +23,7 @@
             %td{ style: 'width: 750px;' }
               = procedure.libelle
             %td{ style: 'padding-right: 10px; padding-left: 10px; width: 60px;' }
-              = link_to('Consulter', apercu_procedure_path(id: procedure.id), target: "_blank")
+              = link_to('Consulter', apercu_procedure_path(id: procedure.id), target: "_blank", rel: "noopener")
             %td
               = link_to('Cloner', admin_procedure_clone_path(procedure.id, from_new_from_existing: true), 'data-method' => :put, class: 'btn-sm btn-primary clone-btn')
             %td{ style: 'padding-left: 10px;' }

--- a/app/views/admin/procedures/show.html.haml
+++ b/app/views/admin/procedures/show.html.haml
@@ -54,7 +54,7 @@
         - elsif @procedure.publiee?
           Cette démarche est <strong>publiée</strong>, certains éléments ne peuvent plus être modifiés.
           Pour y accéder vous pouvez utiliser le lien :
-          = link_to procedure_lien(@procedure), sanitize_url(procedure_lien(@procedure)), target: :blank
+          = link_to procedure_lien(@procedure), sanitize_url(procedure_lien(@procedure)), target: :blank, rel: :noopener
           %br
           %br
           Attention, diffusez toujours le <strong>lien complet</strong> affiché ci-dessus, et non pas un lien générique vers demarches-simplifiees.fr. Ne dites pas non plus aux usagers de se rendre sur le site générique demarches-simplifiees.fr, donnez-leur toujours le lien complet.
@@ -63,7 +63,7 @@
             %p
               Cette démarche est actuellement <strong>en test</strong>,
               pour y accéder vous pouvez utiliser le lien :
-              = link_to procedure_lien(@procedure), sanitize_url(procedure_lien(@procedure)), target: :blank
+              = link_to procedure_lien(@procedure), sanitize_url(procedure_lien(@procedure)), target: :blank, rel: :noopener
             %p
               Tout personne ayant la connaissance de ce lien pourra ainsi remplir des dossiers de test sur votre démarche.
             %br

--- a/app/views/admin/types_de_champ/_fields.html.haml
+++ b/app/views/admin/types_de_champ/_fields.html.haml
@@ -29,7 +29,7 @@
           = ff.file_field :piece_justificative_template,
             direct_upload: true
         - else
-          = link_to template.filename.to_s, url_for(template), target: '_blank'
+          = link_to template.filename.to_s, url_for(template), target: '_blank', rel: 'noopener'
           %br
           Modifier :
           = ff.file_field :piece_justificative_template,

--- a/app/views/demandes/new.html.haml
+++ b/app/views/demandes/new.html.haml
@@ -50,7 +50,7 @@
       %span.mandatory *
       %p.intro{ :style => "font-weight: normal" }
         Vous utilisez un email orange, wanadoo, free, gmail etc. ? Merci de nous
-        %a{ href: contact_admin_path, target:'_blank' }
+        %a{ href: contact_admin_path, target:'_blank', rel: 'noopener' }
           contacter préalablement.
     = email_field_tag :email, nil, placeholder: 'jean.martin@developpement-durable.gouv.fr', required: true
 

--- a/app/views/dossier_mailer/notify_new_answer.html.haml
+++ b/app/views/dossier_mailer/notify_new_answer.html.haml
@@ -6,6 +6,6 @@
 
 %p
   Pour le consulter, merci de vous rendre sur
-  = link_to messagerie_dossier_url(@dossier), messagerie_dossier_url(@dossier), target: '_blank'
+  = link_to messagerie_dossier_url(@dossier), messagerie_dossier_url(@dossier), target: '_blank', rel:'noopener'
 
 = render partial: "layouts/mailers/signature"

--- a/app/views/dossier_mailer/notify_new_draft.html.haml
+++ b/app/views/dossier_mailer/notify_new_draft.html.haml
@@ -5,6 +5,6 @@
   Vous pouvez retrouver et compléter le brouillon que vous avez créé pour la démarche
   %strong= @dossier.procedure.libelle
   à l'adresse suivante :
-  = link_to dossier_url(@dossier), dossier_url(@dossier), target: '_blank'
+  = link_to dossier_url(@dossier), dossier_url(@dossier), target: '_blank', rel: 'noopener'
 
 = render partial: "layouts/mailers/signature"

--- a/app/views/fields/procedure_link_field/_show.html.haml
+++ b/app/views/fields/procedure_link_field/_show.html.haml
@@ -1,4 +1,4 @@
 - if field.data.present?
-  = link_to Addressable::URI.parse(procedure_lien(field.resource)).path, procedure_lien(field.resource), target: '_blank'
+  = link_to Addressable::URI.parse(procedure_lien(field.resource)).path, procedure_lien(field.resource), target: '_blank', rel: 'noopener'
 - else
   Plus en ligne

--- a/app/views/layouts/_navbar.html.haml
+++ b/app/views/layouts/_navbar.html.haml
@@ -10,7 +10,7 @@
   #navbar-body
     .row
       %div{ style: "vertical-align: middle;float:left;position:absolute;line-height: 60px;z-index:2;" }
-        Besoin d'aide ? <a href="tel:#{CONTACT_PHONE}">#{CONTACT_PHONE}</a> ou <a href="#{contact_admin_path}" target="_blank">par email</a>
+        Besoin d'aide ? <a href="tel:#{CONTACT_PHONE}">#{CONTACT_PHONE}</a> ou <a href="#{contact_admin_path}" target="_blank" rel="noopener">par email</a>
       -# BEST WTF EVER
       -# this begin rescue hides potentials bugs by displaying another navbar
       - begin

--- a/app/views/layouts/_outdated_browser_banner.html.haml
+++ b/app/views/layouts/_outdated_browser_banner.html.haml
@@ -3,6 +3,6 @@
   #outdated-browser-banner
     .container
       Attention, votre navigateur (#{browser.name} #{browser.version}) est trop ancien pour utiliser demarches-simplifiees.fr : certaines parties du site ne fonctionneront pas correctement. Nous vous recommendons fortement de
-      %a{ href: "https://browser-update.org/fr/update.html", target: "_blank" }mettre à jour votre navigateur
+      %a{ href: "https://browser-update.org/fr/update.html", target: "_blank", rel: "noopener" }mettre à jour votre navigateur
       %span<>
         \.

--- a/app/views/layouts/left_panels/_left_panel_admin_procedurescontroller_navbar.html.haml
+++ b/app/views/layouts/left_panels/_left_panel_admin_procedurescontroller_navbar.html.haml
@@ -50,7 +50,7 @@
         .procedure-list-element{ class: ('active' if active == 'Annotations privées') }
           Annotations privées
 
-    %a#onglet-preview{ href: url_for(apercu_procedure_path(@procedure)), target: "_blank" }
+    %a#onglet-preview{ href: url_for(apercu_procedure_path(@procedure)), target: "_blank", rel: "noopener" }
       .procedure-list-element{ class: ('active' if active == 'Prévisualisation') }
         Prévisualisation
 

--- a/app/views/layouts/mailers/notification.html.haml
+++ b/app/views/layouts/mailers/notification.html.haml
@@ -2,6 +2,6 @@
   %strong
     Merci de ne pas répondre à cet email. Pour vous adresser à votre administration, passez directement par votre
     = succeed '.' do
-      = link_to 'messagerie', messagerie_dossier_url(@dossier), target: '_blank'
+      = link_to 'messagerie', messagerie_dossier_url(@dossier), target: '_blank', rel: 'noopener'
 
 = render template: 'layouts/mailers/layout'

--- a/app/views/new_administrateur/_breadcrumbs.html.haml
+++ b/app/views/new_administrateur/_breadcrumbs.html.haml
@@ -4,4 +4,4 @@
       - steps.each do |step|
         %li= step
     - if defined?(preview) && preview
-      = link_to "Prévisualiser le formulaire", apercu_procedure_path(@procedure), target: "_blank", class: 'button'
+      = link_to "Prévisualiser le formulaire", apercu_procedure_path(@procedure), target: "_blank", rel: "noopener", class: 'button'

--- a/app/views/new_administrateur/services/_form.html.haml
+++ b/app/views/new_administrateur/services/_form.html.haml
@@ -15,7 +15,7 @@
     %span.mandatory *
   %p
     Pour trouver votre numéro SIRET, utilisez
-    %a{ href: 'https://entreprise.data.gouv.fr/', target: '_blank' }
+    %a{ href: 'https://entreprise.data.gouv.fr/', target: '_blank', rel: 'noopener' }
       entreprise.data.gouv.fr
     ou renseignez-vous auprès de votre service comptable
   = f.number_field :siret, required: true

--- a/app/views/new_gestionnaire/dossiers/_header.html.haml
+++ b/app/views/new_gestionnaire/dossiers/_header.html.haml
@@ -15,7 +15,7 @@
             %span.icon.printer
           %ul.print-menu.dropdown-content
             %li
-              = link_to "Tout le dossier", print_gestionnaire_dossier_path(dossier.procedure, dossier), target: "_blank", class: "menu-item menu-link"
+              = link_to "Tout le dossier", print_gestionnaire_dossier_path(dossier.procedure, dossier), target: "_blank", rel: "noopener", class: "menu-item menu-link"
             %li
               = link_to "Uniquement cet onglet", "#", onclick: "window.print()", class: "menu-item menu-link"
 

--- a/app/views/new_gestionnaire/dossiers/_state_button.html.haml
+++ b/app/views/new_gestionnaire/dossiers/_state_button.html.haml
@@ -64,7 +64,7 @@
         - if dossier.attestation.present?
           %h4 Attestation
           %p.attestation L'acceptation du dossier a envoyé automatiquement une attestation au demandeur
-          = link_to "Voir l'attestation", attestation_gestionnaire_dossier_path(dossier.procedure, dossier), target: '_blank', class: 'button'
+          = link_to "Voir l'attestation", attestation_gestionnaire_dossier_path(dossier.procedure, dossier), target: '_blank', rel: 'noopener', class: 'button'
   - else
     %span.label{ class: button_or_label_class(dossier) }
       = dossier_display_state(dossier, lower: true)

--- a/app/views/new_gestionnaire/dossiers/_state_button_motivation.html.haml
+++ b/app/views/new_gestionnaire/dossiers/_state_button_motivation.html.haml
@@ -30,6 +30,6 @@
       = text_area :dossier, :motivation, class: 'motivation-text-area', placeholder: placeholder, required: true
     .text-right
       - if title == 'Accepter' && dossier.procedure.attestation_template&.activated?
-        = link_to "Voir l'attestation", apercu_attestation_gestionnaire_dossier_path(dossier.procedure, dossier), target: '_blank', class: 'button', title: "Voir l'attestation qui sera envoyée au demandeur"
+        = link_to "Voir l'attestation", apercu_attestation_gestionnaire_dossier_path(dossier.procedure, dossier), target: '_blank', rel: 'noopener', class: 'button', title: "Voir l'attestation qui sera envoyée au demandeur"
       %span.button{ onclick: 'DS.motivationCancel();' } Annuler
       = button_tag 'Valider la décision', name: :process_action, value: process_action, class: 'button primary', title: title, data: { confirm: confirm }

--- a/app/views/new_gestionnaire/procedures/_download_dossiers.html.haml
+++ b/app/views/new_gestionnaire/procedures/_download_dossiers.html.haml
@@ -5,8 +5,8 @@
     .dropdown-content.fade-in-down
       %ul.dropdown-items
         %li
-          = link_to "Au format .csv", download_dossiers_gestionnaire_procedure_path(format: :csv, procedure_id: procedure.id), target: "_blank"
+          = link_to "Au format .csv", download_dossiers_gestionnaire_procedure_path(format: :csv, procedure_id: procedure.id), target: "_blank", rel: "noopener"
         %li
-          = link_to "Au format .xlsx", download_dossiers_gestionnaire_procedure_path(format: :xlsx, procedure_id: procedure.id, tables: [:etablissements]), target: "_blank"
+          = link_to "Au format .xlsx", download_dossiers_gestionnaire_procedure_path(format: :xlsx, procedure_id: procedure.id, tables: [:etablissements]), target: "_blank", rel: "noopener"
         %li
-          = link_to "Au format .ods", download_dossiers_gestionnaire_procedure_path(format: :ods, procedure_id: procedure.id, tables: [:etablissements]), target: "_blank"
+          = link_to "Au format .ods", download_dossiers_gestionnaire_procedure_path(format: :ods, procedure_id: procedure.id, tables: [:etablissements]), target: "_blank", rel: "noopener"

--- a/app/views/new_user/dossiers/show/_status_overview.html.haml
+++ b/app/views/new_user/dossiers/show/_status_overview.html.haml
@@ -65,7 +65,7 @@
 
         - if dossier.attestation.present?
           .action
-            = link_to attestation_dossier_path(dossier), target: '_blank', class: 'button primary' do
+            = link_to attestation_dossier_path(dossier), target: '_blank', rel: 'noopener', class: 'button primary' do
               %span.icon.download
               Télécharger l’attestation
 

--- a/app/views/root/_footer.html.haml
+++ b/app/views/root/_footer.html.haml
@@ -19,7 +19,7 @@
       %li.footer-column
         %ul.footer-links
           %li.footer-link
-            = link_to "Newsletter", "https://my.sendinblue.com/users/subscribe/js_id/3s2q1/id/1", :class => "footer-link", :target => "_blank"
+            = link_to "Newsletter", "https://my.sendinblue.com/users/subscribe/js_id/3s2q1/id/1", :class => "footer-link", :target => "_blank", rel: "noopener"
           %li.footer-link
             = link_to "Nouveautés", "https://github.com/betagouv/tps/releases", :class => "footer-link"
           %li.footer-link

--- a/app/views/root/accessibilite.html.haml
+++ b/app/views/root/accessibilite.html.haml
@@ -5,7 +5,7 @@
   %h1.new-h1 Accessibilité
 
   %p.new-p
-    Nous travaillons à améliorer le niveau d'accessibilité du site et sa conformité avec les normes en la matière. Une première version optimisée pour la partie « Usager » du site ainsi qu'une déclaration de conformité <a href="https://references.modernisation.gouv.fr/rgaa-accessibilite/" target="_blank">RGAA</a> seront disponibles en août 2018.
+    Nous travaillons à améliorer le niveau d'accessibilité du site et sa conformité avec les normes en la matière. Une première version optimisée pour la partie « Usager » du site ainsi qu'une déclaration de conformité <a href="https://references.modernisation.gouv.fr/rgaa-accessibilite/" target="_blank" rel="noopener">RGAA</a> seront disponibles en août 2018.
 
   %h2.new-h2 Signaler un dysfonctionnement
   %p.new-p
@@ -15,6 +15,6 @@
   %p.new-p
     Si vous constatez un défaut d'accessibilité vous empêchant d'accéder à un contenu ou une fonctionnalité du site, que vous nous le signalez et que vous ne parvenez pas à obtenir une réponse rapide de notre part, vous êtes en droit de faire parvenir vos doléances ou une demande de saisine au Défenseur des droits. Plusieurs moyens sont à votre disposition :
     %ul
-      %li un <a href="http://www.defenseurdesdroits.fr/contact" target="_blank">formulaire de contact</a> ;
-      %li la <a href="http://www.defenseurdesdroits.fr/office/" target="_blank">liste du ou des délégués de votre région</a> avec leurs informations de contact direct ;
+      %li un <a href="http://www.defenseurdesdroits.fr/contact" target="_blank" rel="noopener">formulaire de contact</a> ;
+      %li la <a href="http://www.defenseurdesdroits.fr/office/" target="_blank" rel="noopener">liste du ou des délégués de votre région</a> avec leurs informations de contact direct ;
       %li une adresse postale : Le Défenseur des droits - 7 rue Saint-Florentin - 75409 Paris Cedex 08.

--- a/app/views/root/suivi.html.haml
+++ b/app/views/root/suivi.html.haml
@@ -16,8 +16,8 @@
     Rien d'exceptionnel, pas de passe-droit. Nous respectons simplement la loi, qui dit que certains outils de suivi d’audience, correctement configurés pour respecter la vie privée, sont exemptés d’autorisation préalable.
     %br
     %br
-    Nous utilisons pour cela <a href="https://matomo.org/" target="_blank" >Matomo</a>, un outil <a href="https://matomo.org/free-software/" target="_blank">libre</a>, paramétré pour être en conformité avec la <a href="https://www.cnil.fr/fr/solutions-pour-la-mesure-daudience">recommandation « Cookies » </a>de la CNIL. Cela signifie que votre adresse IP, par exemple, est anonymisée avant d’être enregistrée. Il est donc impossible d’associer vos visites sur ce site à votre personne.
+    Nous utilisons pour cela <a href="https://matomo.org/" target="_blank" rel="noopener">Matomo</a>, un outil <a href="https://matomo.org/free-software/" target="_blank" rel="noopener">libre</a>, paramétré pour être en conformité avec la <a href="https://www.cnil.fr/fr/solutions-pour-la-mesure-daudience">recommandation « Cookies » </a>de la CNIL. Cela signifie que votre adresse IP, par exemple, est anonymisée avant d’être enregistrée. Il est donc impossible d’associer vos visites sur ce site à votre personne.
 
   %h2.new-h2 Je contribue à enrichir vos données, puis-je y accéder ?
   %p.new-p
-    Bien sûr ! Les statistiques d’usage sont en accès libre sur <a href="https://stats.data.gouv.fr/index.php?module=MultiSites&action=index&idSite=1&period=range&date=previous30&updated=1#?idSite=1&period=range&date=previous30&category=Dashboard_Dashboard&subcategory=1&module=MultiSites&action=index" target="_blank">stats.data.gouv.fr</a>.
+    Bien sûr ! Les statistiques d’usage sont en accès libre sur <a href="https://stats.data.gouv.fr/index.php?module=MultiSites&action=index&idSite=1&period=range&date=previous30&updated=1#?idSite=1&period=range&date=previous30&category=Dashboard_Dashboard&subcategory=1&module=MultiSites&action=index" target="_blank" rel="noopener">stats.data.gouv.fr</a>.

--- a/app/views/root/tour_de_france.html.haml
+++ b/app/views/root/tour_de_france.html.haml
@@ -54,30 +54,30 @@
 
       %ul
         %li
-          = link_to("Étape Normandie, le 26 septembre à Rouen", "https://www.demarches-simplifiees.fr/commencer/tour-de-france-etape-normandie", target: "_blank")
+          = link_to("Étape Normandie, le 26 septembre à Rouen", "https://www.demarches-simplifiees.fr/commencer/tour-de-france-etape-normandie", target: "_blank", rel: "noopener")
         %li
-          = link_to("Étape Occitanie, le 15 octobre à Toulouse", "https://www.demarches-simplifiees.fr/commencer/tour-de-france-demarches-simplifiees-fr-occitanie", target: "_blank")
+          = link_to("Étape Occitanie, le 15 octobre à Toulouse", "https://www.demarches-simplifiees.fr/commencer/tour-de-france-demarches-simplifiees-fr-occitanie", target: "_blank", rel: "noopener")
         %li
-          = link_to("Étape Nouvelle-Aquitaine, le 18 octobre à Bordeaux", "https://www.demarches-simplifiees.fr/commencer/tour-de-france-demarches-simplifiees-fr-aquitaine", target: "_blank")
+          = link_to("Étape Nouvelle-Aquitaine, le 18 octobre à Bordeaux", "https://www.demarches-simplifiees.fr/commencer/tour-de-france-demarches-simplifiees-fr-aquitaine", target: "_blank", rel: "noopener")
         %li
-          = link_to("Étape Martinique, le 24 octobre à Fort-de-France", "https://www.demarches-simplifiees.fr/commencer/tour-de-france-demarches-simplifiees-fr-martinique", target: "_blank")
+          = link_to("Étape Martinique, le 24 octobre à Fort-de-France", "https://www.demarches-simplifiees.fr/commencer/tour-de-france-demarches-simplifiees-fr-martinique", target: "_blank", rel: "noopener")
         %li
-          = link_to("Étape PACA, le 6 novembre à Marseille", "https://www.demarches-simplifiees.fr/commencer/tour-de-france-demarches-simplifiees-fr-paca", target: "_blank")
+          = link_to("Étape PACA, le 6 novembre à Marseille", "https://www.demarches-simplifiees.fr/commencer/tour-de-france-demarches-simplifiees-fr-paca", target: "_blank", rel: "noopener")
         %li
-          = link_to("Étape Corse, le 8 novembre à Ajaccio", "https://www.demarches-simplifiees.fr/commencer/tour-de-france-demarches-simplifiees-fr-corse", target: "_blank")
+          = link_to("Étape Corse, le 8 novembre à Ajaccio", "https://www.demarches-simplifiees.fr/commencer/tour-de-france-demarches-simplifiees-fr-corse", target: "_blank", rel: "noopener")
         %li
-          = link_to("Étape Ile-de-France, le 13 novembre à Paris", "https://www.demarches-simplifiees.fr/commencer/tour-de-france-demarches-simplifiees-iledefrance", target: "_blank")
+          = link_to("Étape Ile-de-France, le 13 novembre à Paris", "https://www.demarches-simplifiees.fr/commencer/tour-de-france-demarches-simplifiees-iledefrance", target: "_blank", rel: "noopener")
         %li
-          = link_to("Étape Bourgogne Franche-Comté, le 14 novembre à Dijon", "https://www.demarches-simplifiees.fr/commencer/tour-de-france-demarches-simplifiees-bourgogne-fc", target: "_blank")
+          = link_to("Étape Bourgogne Franche-Comté, le 14 novembre à Dijon", "https://www.demarches-simplifiees.fr/commencer/tour-de-france-demarches-simplifiees-bourgogne-fc", target: "_blank", rel: "noopener")
         %li
-          = link_to("Étape Pays de la Loire, le 20 novembre à Nantes", "https://www.demarches-simplifiees.fr/commencer/tour-de-france-demarches-simplifiees-fr-paysloire", target: "_blank")
+          = link_to("Étape Pays de la Loire, le 20 novembre à Nantes", "https://www.demarches-simplifiees.fr/commencer/tour-de-france-demarches-simplifiees-fr-paysloire", target: "_blank", rel: "noopener")
         %li
-          = link_to("Étape Bretagne, le 22 novembre à Rennes", "https://www.demarches-simplifiees.fr/commencer/tour-de-france-demarches-simplifiees-fr-bretagne", target: "_blank")
+          = link_to("Étape Bretagne, le 22 novembre à Rennes", "https://www.demarches-simplifiees.fr/commencer/tour-de-france-demarches-simplifiees-fr-bretagne", target: "_blank", rel: "noopener")
         %li
-          = link_to("Étape Hauts-de-France, le 27 novembre à Lille", "https://www.demarches-simplifiees.fr/commencer/tour-de-france-demarches-simplifiees-hautsdefrance", target: "_blank")
+          = link_to("Étape Hauts-de-France, le 27 novembre à Lille", "https://www.demarches-simplifiees.fr/commencer/tour-de-france-demarches-simplifiees-hautsdefrance", target: "_blank", rel: "noopener")
         %li
-          = link_to("Étape Grand-Est, le 29 novembre à Metz", "https://www.demarches-simplifiees.fr/commencer/tour-de-france-demarches-simplifiees-fr-grand-est", target: "_blank")
+          = link_to("Étape Grand-Est, le 29 novembre à Metz", "https://www.demarches-simplifiees.fr/commencer/tour-de-france-demarches-simplifiees-fr-grand-est", target: "_blank", rel: "noopener")
         %li
-          = link_to("Étape Centre Val-de-Loire, le 5 décembre à Orleans", "https://www.demarches-simplifiees.fr/commencer/tour-de-france-demarches-simplifiees-centre-vdl", target: "_blank")
+          = link_to("Étape Centre Val-de-Loire, le 5 décembre à Orleans", "https://www.demarches-simplifiees.fr/commencer/tour-de-france-demarches-simplifiees-centre-vdl", target: "_blank", rel: "noopener")
         %li
-          = link_to("Étape Auvergne-Rhone-Alpes, le 7 décembre à Lyon", "https://www.demarches-simplifiees.fr/commencer/tour-de-france-demarches-simplifiees-auvergne-rhon", target: "_blank")
+          = link_to("Étape Auvergne-Rhone-Alpes, le 7 décembre à Lyon", "https://www.demarches-simplifiees.fr/commencer/tour-de-france-demarches-simplifiees-auvergne-rhon", target: "_blank", rel: "noopener")

--- a/app/views/shared/champs/dossier_link/_show.html.haml
+++ b/app/views/shared/champs/dossier_link/_show.html.haml
@@ -2,7 +2,7 @@
 - if dossier
   - path = dossier_linked_path(current_gestionnaire || current_user, dossier)
   - if path.present?
-    = link_to("Dossier nº #{dossier.id}", path, target: '_blank')
+    = link_to("Dossier nº #{dossier.id}", path, target: '_blank', rel: 'noopener')
   - else
     Dossier nº #{dossier.id}
   %br

--- a/app/views/shared/champs/piece_justificative/_pj_link.html.haml
+++ b/app/views/shared/champs/piece_justificative/_pj_link.html.haml
@@ -2,7 +2,7 @@
 
 .pj-link
   - if champ.virus_scan.blank? || champ.virus_scan.safe?
-    = link_to url_for(pj), target: '_blank', title: "Télécharger la pièce jointe" do
+    = link_to url_for(pj), target: '_blank', rel: 'noopener', title: "Télécharger la pièce jointe" do
       %span.icon.attachment
       = pj.filename.to_s
     - if champ.virus_scan.blank?

--- a/app/views/shared/champs/siret/_etablissement.html.haml
+++ b/app/views/shared/champs/siret/_etablissement.html.haml
@@ -4,7 +4,7 @@
 
 - when :not_found
   Nous n’avons pas trouvé d’établissement correspondant à ce numéro de SIRET.
-  = link_to('Plus d’informations', "https://faq.demarches-simplifiees.fr/article/4-erreur-siret", target: '_blank')
+  = link_to('Plus d’informations', "https://faq.demarches-simplifiees.fr/article/4-erreur-siret", target: '_blank', rel: 'noopener')
 
 - else
   - if siret.present? && siret == etablissement&.siret

--- a/app/views/shared/dossiers/_edit.html.haml
+++ b/app/views/shared/dossiers/_edit.html.haml
@@ -17,7 +17,7 @@
         ) sont obligatoires.
 
       - if notice_url(dossier.procedure).present?
-        = link_to notice_url(dossier.procedure), target: '_blank', class: 'button notice', title: "Pour vous aider à remplir votre dossier, vous pouvez consulter le guide de cette démarche." do
+        = link_to notice_url(dossier.procedure), target: '_blank', rel: 'noopener', class: 'button notice', title: "Pour vous aider à remplir votre dossier, vous pouvez consulter le guide de cette démarche." do
           %span.icon.info>
           Guide de la démarche
 
@@ -54,13 +54,13 @@
             - if tpj.lien_demarche.present?
               %p.piece-description
                 Récupérer le formulaire vierge pour mon dossier :
-                = link_to "Télécharger", tpj.lien_demarche, target: :blank
+                = link_to "Télécharger", tpj.lien_demarche, target: :blank, rel: :noopener
 
             - if dossier.was_piece_justificative_uploaded_for_type_id?(tpj.id)
               - pj = dossier.retrieve_last_piece_justificative_by_type(tpj.id)
               %p
                 Pièce jointe déjà importée :
-                = link_to pj.original_filename, pj.content_url, target: :blank
+                = link_to pj.original_filename, pj.content_url, target: :blank, rel: :noopener
 
             = file_field_tag "piece_justificative_#{tpj.id}",
               accept: PieceJustificative.accept_format,

--- a/app/views/shared/dossiers/_pieces_jointes.html.haml
+++ b/app/views/shared/dossiers/_pieces_jointes.html.haml
@@ -10,7 +10,7 @@
             %span{ class: highlight_if_unseen_class(demande_seen_at, pj.updated_at) }
               = display_pj_filename(pj)
             ·
-            = link_to "Télécharger", pj.content_url, class: "link", target: :blank
+            = link_to "Télécharger", pj.content_url, class: "link", target: :blank, rel: :noopener
             - if pjs.present?
               %br
               %span.dropdown
@@ -20,7 +20,7 @@
                   %ul.dropdown-items
                     - pjs.each do |pj|
                       %li
-                        = link_to pj.content_url, { target: :blank } do
+                        = link_to pj.content_url, { target: :blank, rel: :noopener } do
                           %span.filename= display_pj_filename(pj)
                           %span
                             ajoutée le #{pj.created_at.strftime('%d/%m/%Y à %H:%M')}

--- a/app/views/shared/dossiers/editable_champs/_piece_justificative.html.haml
+++ b/app/views/shared/dossiers/editable_champs/_piece_justificative.html.haml
@@ -4,7 +4,7 @@
   - if champ.type_de_champ.piece_justificative_template.attached?
     %p.edit-pj-template.mb-1
       Veuillez télécharger, remplir et joindre
-      = link_to('le modèle suivant', url_for(champ.type_de_champ.piece_justificative_template), target: '_blank')
+      = link_to('le modèle suivant', url_for(champ.type_de_champ.piece_justificative_template), target: '_blank', rel: 'noopener')
 
   - if pj.attached?
     .piece-justificative-actions{ id: "piece_justificative_#{champ.id}" }

--- a/app/views/shared/dossiers/messages/_message.html.haml
+++ b/app/views/shared/dossiers/messages/_message.html.haml
@@ -12,11 +12,11 @@
 
   - if commentaire.piece_justificative
     .attachment-link
-      = link_to commentaire.piece_justificative.content_url, class: "button", target: "_blank", title: "Télécharger" do
+      = link_to commentaire.piece_justificative.content_url, class: "button", target: "_blank", rel: "noopener", title: "Télécharger" do
         %span.icon.attachment
         = commentaire.piece_justificative.original_filename
   - elsif commentaire.file.present?
     .attachment-link
-      = link_to commentaire.file_url, class: "button", target: "_blank", title: "Télécharger" do
+      = link_to commentaire.file_url, class: "button", target: "_blank", rel: "noopener", title: "Télécharger" do
         %span.icon.attachment
         = commentaire.file_identifier

--- a/app/views/users/registrations/new.html.haml
+++ b/app/views/users/registrations/new.html.haml
@@ -19,4 +19,4 @@
     = link_to "", france_connect_particulier_path, class: "login-with-fc"
 
   .center
-    = link_to "Qu’est-ce que FranceConnect ?", "https://franceconnect.gouv.fr/", target: "_blank", class: "link"
+    = link_to "Qu’est-ce que FranceConnect ?", "https://franceconnect.gouv.fr/", target: "_blank", rel: "noopener", class: "link"

--- a/app/views/users/sessions/link_sent.html.haml
+++ b/app/views/users/sessions/link_sent.html.haml
@@ -14,7 +14,7 @@
     <b>Attention</b>, ce message peut mettre jusqu'à <b>15 minutes</b> pour arriver.
 
   %p.help
-    Si vous voyez cette page trop souvent, consultez notre aide : #{link_to 'https://faq.demarches-simplifiees.fr/article/34-je-dois-confirmer-mon-compte-a-chaque-connexion', 'https://faq.demarches-simplifiees.fr/article/34-je-dois-confirmer-mon-compte-a-chaque-connexion', target: '_blank' }
+    Si vous voyez cette page trop souvent, consultez notre aide : #{link_to 'https://faq.demarches-simplifiees.fr/article/34-je-dois-confirmer-mon-compte-a-chaque-connexion', 'https://faq.demarches-simplifiees.fr/article/34-je-dois-confirmer-mon-compte-a-chaque-connexion', target: '_blank', rel: 'noopener' }
     %br
     %br
     En cas de difficultés, nous restons joignables sur #{link_to 'contact@demarches-simplifiees.fr', 'mailto:contact@demarches-simplifiees.fr'}.

--- a/app/views/users/sessions/new.html.haml
+++ b/app/views/users/sessions/new.html.haml
@@ -36,4 +36,4 @@
     = link_to "", france_connect_particulier_path, class: "login-with-fc"
 
   .center
-    = link_to "Qu’est-ce que FranceConnect ?", "https://franceconnect.gouv.fr/", target: "_blank", class: "link"
+    = link_to "Qu’est-ce que FranceConnect ?", "https://franceconnect.gouv.fr/", target: "_blank", rel: "noopener", class: "link"

--- a/public/500.html
+++ b/public/500.html
@@ -45,7 +45,7 @@
     <div class='container'>
       <h1 class='new-h1'>Une erreur est survenue</h1>
       <div class='description'>
-        Nos équipes ont été averties. Si le problème persiste ou si vous voulez nous donner des détails concernant l'erreur qui vient de se produire, vous pouvez nous contacter à l'adresse <a href="mailto:contact@demarches-simplifiees.fr" target="_blank">contact@demarches-simplifiees.fr</a>.
+        Nos équipes ont été averties. Si le problème persiste ou si vous voulez nous donner des détails concernant l'erreur qui vient de se produire, vous pouvez nous contacter à l'adresse <a href="mailto:contact@demarches-simplifiees.fr" target="_blank" rel="noopener">contact@demarches-simplifiees.fr</a>.
       </div>
     </div>
   </div>

--- a/spec/helpers/string_to_html_helper_spec.rb
+++ b/spec/helpers/string_to_html_helper_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe StringToHtmlHelper, type: :helper do
     context "with a link" do
       let(:description) { "https://d-s.fr" }
 
-      it { is_expected.to eq("<p><a target=\"_blank\" href=\"https://d-s.fr\">https://d-s.fr</a></p>") }
+      it { is_expected.to eq("<p><a target=\"_blank\" rel=\"noopener\" href=\"https://d-s.fr\">https://d-s.fr</a></p>") }
     end
 
     context "with empty decription" do


### PR DESCRIPTION
J’ai fait une passe et rajouté des `rel=noopener` sur les liens qui ouvrent une nouvelle fenêtre.

Techniquement, c’est surtout nécessaire pour les liens vers un autre site, mais 

- non seulement je ne vois pas d’inconvénient à le faire aussi pour les liens internes, mais en plus
- ça apporterait un petit bénéfice en termes de perfs car ça permet d’avoir des process séparés pour les onglets (?)
- et surtout, ça me semble plus simple de traiter tous les liens que de faire dans la dentelle.

https://blog.dareboost.com/fr/2017/03/target-blank-rel-noopener-securite-performance/
http://support.detectify.com/customer/portal/articles/2792257-external-links-using-target-_blank-