### PR TITLE
converting DateTime to Date looses time zone information resulting in…

### DIFF
--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -204,7 +204,7 @@ class StatsController < ApplicationController
 
   def max_date
     if administration_signed_in?
-      Time.zone.now.to_date
+      Time.zone.now
     else
       Time.zone.now.beginning_of_month - 1.second
     end


### PR DESCRIPTION
… bad time computing

Specifically, for Tahiti, time zone is -10 so after 14h, UTC time is Tahiti time + 10h i.e the day after. 
Loosing time zone with to_date call results in 1 day difference whether the time is computed before of after 14h :-)