### PR TITLE
Fix Turbolinks page views are not tracked properly in matomo #3542

### DIFF
--- a/app/views/layouts/_matomo.html.haml
+++ b/app/views/layouts/_matomo.html.haml
@@ -23,7 +23,7 @@
     addEventListener('turbolinks:load', function(event) {
       if (previousPageUrl) {
         _paq.push(['setReferrerUrl', previousPageUrl]);
-        _paq.push(['setCustomUrl', '/' + window.location.href]);
+        _paq.push(['setCustomUrl', window.location.href]);
         _paq.push(['setDocumentTitle', document.title]);
         if (event.data && event.data.timing) {
           _paq.push(['setGenerationTimeMs', event.data.timing.visitEnd - event.data.timing.visitStart]);


### PR DESCRIPTION
fixes #3542 


<img width="1280" alt="capture d ecran 2019-03-08 15 05 48" src="https://user-images.githubusercontent.com/3593868/54033128-c74a5680-41b3-11e9-944a-8d6ee4db916a.png">
