### PR TITLE
footer: rename "FAQ" to "Help"

### DIFF
--- a/app/views/layouts/_footer.html.haml
+++ b/app/views/layouts/_footer.html.haml
@@ -11,6 +11,6 @@
     \-
     = contact_link 'Contact'
     \-
-    = link_to 'FAQ', FAQ_URL
-    \-
     = link_to 'Documentation', DOC_URL
+    \-
+    = link_to 'Aide', FAQ_URL

--- a/app/views/new_user/_general_footer_row.html.haml
+++ b/app/views/new_user/_general_footer_row.html.haml
@@ -4,8 +4,8 @@
 –
 = link_to "Mentions légales", MENTIONS_LEGALES_URL, :class => "footer-link", :target => "_blank", rel: "noopener noreferrer"
 –
-= link_to 'FAQ', FAQ_URL
-–
 = link_to 'Documentation', DOC_URL
 –
 = contact_link "Contact technique", class: "footer-link", dossier_id: dossier&.id
+–
+= link_to 'Aide', FAQ_URL


### PR DESCRIPTION
Dans l'optique de rajouter un bouton "Aide" partout sur le site (PR à venir), cette PR renomme le lien "FAQ" des différents footers (Usager et Admin) en "Aide" – et le bouge au bord pour le rendre plus visible.

<img width="1053" alt="Capture d’écran 2019-03-11 à 14 45 24" src="https://user-images.githubusercontent.com/179923/54128749-032c2880-440d-11e9-9225-82bb094ecca8.png">
