### PR TITLE
ajouter nom du service dans signature mail

### DIFF
--- a/app/views/layouts/mailers/_signature.html.haml
+++ b/app/views/layouts/mailers/_signature.html.haml
@@ -2,4 +2,4 @@
   Bonne journée,
 
 %p
-  L'équipe demarches-simplifiees.fr
+  --nom du service--


### PR DESCRIPTION
propose par défaut à l'administrateur que les mails de notification soient signés au nom de son service et non par "l'Equipe démarches-simplifiées" (car cela est source de confusion pour l'usager, qui s'adresse logiquement à nous par la suite)