### PR TITLE
Création de démarche : déplace le champ "Webhook" à la fin du formulaire

### DIFF
--- a/app/views/admin/procedures/_informations.html.haml
+++ b/app/views/admin/procedures/_informations.html.haml
@@ -23,16 +23,6 @@
   %h4 Où les usagers trouveront-ils le lien vers la démarche ?
   = f.text_field :lien_site_web, class: 'form-control', placeholder: 'https://exemple.gouv.fr/ma_demarche'
 
-- if  Flipflop.web_hook?
-  .form-group
-    %h4 Lien de rappel HTTP (webhook)
-    = f.text_field :web_hook_url, class: 'form-control', placeholder: 'https://callback.exemple.fr/'
-    %p.help-block
-      %i.fa.fa-info-circle
-      Vous pouvez définir un lien de rappel HTTP (aussi appelé webhook) pour notifier un service tiers du changement de l'état d’un dossier de cette démarche sur demarches-simplifiees.fr.
-      = link_to("Consulter la documentation du webhook", WEBHOOK_DOC_URL, target: "_blank", rel: "noopener")
-      \.
-
 .form-group
   %h4 Cadre juridique *
   %p Texte qui justifie le droit de collecter les données demandées dans votre démarche auprès des usagers, par exemple :
@@ -130,6 +120,15 @@
 .row
   .col-md-6
     %h4 Options avancées
+
+    - if  Flipflop.web_hook?
+      %label{ for: :web_hook_url } Lien de rappel HTTP (webhook)
+      = f.text_field :web_hook_url, class: 'form-control', placeholder: 'https://callback.exemple.fr/'
+      %p.help-block
+        %i.fa.fa-info-circle
+        Vous pouvez définir un lien de rappel HTTP (aussi appelé webhook) pour notifier un service tiers du changement de l'état d’un dossier de cette démarche sur demarches-simplifiees.fr.
+        = link_to("Consulter la documentation du webhook", WEBHOOK_DOC_URL, target: "_blank", rel: "noopener")
+        \.
 
     %label{ for: :auto_archive_on } Clôture automatique le
     = f.date_field :auto_archive_on, id: 'auto_archive_on', value: @procedure.auto_archive_on


### PR DESCRIPTION
Sur demande de @Benjamin-Doberset 

## Avant

![Avant](https://user-images.githubusercontent.com/179923/54286388-10c7e680-45a4-11e9-8dd0-ade37fc7e537.png)

## Après

![Après](https://user-images.githubusercontent.com/179923/54286397-132a4080-45a4-11e9-8917-bf15a337e025.png)
