### PR TITLE
Affiche correctement le formulaire de contact sur mobile

### DIFF
--- a/app/assets/stylesheets/new_design/contact.scss
+++ b/app/assets/stylesheets/new_design/contact.scss
@@ -2,7 +2,6 @@ $default-space: 15px;
 $contact-padding: $default-space * 2;
 
 #contact-form {
-  width: 1040px;
   margin: 0 auto;
   padding-top: $contact-padding;
 


### PR DESCRIPTION
La page de support n'est pas responsive, ce qui la rend très difficile à utiliser sur mobile.

C'est parce que le viewport est hardcodé 😱 J'ai viré la valeur en dur, et ça fonctionne au poil 👌 

@tchak tu sais pourquoi cette valeur était là à l'origine ?