### PR TITLE
stylesheet: increase contrast of gray texts

### DIFF
--- a/app/assets/stylesheets/new_design/_colors.scss
+++ b/app/assets/stylesheets/new_design/_colors.scss
@@ -3,7 +3,7 @@ $light-blue: #1C7EC9;
 $lighter-blue: #C3D9FF;
 $black: #333333;
 $white: #FFFFFF;
-$grey: #999999;
+$grey: #888888;
 $light-grey: #F8F8F8;
 $border-grey: #CCCCCC;
 $dark-red: #A10005;


### PR DESCRIPTION
Le contraste de certains textes gris sur font blanc est aujourd'hui vraiment faible. Du coup c'est difficile à lire. J'ai réhaussé un tout petit peu ça.

## Avant

![Avant](https://user-images.githubusercontent.com/179923/54365410-0e7e8e80-466f-11e9-9422-4dd6b4686843.png)

## Après

![Après](https://user-images.githubusercontent.com/179923/54365413-11797f00-466f-11e9-9f52-46ac1ab9583b.png)
