### PR TITLE
Améliore le layout à deux colonnes sur les écrans étroits

### DIFF
--- a/app/assets/stylesheets/new_design/_constants.scss
+++ b/app/assets/stylesheets/new_design/_constants.scss
@@ -6,7 +6,7 @@ $default-padding: 2 * $default-spacer;
 
 // layouts
 $two-columns-padding: 60px;
-$two-columns-breakpoint: $page-width + (2 * $default-padding);
+$two-columns-breakpoint: 980px;
 
 // z-order
 $alert-z-index: 100;

--- a/app/assets/stylesheets/new_design/_constants.scss
+++ b/app/assets/stylesheets/new_design/_constants.scss
@@ -6,7 +6,7 @@ $default-padding: 2 * $default-spacer;
 
 // layouts
 $two-columns-padding: 60px;
-$two-columns-breakpoint: $page-width + (2 * $two-columns-padding);
+$two-columns-breakpoint: $page-width + (2 * $default-padding);
 
 // z-order
 $alert-z-index: 100;

--- a/app/assets/stylesheets/new_design/layouts.scss
+++ b/app/assets/stylesheets/new_design/layouts.scss
@@ -23,14 +23,23 @@
   }
 
   .column {
-    padding: $two-columns-padding 0 $two-columns-padding 0;
     width: 100%;
     max-width: 500px;
     margin: 0 auto;
+    padding: ($default-padding * 2) 0 0 0;
+
+    &:last-of-type {
+      padding-bottom: $default-padding * 2;
+    }
 
     @media (min-width: $two-columns-breakpoint) {
       width: 45%;
       margin: 0;
+      padding: $two-columns-padding 0 $two-columns-padding 0;
+
+      &:last-of-type {
+        padding-bottom: $two-columns-padding;
+      }
     }
   }
 }

--- a/app/assets/stylesheets/new_design/layouts.scss
+++ b/app/assets/stylesheets/new_design/layouts.scss
@@ -13,6 +13,7 @@
     @extend .container;
     display: flex;
     flex-direction: column;
+    justify-content: center;
 
     @media (min-width: $two-columns-breakpoint) {
       flex-direction: row;
@@ -25,9 +26,11 @@
     padding: $two-columns-padding 0 $two-columns-padding 0;
     width: 100%;
     max-width: 500px;
+    margin: 0 auto;
 
     @media (min-width: $two-columns-breakpoint) {
       width: 45%;
+      margin: 0;
     }
   }
 }

--- a/app/assets/stylesheets/new_design/layouts.scss
+++ b/app/assets/stylesheets/new_design/layouts.scss
@@ -17,26 +17,17 @@
     @media (min-width: $two-columns-breakpoint) {
       flex-direction: row;
       align-items: stretch;
-      justify-content: center;
+      justify-content: space-between;
     }
   }
 
   .column {
-    padding: $two-columns-padding 0 0;
+    padding: $two-columns-padding 0 $two-columns-padding 0;
     width: 100%;
     max-width: 500px;
 
     @media (min-width: $two-columns-breakpoint) {
-      padding: $two-columns-padding;
-      width: 50%;
-
-      &:first-child {
-        padding-left: 0;
-      }
-
-      &:last-child {
-        padding-right: 0;
-      }
+      width: 45%;
     }
   }
 }

--- a/app/assets/stylesheets/new_design/procedure_context.scss
+++ b/app/assets/stylesheets/new_design/procedure_context.scss
@@ -27,9 +27,11 @@ $procedure-context-breakpoint: $two-columns-breakpoint;
   .procedure-title {
     font-size: 30px;
     margin: 20px 0 0;
+    text-align: center;
 
     @media (min-width: $procedure-context-breakpoint) {
       margin: 50px 0 32px;
+      text-align: left;
     }
   }
 

--- a/app/assets/stylesheets/new_design/procedure_context.scss
+++ b/app/assets/stylesheets/new_design/procedure_context.scss
@@ -26,7 +26,7 @@ $procedure-context-breakpoint: $two-columns-breakpoint;
 
   .procedure-title {
     font-size: 30px;
-    margin: 20px 0 0;
+    margin: 0 0 20px 0;
     text-align: center;
 
     @media (min-width: $procedure-context-breakpoint) {
@@ -38,7 +38,7 @@ $procedure-context-breakpoint: $two-columns-breakpoint;
   .procedure-description {
     font-size: 16px;
 
-    p {
+    p:not(:last-of-type) {
       margin-bottom: 2 * $default-spacer;
     }
 
@@ -54,7 +54,7 @@ $procedure-context-breakpoint: $two-columns-breakpoint;
     img {
       max-height: 50px;
       max-width: 100%;
-      margin: 0 10px;
+      margin: 0 10px 20px 10px;
 
       @media (min-width: $procedure-context-breakpoint) {
         max-height: 130px;


### PR DESCRIPTION
- Le layout à deux colonnes est maintenant affiché dès 950 px de large (au lieu de 1200 px).
- Sur un écran étroit, la colonne centrale est centrée au milieu de l'écran.
- Petites améliorations de marges sur les colonnes ici et là.

C'est en préparation de l'affichage de la description de la démarche même sur les layouts étroits.

## Avant

![responsive-1](https://user-images.githubusercontent.com/179923/54375136-c5373a80-4680-11e9-9a0e-27e2ee743b3f.gif)

## Après

![responsive-1-after](https://user-images.githubusercontent.com/179923/54375173-d718dd80-4680-11e9-804b-d737b78747da.gif)
