### PR TITLE
Correction du temps habituel avant instruction

### DIFF
--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -467,7 +467,6 @@ class Procedure < ApplicationRecord
 
   def percentile_time(start_attribute, end_attribute, p)
     times = dossiers
-      .state_termine
       .where(end_attribute => 1.month.ago..Time.zone.now)
       .pluck(start_attribute, end_attribute)
       .map { |(start_date, end_date)| end_date - start_date }

--- a/spec/models/procedure_spec.rb
+++ b/spec/models/procedure_spec.rb
@@ -707,6 +707,48 @@ describe Procedure do
     end
   end
 
+  describe '#usual_verification_time' do
+    let(:procedure) { create(:procedure) }
+
+    def create_dossier(construction_date:, instruction_date:)
+      dossier = create(:dossier, :en_instruction, procedure: procedure)
+      dossier.update!(en_construction_at: construction_date, en_instruction_at: instruction_date)
+    end
+
+    before do
+      delays.each do |delay|
+        create_dossier(construction_date: 1.week.ago - delay, instruction_date: 1.week.ago)
+      end
+    end
+
+    context 'when there are several dossiers in the time frame' do
+      let(:delays) { [1.day, 2.days, 2.days, 2.days, 2.days, 3.days, 3.days, 3.days, 3.days, 12.days] }
+
+      it 'returns a time representative of the dossier verification delay' do
+        expect(procedure.usual_verification_time).to be_between(3.days, 4.days)
+      end
+    end
+
+    context 'when there are very old dossiers' do
+      let(:delays) { [2.days, 2.days] }
+      let!(:old_dossier) { create_dossier(construction_date: 3.months.ago, instruction_date: 2.months.ago) }
+
+      it 'ignores dossiers older than 1 month' do
+        expect(procedure.usual_verification_time).to be_within(10.seconds).of(2.days)
+      end
+    end
+
+    context 'when there is only one dossier in the time frame' do
+      let(:delays) { [1.day] }
+      it { expect(procedure.usual_verification_time).to be_within(10.seconds).of(1.day) }
+    end
+
+    context 'where there are no dossiers' do
+      let(:delays) { [] }
+      it { expect(procedure.usual_verification_time).to be_nil }
+    end
+  end
+
   describe '#usual_instruction_time' do
     let(:procedure) { create(:procedure) }
 
@@ -716,13 +758,13 @@ describe Procedure do
     end
 
     before do
-      processed_delays.each do |delay|
+      delays.each do |delay|
         create_dossier(instruction_date: 1.week.ago - delay, processed_date: 1.week.ago)
       end
     end
 
     context 'when there are several processed dossiers' do
-      let(:processed_delays) { [1.day, 2.days, 2.days, 2.days, 2.days, 3.days, 3.days, 3.days, 3.days, 12.days] }
+      let(:delays) { [1.day, 2.days, 2.days, 2.days, 2.days, 3.days, 3.days, 3.days, 3.days, 12.days] }
 
       it 'returns a time representative of the dossier instruction delay' do
         expect(procedure.usual_instruction_time).to be_between(3.days, 4.days)
@@ -730,7 +772,7 @@ describe Procedure do
     end
 
     context 'when there are very old dossiers' do
-      let(:processed_delays) { [2.days, 2.days] }
+      let(:delays) { [2.days, 2.days] }
       let!(:old_dossier) { create_dossier(instruction_date: 3.months.ago, processed_date: 2.months.ago) }
 
       it 'ignores dossiers older than 1 month' do
@@ -739,12 +781,12 @@ describe Procedure do
     end
 
     context 'when there is only one processed dossier' do
-      let(:processed_delays) { [1.day] }
+      let(:delays) { [1.day] }
       it { expect(procedure.usual_instruction_time).to be_within(10.seconds).of(1.day) }
     end
 
     context 'where there is no processed dossier' do
-      let(:processed_delays) { [] }
+      let(:delays) { [] }
       it { expect(procedure.usual_instruction_time).to be_nil }
     end
   end


### PR DESCRIPTION
Le calcul du temps habituel avant instruction ne prenait en compte que les dossiers **terminés** passés en instruction dans les 30 derniers jours – alors qu'il vaut mieux prendre en compte tous les dossiers passés en instruction dans les 30 derniers jours, qu'ils soient clos ou pas.