### PR TITLE
suppression de l'option SIRET personnes physiques

### DIFF
--- a/app/views/admin/procedures/_informations.html.haml
+++ b/app/views/admin/procedures/_informations.html.haml
@@ -110,11 +110,6 @@
         %li
           .checkbox
             %label
-              = f.check_box :individual_with_siret
-              Donner la possibilité de renseigner un SIRET au cours de la construction du dossier.
-        %li
-          .checkbox
-            %label
               = f.check_box :ask_birthday
               Demander la date de naissance.
 .row


### PR DESCRIPTION
car existe dans tous les cas dans le type de champ "SIRET", davantage source de confusion qu'autre chose