### PR TITLE
stylesheet: fix logo layout on Chrome

### DIFF
--- a/app/assets/stylesheets/new_design/procedure_context.scss
+++ b/app/assets/stylesheets/new_design/procedure_context.scss
@@ -50,15 +50,27 @@ $procedure-context-breakpoint: $two-columns-breakpoint;
   .procedure-logos {
     display: flex;
     justify-content: space-around;
+    align-items: center;
+    margin-bottom: 20px;
+
+    > :not(:last-child) {
+      margin-right: $default-padding;
+    }
 
     img {
-      max-height: 50px;
       max-width: 100%;
-      margin: 0 10px 20px 10px;
+      max-height: 50px;
+
+      // Fix Chrome flexbox issue
+      // See https://github.com/philipwalton/flexbugs/issues/225
+      width: 100%;
+      height: 100%;
+      min-width: 0;
+      object-fit: contain;
 
       @media (min-width: $procedure-context-breakpoint) {
-        max-height: 130px;
         max-width: 500px;
+        max-height: 130px;
       }
     }
   }


### PR DESCRIPTION
The procedure-logo layout code hits a Chrome bug where the `img`s inside flex containers are not laid out properly.
See https://github.com/philipwalton/flexbugs/issues/225

Turns out this bug was there for a while (it doesn't seem to be a regression due to the recent layout changes).

## Before

<img width="1115" alt="Chrome avant" src="https://user-images.githubusercontent.com/179923/54699832-17b9a080-4b32-11e9-90e4-cdbaa9c6a3a6.png">

## After

<img width="1101" alt="Chrome après" src="https://user-images.githubusercontent.com/179923/54699884-299b4380-4b32-11e9-943e-7bff527d3fa9.png">
